### PR TITLE
Update StepSemanticsProp with working Map theorems

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ COQEXEC="$(COQBIN)coqtop" -q -w none $(COQINCLUDES) -batch -load-vernac-source
 MENHIR=menhir
 CP=cp
 
-COQFILES := LLVMAst Classes Util Misc AstLib Dom CFG CFGProp Trace MemoryAddress DynamicValues LLVMIO TypeUtil StepSemantics Memory Renaming DeadInstr Transform TopLevel
+COQFILES := LLVMAst Classes Util Misc AstLib Dom CFG CFGProp Trace MemoryAddress DynamicValues LLVMIO TypeUtil StepSemantics StepSemanticsProp Memory Renaming DeadInstr Transform TopLevel
 OLLVMFILES := 
 
 VFILES := $(COQFILES:%=coq/%.v)


### PR DESCRIPTION
The old code was commented (and was not being built with VELLVM).
- Re-implement the theorems since some of the lemma names changed.
- Make the code build, and add it to the Makefile.
- Refer to the lemmas as `gss` and `gso` for someone else who is
  familiar with the `CompCert` names.

Closes #53 