### PR TITLE
[WIP] Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+dist: trusty
+sudo: required
+language: c
+cache:
+  apt: true
+  directories:
+  - $HOME/.opam
+addons:
+  apt:
+    sources:
+    - avsm
+    packages:
+    - opam
+    - aspcud
+env:
+  global:
+  - NJOBS=1
+  # https://github.com/AbsInt/CompCert/issues/234
+  - EXTRA_OPAM=menhir.20180528
+
+  # for CompCert: http://compcert.inria.fr/man/manual002.html
+  - COMPILER="system"
+  # Main test targets
+  # get versions from: https://opam.ocaml.org/packages/coq/
+  # Only use versions that CompCert can build with...
+  matrix:
+  - TEST_TARGET="8.6.1"
+  - TEST_TARGET="8.7.2"
+  - TEST_TARGET="8.8.0"
+
+before_script:
+  -  ./ci/keep_alive.sh &
+
+install:
+  - opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
+  - eval $(opam config env)
+  - opam config var root
+  # this somehow fails the second time...
+  - opam repo add coq-released http://coq.inria.fr/opam/released || true
+  - opam install -y --verbose -j ${NJOBS} coq.${TEST_TARGET} && opam pin add coq ${TEST_TARGET} -y
+  - opam install -y --verbose -j ${NJOBS} coq-mathcomp-ssreflect
+  - opam install -y --verbose -j ${NJOBS} ocamlfind camlp5 ${EXTRA_OPAM} 
+
+
+script:
+  - eval $(opam config env)
+  - opam config var root
+  # Look at how Coq builds compcert for their test suite
+  # https://github.com/coq/coq/blob/b67b8ab65448a63cb53517ab9dfccb3b4d541d77/dev/ci/ci-compcert.sh
+  - cd lib/CompCert &&  ./configure x86_64-linux -ignore-coq-version && make; cd ../../
+  - make -j ${NJOBS} -C lib/paco/src 
+  - make -j ${NJOBS} -C src/
+  - cd src && ./vellvm --test

--- a/ci/keep_alive.sh
+++ b/ci/keep_alive.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Stolen from fiat-crypto: https://github.com/mit-plv/fiat-crypto/blob/78656baa06ed1daeb7ba90c2d429228516dc8475/etc/ci/keep_alive.sh
+
+while [ 1 ]
+do
+    echo ""
+    echo "Travis keep-alive spew"
+    sleep 5m
+done


### PR DESCRIPTION
The CI infrastructure I setup is very dumb right now, we can do much better at multiple places:

1. don't build coq each time. Rather, pull from coq packages (which contains nightlies as well), which are packaged by @jasongross. [`fiat-crypto`](https://github.com/mit-plv/fiat-crypto/blob/master/.travis.yml#L20) does this.

2. Find some way to not have to recompile `CompCert` each time. Is there some way to cache submodule builds? I'm not sure. A quick google search does not show anything related (there are threads on caching submodule clones, like [this Rust issue](https://github.com/rust-lang/rust/issues/40772) and [this commit on `qemu`](https://patchwork.kernel.org/patch/9803371/), but none on caching submodule builds).

2.b Possibly, we can extract out the `CompCert` files `vellvm` needs? I think `vellvm` only depends on `Integers`, `Floats`, and maybe some other odds-and-ends, correct? So there is no need to build _all_ of `CompCert`.

3. Similarly, find some way to not have to recompile `paco` every time.

There is also the (blocking) issue that the test harness failure does not return a non-zero exit code. [I filed an issue](https://github.com/vellvm/vellvm/issues/57). Once this is fixed, a test harness failure will cause Travis to log the build as `failed`.

#### Example run:
[here's a link to an example run](https://travis-ci.org/bollu/vellvm/builds/397379318)
#### Blocking issues
- [x] teach test harness to return non-zero exit code (Fixed by [`0fbf3e2`](https://github.com/vellvm/vellvm/commit/0fbf3e2c177fdb1300bb4107f4e194a3f46f4895))

Closes #55 
