### PR TITLE
Extend the Exception Monad with a catch operation. Axiomatize its laws

### DIFF
--- a/src/coq/LLVMIO.v
+++ b/src/coq/LLVMIO.v
@@ -66,8 +66,13 @@ Inductive IO : Type -> Type :=
 Definition Trace X := M IO X.
 Global Instance functor_trace : Functor Trace := (@mapM IO).
 Global Instance monad_trace : (@Monad Trace) (@mapM IO) := { mret X x := Ret x; mbind := @bindM IO }.
-Global Instance exn_trace : (@ExceptionMonad string Trace _ _) := fun _ s => Err s.
-
+Global Instance exn_trace : (@ExceptionMonad string Trace _ _) :=
+  {| raise := fun _ s => Err s;
+     catch := fun _ e k => match e with
+                        | Err e => k e
+                        | _ => e
+                        end
+  |}.
 (* Trace Utilities ---------------------------------------------------------- *)
 
 (* Lift the error monad into the trace monad. *)

--- a/src/coq/Renaming.v
+++ b/src/coq/Renaming.v
@@ -645,11 +645,12 @@ Section PROOFS.
     induction o; simpl.
     - rewrite swap_lookup_id.
       destruct (lookup_id g e id); simpl; auto.
-    - destruct top. destruct d; simpl; unfold failwith; auto.
+      apply swap_raise. (** The extension of the Exception monad broke the automation, to fix **)
+    - destruct top. destruct d; simpl; unfold failwith; auto; try now apply swap_raise.
       symmetry. rewrite Trace.matchM. simpl.
       destruct (coerce_integer_to_int sz x); reflexivity. 
-      simpl. unfold failwith. auto.
-    - destruct top. destruct d; simpl; unfold failwith; auto.
+      simpl. unfold failwith. apply swap_raise.
+    - destruct top. destruct d; simpl; unfold failwith; auto; try now apply swap_raise.
       
 
       


### PR DESCRIPTION
The Exception Monad is currently only used as an Error one, and hence was minimalist. This PR adds a catch operator and axiomatizes a few of its laws.

Closes #42 