### PR TITLE
Add theory and induction schemes to make equality decidable on `typ`.

### DIFF
--- a/src/coq/AstLib.v
+++ b/src/coq/AstLib.v
@@ -231,9 +231,6 @@ Module RawIDOrd <: UsualOrderedType.
 
   Definition eq_dec : forall (x y : t), {x = y} + {x <> y}.
     decide equality.
-    - apply string_dec.
-    - apply eq_dec_int.
-    - apply eq_dec_int.
   Defined.
 
 End RawIDOrd.  

--- a/src/coq/Util.v
+++ b/src/coq/Util.v
@@ -847,3 +847,12 @@ Fixpoint combine_lists_err {A B:Type} (l1:list A) (l2:list B) : err (list (A * B
       mret ((x,y)::l)
   | _, _ => failwith "combine_lists_err: different lenth lists"
   end.
+
+
+(** Predictes over Lists **)
+
+(** Analogue of Forall for a predicate into Type, rather than into Prop.
+   Used to generate induction principles in LLVMAst.v **)
+Inductive ForallListT A (T : A -> Type) : list A -> Type :=
+| ForallListT_nil : ForallListT T []
+| ForallListT_cons : forall x l, T x -> ForallListT T l -> ForallListT T (x :: l).


### PR DESCRIPTION
To show that equality is decidable on `typ`, we need a stronger
induction principle than the one generated by default from Coq.

Use the trick/folklore in CPDT from the "Nested Inductive type" section to
generate a stronger induction principle.

TODO: Extend this to show decidable equality of `exp`, and in general
all of `LLVMAst`.

This is useful to perform pattern matching on the IR.