### PR TITLE
Added a typeclass for VELLVM integers.

### DIFF
--- a/src/coq/DynamicValues.v
+++ b/src/coq/DynamicValues.v
@@ -110,241 +110,364 @@ Definition undef_i1  := DVALUE_Undef.
 Definition undef_i8  := DVALUE_Undef.
 Definition undef_i32 := DVALUE_Undef.
 Definition undef_i64 := DVALUE_Undef.
+Definition undef_int := DVALUE_Undef.
+
+
+Class VInt I : Type :=
+  {
+    (* Comparisons *)
+    eq : I -> I -> bool;
+    cmp : comparison -> I -> I -> bool;
+    cmpu : comparison -> I -> I -> bool;
+
+    (* Constants *)
+    bitwidth : nat;
+    zero : I;
+    one : I;
+
+    (* Arithmetic *)
+    add : I -> I -> I;
+    add_carry : I -> I -> I -> I;
+    add_overflow : I -> I -> I -> I;
+
+    sub : I -> I -> I;
+    sub_borrow : I -> I -> I -> I;
+    sub_overflow : I -> I -> I -> I;
+
+    mul : I -> I -> I;
+
+    divu : I -> I -> I;
+    divs : I -> I -> I;
+    modu : I -> I -> I;
+    mods : I -> I -> I;
+
+    shl : I -> I -> I;
+    shr : I -> I -> I;
+    shru : I -> I -> I;
+
+    negative : I -> I;
+
+    (* Logic *)
+    and : I -> I -> I;
+    or : I -> I -> I;
+    xor : I -> I -> I;
+
+    (* Bounds *)
+    min_signed : Z;
+    max_signed : Z;
+
+    (* Conversion *)
+    to_dvalue : I -> dvalue;
+    unsigned : I -> Z;
+    signed : I -> Z;
+
+    repr : Z -> I;
+  }.
+
+
+  Global Instance VInt1 : VInt Int1.int :=
+  {
+    (* Comparisons *)
+    eq := Int1.eq;
+    cmp := Int1.cmp;
+    cmpu := Int1.cmpu;
+
+    bitwidth := 1;
+
+    (* Constants *)
+    zero := Int1.zero;
+    one := Int1.one;    
+
+    (* Arithmetic *)
+    add := Int1.add;
+    add_carry := Int1.add_carry;
+    add_overflow := Int1.add_overflow;
+
+    sub := Int1.sub;
+    sub_borrow := Int1.sub_borrow;
+    sub_overflow := Int1.sub_overflow;
+
+    mul := Int1.mul;
+
+    divu := Int1.divu;
+    divs := Int1.divs;
+    modu := Int1.modu;
+    mods := Int1.mods;
+
+    shl := Int1.shl;
+    shr := Int1.shr;
+    shru := Int1.shru;
+
+    negative := Int1.negative;
+
+    (* Logic *)
+    and := Int1.and;
+    or := Int1.or;
+    xor := Int1.xor;
+
+    (* Bounds *)
+    min_signed := Int1.min_signed;
+    max_signed := Int1.max_signed;
+    
+    (* Conversion *)
+    to_dvalue := DVALUE_I1;
+    unsigned := Int1.unsigned;
+    signed := Int1.signed;
+
+    repr := Int1.repr;
+  }.
+
+
+  Global Instance VInt8 : VInt Int8.int :=
+  {
+    (* Comparisons *)
+    eq := Int8.eq;
+    cmp := Int8.cmp;
+    cmpu := Int8.cmpu;
+
+    bitwidth := 8;
+
+    (* Constants *)
+    zero := Int8.zero;
+    one := Int8.one;    
+
+    (* Arithmetic *)
+    add := Int8.add;
+    add_carry := Int8.add_carry;
+    add_overflow := Int8.add_overflow;
+
+    sub := Int8.sub;
+    sub_borrow := Int8.sub_borrow;
+    sub_overflow := Int8.sub_overflow;
+
+    mul := Int8.mul;
+
+    divu := Int8.divu;
+    divs := Int8.divs;
+    modu := Int8.modu;
+    mods := Int8.mods;
+
+    shl := Int8.shl;
+    shr := Int8.shr;
+    shru := Int8.shru;
+
+    negative := Int8.negative;
+
+    (* Logic *)
+    and := Int8.and;
+    or := Int8.or;
+    xor := Int8.xor;
+
+    (* Bounds *)
+    min_signed := Int8.min_signed;
+    max_signed := Int8.max_signed;
+    
+    (* Conversion *)
+    to_dvalue := DVALUE_I8;
+    unsigned := Int8.unsigned;
+    signed := Int8.signed;
+
+    repr := Int8.repr;
+  }.
+
+
+  Global Instance VInt32 : VInt Int32.int :=
+  {
+    (* Comparisons *)
+    eq := Int32.eq;
+    cmp := Int32.cmp;
+    cmpu := Int32.cmpu;
+
+    bitwidth := 32;
+
+    (* Constants *)
+    zero := Int32.zero;
+    one := Int32.one;    
+
+    (* Arithmetic *)
+    add := Int32.add;
+    add_carry := Int32.add_carry;
+    add_overflow := Int32.add_overflow;
+
+    sub := Int32.sub;
+    sub_borrow := Int32.sub_borrow;
+    sub_overflow := Int32.sub_overflow;
+
+    mul := Int32.mul;
+
+    divu := Int32.divu;
+    divs := Int32.divs;
+    modu := Int32.modu;
+    mods := Int32.mods;
+
+    shl := Int32.shl;
+    shr := Int32.shr;
+    shru := Int32.shru;
+
+    negative := Int32.negative;
+
+    (* Logic *)
+    and := Int32.and;
+    or := Int32.or;
+    xor := Int32.xor;
+
+    (* Bounds *)
+    min_signed := Int32.min_signed;
+    max_signed := Int32.max_signed;
+    
+    (* Conversion *)
+    to_dvalue := DVALUE_I32;
+    unsigned := Int32.unsigned;
+    signed := Int32.signed;
+
+    repr := Int32.repr;
+  }.
+
+  Global Instance VInt64 : VInt Int64.int :=
+  {
+    (* Comparisons *)
+    eq := Int64.eq;
+    cmp := Int64.cmp;
+    cmpu := Int64.cmpu;
+
+    bitwidth := 64;
+
+    (* Constants *)
+    zero := Int64.zero;
+    one := Int64.one;
+
+    (* Arithmetic *)
+    add := Int64.add;
+    add_carry := Int64.add_carry;
+    add_overflow := Int64.add_overflow;
+
+    sub := Int64.sub;
+    sub_borrow := Int64.sub_borrow;
+    sub_overflow := Int64.sub_overflow;
+
+    mul := Int64.mul;
+
+    divu := Int64.divu;
+    divs := Int64.divs;
+    modu := Int64.modu;
+    mods := Int64.mods;
+
+    shl := Int64.shl;
+    shr := Int64.shr;
+    shru := Int64.shru;
+
+    negative := Int64.negative;
+
+    (* Logic *)
+    and := Int64.and;
+    or := Int64.or;
+    xor := Int64.xor;
+
+    (* Bounds *)
+    min_signed := Int64.min_signed;
+    max_signed := Int64.max_signed;
+    
+    (* Conversion *)
+    to_dvalue := DVALUE_I64;
+    unsigned := Int64.unsigned;
+    signed := Int64.signed;
+
+    repr := Int64.repr;
+  }.
+
 
   (* Arithmetic Operations ---------------------------------------------------- *)
   Section ARITHMETIC.
-
+    
   (* Since modules are not first class, this code duplication
      will probably have to do. *)
-
-  Definition eval_i1_op (iop:ibinop) (x y:inttyp 1) : dvalue:=
+  Definition eval_int_op `{VInt Int} (iop:ibinop) (x y: Int) : dvalue:=
     (* See eval_i64_op for a few comments *)
     match iop with
     | Add nuw nsw =>
-      if orb (andb nuw (Int1.eq (Int1.add_carry x y Int1.zero) Int1.one))
-             (andb nsw (Int1.eq (Int1.add_overflow x y Int1.zero) Int1.one))
-      then DVALUE_Poison else DVALUE_I1 (Int1.add x y)
+      if orb (andb nuw (eq (add_carry x y zero) one))
+             (andb nsw (eq (add_overflow x y zero) one))
+      then DVALUE_Poison else to_dvalue (add x y)
     | Sub nuw nsw =>
-      if orb (andb nuw (Int1.eq (Int1.sub_borrow x y Int1.zero) Int1.one))
-             (andb nsw (Int1.eq (Int1.sub_overflow x y Int1.zero) Int1.one))
-      then DVALUE_Poison else DVALUE_I1 (Int1.sub x y)
+      if orb (andb nuw (eq (sub_borrow x y zero) one))
+             (andb nsw (eq (sub_overflow x y zero) one))
+      then DVALUE_Poison else to_dvalue (sub x y)
     | Mul nuw nsw =>
       (* I1 mul can't overflow, just based on the 4 possible multiplications. *)
-      DVALUE_I1 (Int1.mul x y)
+      if (bitwidth == 1)%nat then to_dvalue (mul x y)
+      else 
+        let res := mul x y in
+        let res_s' := (signed x) * (signed y) in
+        if orb (andb nuw ((unsigned x) * (unsigned y) >?
+                      unsigned res))
+             (andb nsw (orb (min_signed >? res_s')
+                            (res_s' >? max_signed)))
+      then DVALUE_Poison else to_dvalue res
     | Shl nuw nsw =>
-      if (Int1.unsigned y) >=? 1 then undef_i1 else DVALUE_I1 x
+      if (bitwidth == 1)%nat
+      then
+        if (unsigned y) >=? 1 then undef_int else to_dvalue x
+      else
+        let bz := Z.of_nat bitwidth in
+        let res := shl x y in
+        let res_u := unsigned res in
+        let res_u' := Z.shiftl (unsigned x) (unsigned y) in
+        if (unsigned y) >=? bz then undef_int
+        else if orb (andb nuw (res_u' >? res_u))
+                    (andb nsw (negb (Z.shiftr (unsigned x)
+                                              (bz - unsigned y)
+                                     =? (unsigned (negative res))
+                                        * (Z.pow 2 (unsigned y) - 1))))
+             then DVALUE_Poison else to_dvalue res
     | UDiv ex =>
-      if andb ex (negb ((Int1.unsigned x) mod (Int1.unsigned y) =? 0))
-      then DVALUE_Poison else DVALUE_I1 (Int1.divu x y)
+      if andb ex (negb ((unsigned x) mod (unsigned y) =? 0))
+      then DVALUE_Poison else to_dvalue (divu x y)
     | SDiv ex =>
       (* What does signed i1 mean? *)
-      if andb ex (negb (((Int1.signed x) mod (Int1.signed y)) =? 0))
-      then DVALUE_Poison else DVALUE_I1 (Int1.divs x y)
+      if andb ex (negb (((signed x) mod (signed y)) =? 0))
+      then DVALUE_Poison else to_dvalue (divs x y)
     | LShr ex =>
-      if (Int1.unsigned y) >=? 1 then undef_i1 else DVALUE_I1 x
+      if (bitwidth == 1)%nat
+      then
+        if (unsigned y) >=? 1 then undef_int else to_dvalue x
+      else
+        let bz := Z.of_nat bitwidth in
+        if (unsigned y) >=? bz then undef_int
+        else if andb ex (negb ((unsigned x)
+                                 mod (Z.pow 2 (unsigned y)) =? 0))
+             then DVALUE_Poison else to_dvalue (shru x y)
     | AShr ex =>
-      if (Int1.unsigned y) >=? 1 then undef_i1 else DVALUE_I1 x
+      if (bitwidth == 1)%nat
+      then
+        if (unsigned y) >=? 1 then undef_int else to_dvalue x
+      else
+        let bz := Z.of_nat bitwidth in
+        if (unsigned y) >=? bz then undef_int
+        else if andb ex (negb ((unsigned x)
+                                 mod (Z.pow 2 (unsigned y)) =? 0))
+             then DVALUE_Poison else to_dvalue (shr x y)
+
     | URem =>
-      DVALUE_I1 (Int1.modu x y)
+      to_dvalue (modu x y)
     | SRem =>
-      DVALUE_I1 (Int1.mods x y)
+      to_dvalue (mods x y)
     | And =>
-      DVALUE_I1 (Int1.and x y)
+      to_dvalue (and x y)
     | Or =>
-      DVALUE_I1 (Int1.or x y)
+      to_dvalue (or x y)
     | Xor =>
-      DVALUE_I1 (Int1.xor x y)
+      to_dvalue (xor x y)
     end.
-  Arguments eval_i1_op _ _ _ : simpl nomatch.
+  Arguments eval_int_op _ _ _ : simpl nomatch.
 
-
-  Definition eval_i8_op (iop:ibinop) (x y:inttyp 8) : dvalue:=
-    match iop with
-    | Add nuw nsw =>
-      if orb (andb nuw (Int8.eq (Int8.add_carry x y Int8.zero) Int8.one))
-             (andb nsw (Int8.eq (Int8.add_overflow x y Int8.zero) Int8.one))
-      then DVALUE_Poison else DVALUE_I8 (Int8.add x y)
-    | Sub nuw nsw =>
-      if orb (andb nuw (Int8.eq (Int8.sub_borrow x y Int8.zero) Int8.one))
-             (andb nsw (Int8.eq (Int8.sub_overflow x y Int8.zero) Int8.one))
-      then DVALUE_Poison else DVALUE_I8 (Int8.sub x y)
-    | Mul nuw nsw =>
-      let res := Int8.mul x y in
-      let res_s' := (Int8.signed x) * (Int8.signed y) in
-      if orb (andb nuw ((Int8.unsigned x) * (Int8.unsigned y) >?
-                      Int8.unsigned res))
-             (andb nsw (orb (Int8.min_signed >? res_s')
-                            (res_s' >? Int8.max_signed)))
-      then DVALUE_Poison else DVALUE_I8 res
-    | Shl nuw nsw =>
-      let res := Int8.shl x y in
-      let res_u := Int8.unsigned res in
-      let res_u' := Z.shiftl (Int8.unsigned x) (Int8.unsigned y) in
-      if (Int8.unsigned y) >=? 8 then undef_i8
-      else if orb (andb nuw (res_u' >? res_u))
-                  (andb nsw (negb (Z.shiftr (Int8.unsigned x)
-                                            (8 - Int8.unsigned y)
-                                   =? (Int8.unsigned (Int8.negative res))
-                                      * (Z.pow 2 (Int8.unsigned y) - 1))))
-      then DVALUE_Poison else DVALUE_I8 res
-    | UDiv ex =>
-      if andb ex (negb ((Int8.unsigned x) mod (Int8.unsigned y) =? 0))
-      then DVALUE_Poison else DVALUE_I8 (Int8.divu x y)
-    | SDiv ex =>
-      if andb ex (negb (((Int8.signed x) mod (Int8.signed y)) =? 0))
-      then DVALUE_Poison else DVALUE_I8 (Int8.divs x y)
-    | LShr ex =>
-      if (Int8.unsigned y) >=? 8 then undef_i8
-      else if andb ex (negb ((Int8.unsigned x)
-                               mod (Z.pow 2 (Int8.unsigned y)) =? 0))
-      then DVALUE_Poison else DVALUE_I8 (Int8.shru x y)
-    | AShr ex =>
-      if (Int8.unsigned y) >=? 8 then undef_i8
-      else if andb ex (negb ((Int8.unsigned x)
-                               mod (Z.pow 2 (Int8.unsigned y)) =? 0))
-      then DVALUE_Poison else DVALUE_I8 (Int8.shr x y)
-    | URem =>
-      DVALUE_I8 (Int8.modu x y)
-    | SRem =>
-      DVALUE_I8 (Int8.mods x y)
-    | And =>
-      DVALUE_I8 (Int8.and x y)
-    | Or =>
-      DVALUE_I8 (Int8.or x y)
-    | Xor =>
-      DVALUE_I8 (Int8.xor x y)
-    end.
-  Arguments eval_i8_op _ _ _ : simpl nomatch.
-
-
-  Definition eval_i32_op (iop:ibinop) (x y:inttyp 32) : dvalue:=
-    match iop with
-    | Add nuw nsw =>
-      if orb (andb nuw (Int32.eq (Int32.add_carry x y Int32.zero) Int32.one))
-             (andb nsw (Int32.eq (Int32.add_overflow x y Int32.zero) Int32.one))
-      then DVALUE_Poison else DVALUE_I32 (Int32.add x y)
-    | Sub nuw nsw =>
-      if orb (andb nuw (Int32.eq (Int32.sub_borrow x y Int32.zero) Int32.one))
-             (andb nsw (Int32.eq (Int32.sub_overflow x y Int32.zero) Int32.one))
-      then DVALUE_Poison else DVALUE_I32 (Int32.sub x y)
-    | Mul nuw nsw =>
-      let res := Int32.mul x y in
-      let res_s' := (Int32.signed x) * (Int32.signed y) in
-      if orb (andb nuw ((Int32.unsigned x) * (Int32.unsigned y) >?
-                      Int32.unsigned res))
-             (andb nsw (orb (Int32.min_signed >? res_s')
-                            (res_s' >? Int32.max_signed)))
-      then DVALUE_Poison else DVALUE_I32 res
-    | Shl nuw nsw =>
-      let res := Int32.shl x y in
-      let res_u := Int32.unsigned res in
-      let res_u' := Z.shiftl (Int32.unsigned x) (Int32.unsigned y) in
-      if (Int32.unsigned y) >=? 32 then undef_i32
-      else if orb (andb nuw (res_u' >? res_u))
-                  (andb nsw (negb (Z.shiftr (Int32.unsigned x)
-                                            (32 - Int32.unsigned y)
-                                   =? (Int32.unsigned (Int32.negative res))
-                                      * (Z.pow 2 (Int32.unsigned y) - 1))))
-      then DVALUE_Poison else DVALUE_I32 res
-    | UDiv ex =>
-      if andb ex (negb ((Int32.unsigned x) mod (Int32.unsigned y) =? 0))
-      then DVALUE_Poison else DVALUE_I32 (Int32.divu x y)
-    | SDiv ex =>
-      if andb ex (negb (((Int32.signed x) mod (Int32.signed y)) =? 0))
-      then DVALUE_Poison else DVALUE_I32 (Int32.divs x y)
-    | LShr ex =>
-      if (Int32.unsigned y) >=? 32 then undef_i32
-      else if andb ex (negb ((Int32.unsigned x)
-                               mod (Z.pow 2 (Int32.unsigned y)) =? 0))
-      then DVALUE_Poison else DVALUE_I32 (Int32.shru x y)
-    | AShr ex =>
-      if (Int32.unsigned y) >=? 32 then undef_i32
-      else if andb ex (negb ((Int32.unsigned x)
-                               mod (Z.pow 2 (Int32.unsigned y)) =? 0))
-      then DVALUE_Poison else DVALUE_I32 (Int32.shr x y)
-    | URem =>
-      DVALUE_I32 (Int32.modu x y)
-    | SRem =>
-      DVALUE_I32 (Int32.mods x y)
-    | And =>
-      DVALUE_I32 (Int32.and x y)
-    | Or =>
-      DVALUE_I32 (Int32.or x y)
-    | Xor =>
-      DVALUE_I32 (Int32.xor x y)
-    end.
-  Arguments eval_i32_op _ _ _ : simpl nomatch.
-
-
-  Definition eval_i64_op (iop:ibinop) (x y:inttyp 64) : dvalue:=
-    (* This needs to be tested *)
-    match iop with
-    (* Following to cases are probably right since they use CompCert *)
-    | Add nuw nsw =>
-      if orb (andb nuw (Int64.eq (Int64.add_carry x y Int64.zero) Int64.one))
-             (andb nsw (Int64.eq (Int64.add_overflow x y Int64.zero) Int64.one))
-      then DVALUE_Poison else DVALUE_I64 (Int64.add x y)
-    | Sub nuw nsw =>
-      if orb (andb nuw (Int64.eq (Int64.sub_borrow x y Int64.zero) Int64.one))
-             (andb nsw (Int64.eq (Int64.sub_overflow x y Int64.zero) Int64.one))
-      then DVALUE_Poison else DVALUE_I64 (Int64.sub x y)
-    | Mul nuw nsw =>
-      let res := Int64.mul x y in
-      let res_s' := (Int64.signed x) * (Int64.signed y) in
-      if orb (andb nuw ((Int64.unsigned x) * (Int64.unsigned y) >?
-                      Int64.unsigned res))
-             (andb nsw (orb (Int64.min_signed >? res_s')
-                            (res_s' >? Int64.max_signed)))
-      then DVALUE_Poison else DVALUE_I64 res
-    | Shl nuw nsw =>
-      let res := Int64.shl x y in
-      let res_u := Int64.unsigned res in
-      let res_u' := Z.shiftl (Int64.unsigned x) (Int64.unsigned y) in
-      (* Unsigned shift x right by 64 - y. If shifted x != sign bit * (2^y - 1),
-         then there is overflow. *)
-      if (Int64.unsigned y) >=? 64 then undef_i64
-      else if orb (andb nuw (res_u' >? res_u))
-                  (andb nsw (negb (Z.shiftr (Int64.unsigned x)
-                                            (64 - Int64.unsigned y)
-                                   =? (Int64.unsigned (Int64.negative res))
-                                      * (Z.pow 2 (Int64.unsigned y) - 1))))
-           then DVALUE_Poison else DVALUE_I64 res
-    | UDiv ex =>
-      if andb ex (negb ((Int64.unsigned x) mod (Int64.unsigned y) =? 0))
-      then DVALUE_Poison else DVALUE_I64 (Int64.divu x y)
-    | SDiv ex =>
-      if andb ex (negb (((Int64.signed x) mod (Int64.signed y)) =? 0))
-      then DVALUE_Poison else DVALUE_I64 (Int64.divs x y)
-    | LShr ex =>
-      if (Int64.unsigned y) >=? 64 then undef_i64
-      else if andb ex (negb ((Int64.unsigned x)
-                               mod (Z.pow 2 (Int64.unsigned y)) =? 0))
-      then DVALUE_Poison else DVALUE_I64 (Int64.shru x y)
-    | AShr ex =>
-      if (Int64.unsigned y) >=? 64 then undef_i64
-      else if andb ex (negb ((Int64.unsigned x)
-                               mod (Z.pow 2 (Int64.unsigned y)) =? 0))
-      then DVALUE_Poison else DVALUE_I64 (Int64.shr x y)
-    | URem =>
-      DVALUE_I64 (Int64.modu x y)
-    | SRem =>
-      DVALUE_I64 (Int64.mods x y)
-    | And =>
-      DVALUE_I64 (Int64.and x y)
-    | Or =>
-      DVALUE_I64 (Int64.or x y)
-    | Xor =>
-      DVALUE_I64 (Int64.xor x y)
-    end.
-  Arguments eval_i64_op _ _ _ : simpl nomatch.
 
   (* Evaluate the given iop on the given arguments according to the bitsize *)
   Definition integer_op (bits:Z) (iop:ibinop) (x y:inttyp bits) : err dvalue :=
     match bits, x, y with
-    | 1, x, y => mret (eval_i1_op iop x y)
-    | 8, x, y => mret (eval_i8_op iop x y)
-    | 32, x, y => mret (eval_i32_op iop x y)
-    | 64, x, y => mret (eval_i64_op iop x y)
+    | 1, x, y => mret (eval_int_op iop x y)
+    | 8, x, y => mret (eval_int_op iop x y)
+    | 32, x, y => mret (eval_int_op iop x y)
+    | 64, x, y => mret (eval_int_op iop x y)
     | _, _, _ => failwith "unsupported bitsize"
     end.
   Arguments integer_op _ _ _ _ : simpl nomatch.
@@ -353,10 +476,10 @@ Definition undef_i64 := DVALUE_Undef.
      Takes the integer modulo 2^bits. *)
   Definition coerce_integer_to_int (bits:Z) (i:Z) : err dvalue :=
     match bits with
-    | 1 => mret (DVALUE_I1 (Int1.repr i))
-    | 8 => mret (DVALUE_I8 (Int8.repr i))
-    | 32 => mret (DVALUE_I32 (Int32.repr i))
-    | 64 => mret (DVALUE_I64 (Int64.repr i))
+    | 1 => mret (DVALUE_I1 (repr i))
+    | 8 => mret (DVALUE_I8 (repr i))
+    | 32 => mret (DVALUE_I32 (repr i))
+    | 64 => mret (DVALUE_I64 (repr i))
     | _ => failwith "unsupported integer size"
     end.
   Arguments coerce_integer_to_int _ _ : simpl nomatch.
@@ -374,10 +497,10 @@ Definition undef_i64 := DVALUE_Undef.
      in order to prevent eval_iop from being recursive. *)
   Definition eval_iop_integer_h iop v1 v2 : err dvalue :=
     match v1, v2 with
-    | DVALUE_I1 i1, DVALUE_I1 i2 => integer_op 1 iop i1 i2
-    | DVALUE_I8 i1, DVALUE_I8 i2 => integer_op 8 iop i1 i2
-    | DVALUE_I32 i1, DVALUE_I32 i2 => integer_op 32 iop i1 i2
-    | DVALUE_I64 i1, DVALUE_I64 i2 => integer_op 64 iop i1 i2
+    | DVALUE_I1 i1, DVALUE_I1 i2 => mret (eval_int_op iop i1 i2)
+    | DVALUE_I8 i1, DVALUE_I8 i2 => mret (eval_int_op iop i1 i2)
+    | DVALUE_I32 i1, DVALUE_I32 i2 => mret (eval_int_op iop i1 i2)
+    | DVALUE_I64 i1, DVALUE_I64 i2 => mret (eval_int_op iop i1 i2)
     | _, _ => failwith "ill_typed-iop"
     end.
   Arguments eval_iop_integer_h _ _ _ : simpl nomatch.
@@ -395,86 +518,28 @@ Definition undef_i64 := DVALUE_Undef.
   Arguments eval_iop _ _ _ : simpl nomatch.
 
 
-  Definition eval_i1_icmp icmp x y : dvalue :=
+  Definition eval_int_icmp `{VInt Int} icmp (x y : Int) : dvalue :=
     if match icmp with
-       | Eq => Int1.cmp Ceq x y
-       | Ne => Int1.cmp Cne x y
-       | Ugt => Int1.cmpu Cgt x y
-       | Uge => Int1.cmpu Cge x y
-       | Ult => Int1.cmpu Clt x y
-       | Ule => Int1.cmpu Cle x y
-       | Sgt => Int1.cmp Cgt x y
-       | Sge => Int1.cmp Cge x y
-       | Slt => Int1.cmp Clt x y
-       | Sle => Int1.cmp Cle x y
+       | Eq => cmp Ceq x y
+       | Ne => cmp Cne x y
+       | Ugt => cmpu Cgt x y
+       | Uge => cmpu Cge x y
+       | Ult => cmpu Clt x y
+       | Ule => cmpu Cle x y
+       | Sgt => cmp Cgt x y
+       | Sge => cmp Cge x y
+       | Slt => cmp Clt x y
+       | Sle => cmp Cle x y
        end
-    then DVALUE_I1 Int1.one else DVALUE_I1 Int1.zero.
-  Arguments eval_i1_icmp _ _ _ : simpl nomatch.
-
-  Definition eval_i8_icmp icmp x y : dvalue :=
-    if match icmp with
-       | Eq => Int8.cmp Ceq x y
-       | Ne => Int8.cmp Cne x y
-       | Ugt => Int8.cmpu Cgt x y
-       | Uge => Int8.cmpu Cge x y
-       | Ult => Int8.cmpu Clt x y
-       | Ule => Int8.cmpu Cle x y
-       | Sgt => Int8.cmp Cgt x y
-       | Sge => Int8.cmp Cge x y
-       | Slt => Int8.cmp Clt x y
-       | Sle => Int8.cmp Cle x y
-       end
-    then DVALUE_I1 Int1.one else DVALUE_I1 Int1.zero.
-  Arguments eval_i8_icmp _ _ _ : simpl nomatch.
-
-  Definition eval_i32_icmp icmp x y : dvalue :=
-    if match icmp with
-       | Eq => Int32.cmp Ceq x y
-       | Ne => Int32.cmp Cne x y
-       | Ugt => Int32.cmpu Cgt x y
-       | Uge => Int32.cmpu Cge x y
-       | Ult => Int32.cmpu Clt x y
-       | Ule => Int32.cmpu Cle x y
-       | Sgt => Int32.cmp Cgt x y
-       | Sge => Int32.cmp Cge x y
-       | Slt => Int32.cmp Clt x y
-       | Sle => Int32.cmp Cle x y
-       end
-    then DVALUE_I1 Int1.one else DVALUE_I1 Int1.zero.
-  Arguments eval_i32_icmp _ _ _ : simpl nomatch.
-
-  Definition eval_i64_icmp icmp x y : dvalue :=
-    if match icmp with
-       | Eq => Int64.cmp Ceq x y
-       | Ne => Int64.cmp Cne x y
-       | Ugt => Int64.cmpu Cgt x y
-       | Uge => Int64.cmpu Cge x y
-       | Ult => Int64.cmpu Clt x y
-       | Ule => Int64.cmpu Cle x y
-       | Sgt => Int64.cmp Cgt x y
-       | Sge => Int64.cmp Cge x y
-       | Slt => Int64.cmp Clt x y
-       | Sle => Int64.cmp Cle x y
-       end
-    then DVALUE_I1 Int1.one else DVALUE_I1 Int1.zero.
-  Arguments eval_i64_icmp _ _ _ : simpl nomatch.
-
-  Definition integer_cmp bits icmp (x y:inttyp bits) : err dvalue :=
-    match bits, x, y with
-    | 1, x, y => mret (eval_i1_icmp icmp x y)
-    | 8, x, y => mret (eval_i8_icmp icmp x y)
-    | 32, x, y => mret (eval_i32_icmp icmp x y)
-    | 64, x, y => mret (eval_i64_icmp icmp x y)
-    | _, _, _ => failwith "unsupported bitsize"
-    end.
-  Arguments integer_cmp _ _ _ _ : simpl nomatch.
+    then to_dvalue one else to_dvalue zero.
+  Arguments eval_int_icmp _ _ _ : simpl nomatch.
 
   Definition eval_icmp icmp v1 v2 : err dvalue :=
     match v1, v2 with
-    | DVALUE_I1 i1, DVALUE_I1 i2 => integer_cmp 1 icmp i1 i2
-    | DVALUE_I8 i1, DVALUE_I8 i2 => integer_cmp 8 icmp i1 i2
-    | DVALUE_I32 i1, DVALUE_I32 i2 => integer_cmp 32 icmp i1 i2
-    | DVALUE_I64 i1, DVALUE_I64 i2 => integer_cmp 64 icmp i1 i2
+    | DVALUE_I1 i1, DVALUE_I1 i2 => mret (eval_int_icmp icmp i1 i2)
+    | DVALUE_I8 i1, DVALUE_I8 i2 => mret (eval_int_icmp icmp i1 i2)
+    | DVALUE_I32 i1, DVALUE_I32 i2 => mret (eval_int_icmp icmp i1 i2)
+    | DVALUE_I64 i1, DVALUE_I64 i2 => mret (eval_int_icmp icmp i1 i2)
     | _, _ => failwith "ill_typed-icmp"
     end.
   Arguments eval_icmp _ _ _ : simpl nomatch.

--- a/src/coq/Memory.v
+++ b/src/coq/Memory.v
@@ -164,10 +164,10 @@ Qed.
 Fixpoint serialize_dvalue (dval:dvalue) : list SByte :=
   match dval with
   | DVALUE_Addr addr => (Ptr addr) :: (repeat PtrFrag 7)
-  | DVALUE_I1 i => Z_to_sbyte_list 8 (DynamicValues.Int1.unsigned i)
-  | DVALUE_I8 i => Z_to_sbyte_list 8 (DynamicValues.Int8.unsigned i)
-  | DVALUE_I32 i => Z_to_sbyte_list 8 (DynamicValues.Int32.unsigned i)
-  | DVALUE_I64 i => Z_to_sbyte_list 8 (Int64.unsigned i)
+  | DVALUE_I1 i => Z_to_sbyte_list 8 (unsigned i)
+  | DVALUE_I8 i => Z_to_sbyte_list 8 (unsigned i)
+  | DVALUE_I32 i => Z_to_sbyte_list 8 (unsigned i)
+  | DVALUE_I64 i => Z_to_sbyte_list 8 (unsigned i)
   | DVALUE_Struct fields | DVALUE_Array fields =>
       (* note the _right_ fold is necessary for byte ordering. *)
       fold_right (fun 'dv acc => ((serialize_dvalue dv) ++ acc) % list) [] fields
@@ -180,10 +180,10 @@ Fixpoint deserialize_sbytes (bytes:list SByte) (t:dtyp) : dvalue :=
   | DTYPE_I sz =>
     let des_int := sbyte_list_to_Z bytes in
     match sz with
-    | 1 => DVALUE_I1 (DynamicValues.Int1.repr des_int)
-    | 8 => DVALUE_I8 (DynamicValues.Int8.repr des_int)
-    | 32 => DVALUE_I32 (DynamicValues.Int32.repr des_int)
-    | 64 => DVALUE_I64 (Int64.repr des_int)
+    | 1 => DVALUE_I1 (repr des_int)
+    | 8 => DVALUE_I8 (repr des_int)
+    | 32 => DVALUE_I32 (repr des_int)
+    | 64 => DVALUE_I64 (repr des_int)
     | _ => DVALUE_None (* invalid size. *)
     end
   | DTYPE_Pointer =>
@@ -307,7 +307,7 @@ Fixpoint handle_gep_h (t:dtyp) (b:Z) (off:Z) (vs:list dvalue) (m:memory) : err (
   | v :: vs' =>
     match v with
     | DVALUE_I32 i =>
-      let k := DynamicValues.Int32.unsigned i in
+      let k := unsigned i in
       let n := BinIntDef.Z.to_nat k in
       match t with
       | DTYPE_Vector _ ta | DTYPE_Array _ ta =>
@@ -323,7 +323,7 @@ Fixpoint handle_gep_h (t:dtyp) (b:Z) (off:Z) (vs:list dvalue) (m:memory) : err (
       | _ => raise ("non-i32-indexable type")
       end
     | DVALUE_I8 i =>
-      let k := DynamicValues.Int8.unsigned i in
+      let k := unsigned i in
       let n := BinIntDef.Z.to_nat k in
       match t with
       | DTYPE_Vector _ ta | DTYPE_Array _ ta =>
@@ -331,7 +331,7 @@ Fixpoint handle_gep_h (t:dtyp) (b:Z) (off:Z) (vs:list dvalue) (m:memory) : err (
       | _ => raise ("non-i8-indexable type")
       end
     | DVALUE_I64 i =>
-      let k := Int64.unsigned i in
+      let k := unsigned i in
       let n := BinIntDef.Z.to_nat k in
       match t with
       | DTYPE_Vector _ ta | DTYPE_Array _ ta =>
@@ -363,7 +363,7 @@ Definition handle_gep (t:dtyp) (dv:dvalue) (vs:list dvalue) (m:memory) : err (me
   | DVALUE_I32 i :: vs' => (* TODO: Handle non i32 indices *)
     match dv with
     | DVALUE_Addr (b, o) =>
-      handle_gep_h t b (o + (sizeof_dtyp t) * (DynamicValues.Int32.unsigned i)) vs' m
+      handle_gep_h t b (o + (sizeof_dtyp t) * (unsigned i)) vs' m
     | _ => raise "non-address" 
     end
   | _ => raise "non-I32 index"
@@ -413,10 +413,10 @@ Definition mem_step {X} (e:IO X) (m:memory) : err ((IO X) + (memory * X)) :=
 
   | ItoP i =>
     match i with
-    | DVALUE_I64 i => mret (inr (m, DVALUE_Addr (0, DynamicValues.Int64.unsigned i)))
-    | DVALUE_I32 i => mret (inr (m, DVALUE_Addr (0, DynamicValues.Int32.unsigned i)))
-    | DVALUE_I8 i => mret (inr (m, DVALUE_Addr (0, DynamicValues.Int8.unsigned i)))
-    | DVALUE_I1 i => mret (inr (m, DVALUE_Addr (0, DynamicValues.Int1.unsigned i)))
+    | DVALUE_I64 i => mret (inr (m, DVALUE_Addr (0, unsigned i)))
+    | DVALUE_I32 i => mret (inr (m, DVALUE_Addr (0, unsigned i)))
+    | DVALUE_I8 i => mret (inr (m, DVALUE_Addr (0, unsigned i)))
+    | DVALUE_I1 i => mret (inr (m, DVALUE_Addr (0, unsigned i)))
     | _ => raise "Non integer passed to ItoP"
     end
     

--- a/src/coq/Renaming.v
+++ b/src/coq/Renaming.v
@@ -569,7 +569,7 @@ Section PROOFS.
   Qed.
   
   Lemma swap_eval_i1_op : forall (iop:ibinop) (x y:inttyp 1),
-      eval_i1_op (swap id1 id2 iop) (swap id1 id2 x) (swap id1 id2 y) = swap id1 id2 (eval_i1_op iop x y).
+      eval_int_op (swap id1 id2 iop) (swap id1 id2 x) (swap id1 id2 y) = swap id1 id2 (eval_int_op iop x y).
   Proof.
     unfold_swaps.
     intros iop x y.
@@ -577,7 +577,7 @@ Section PROOFS.
   Qed.
 
   Lemma swap_eval_i32_op : forall (iop:ibinop) (x y:inttyp 32),
-      eval_i32_op (swap id1 id2 iop) (swap id1 id2 x) (swap id1 id2 y) = swap id1 id2 (eval_i32_op iop x y).
+      eval_int_op (swap id1 id2 iop) (swap id1 id2 x) (swap id1 id2 y) = swap id1 id2 (eval_int_op iop x y).
   Proof.
     unfold_swaps.
     intros iop x y.
@@ -585,7 +585,7 @@ Section PROOFS.
   Qed.
 
   Lemma swap_eval_i64_op : forall (iop:ibinop) (x y:inttyp 64),
-      eval_i64_op (swap id1 id2 iop) (swap id1 id2 x) (swap id1 id2 y) = swap id1 id2 (eval_i64_op iop x y).
+      eval_int_op (swap id1 id2 iop) (swap id1 id2 x) (swap id1 id2 y) = swap id1 id2 (eval_int_op iop x y).
   Proof.
     unfold_swaps.
     intros iop x y. 

--- a/src/coq/StepSemantics.v
+++ b/src/coq/StepSemantics.v
@@ -109,49 +109,49 @@ Module StepSemantics(A:MemoryAddress.ADDRESS)(LLVMIO:LLVM_INTERACTIONS(A)).
     | Trunc =>
       match t1, x, t2 with
       | TYPE_I 8, DVALUE_I8 i1, TYPE_I 1 =>
-        mret (DVALUE_I1 (Int1.repr (Int8.unsigned i1)))
+        mret (DVALUE_I1 (repr (unsigned i1)))
       | TYPE_I 32, DVALUE_I32 i1, TYPE_I 1 =>
-        mret (DVALUE_I1 (Int1.repr (Int32.unsigned i1)))
+        mret (DVALUE_I1 (repr (unsigned i1)))
       | TYPE_I 32, DVALUE_I32 i1, TYPE_I 8 =>
-        mret (DVALUE_I8 (Int8.repr (Int32.unsigned i1)))
+        mret (DVALUE_I8 (repr (unsigned i1)))
       | TYPE_I 64, DVALUE_I64 i1, TYPE_I 1 =>
-        mret (DVALUE_I1 (Int1.repr (Int64.unsigned i1)))
+        mret (DVALUE_I1 (repr (unsigned i1)))
       | TYPE_I 64, DVALUE_I64 i1, TYPE_I 8 =>
-        mret (DVALUE_I8 (Int8.repr (Int64.unsigned i1)))
+        mret (DVALUE_I8 (repr (unsigned i1)))
       | TYPE_I 64, DVALUE_I64 i1, TYPE_I 32 =>
-        mret (DVALUE_I32 (Int32.repr (Int64.unsigned i1)))
+        mret (DVALUE_I32 (repr (unsigned i1)))
       | _, _, _ => failwith "ill typed-conv"
       end
     | Zext =>
       match t1, x, t2 with
       | TYPE_I 1, DVALUE_I1 i1, TYPE_I 8 =>
-        mret (DVALUE_I8 (Int8.repr (Int1.unsigned i1)))
+        mret (DVALUE_I8 (repr (unsigned i1)))
       | TYPE_I 1, DVALUE_I1 i1, TYPE_I 32 =>
-        mret (DVALUE_I32 (Int32.repr (Int1.unsigned i1)))
+        mret (DVALUE_I32 (repr (unsigned i1)))
       | TYPE_I 1, DVALUE_I1 i1, TYPE_I 64 =>
-        mret (DVALUE_I64 (Int64.repr (Int1.unsigned i1)))
+        mret (DVALUE_I64 (repr (unsigned i1)))
       | TYPE_I 8, DVALUE_I8 i1, TYPE_I 32 =>
-        mret (DVALUE_I32 (Int32.repr (Int8.unsigned i1)))
+        mret (DVALUE_I32 (repr (unsigned i1)))
       | TYPE_I 8, DVALUE_I8 i1, TYPE_I 64 =>
-        mret (DVALUE_I64 (Int64.repr (Int8.unsigned i1)))
+        mret (DVALUE_I64 (repr (unsigned i1)))
       | TYPE_I 32, DVALUE_I32 i1, TYPE_I 64 =>
-        mret (DVALUE_I64 (Int64.repr (Int32.unsigned i1)))
+        mret (DVALUE_I64 (repr (unsigned i1)))
       | _, _, _ => failwith "ill typed-conv"
       end
     | Sext =>
       match t1, x, t2 with
       | TYPE_I 1, DVALUE_I1 i1, TYPE_I 8 =>
-        mret (DVALUE_I8 (Int8.repr (Int1.signed i1)))
+        mret (DVALUE_I8 (repr (signed i1)))
       | TYPE_I 1, DVALUE_I1 i1, TYPE_I 32 =>
-        mret (DVALUE_I32 (Int32.repr (Int1.signed i1)))
+        mret (DVALUE_I32 (repr (signed i1)))
       | TYPE_I 1, DVALUE_I1 i1, TYPE_I 64 =>
-        mret (DVALUE_I64 (Int64.repr (Int1.signed i1)))
+        mret (DVALUE_I64 (repr (signed i1)))
       | TYPE_I 8, DVALUE_I8 i1, TYPE_I 32 =>
-        mret (DVALUE_I32 (Int32.repr (Int8.signed i1)))
+        mret (DVALUE_I32 (repr (signed i1)))
       | TYPE_I 8, DVALUE_I8 i1, TYPE_I 64 =>
-        mret (DVALUE_I64 (Int64.repr (Int8.signed i1)))
+        mret (DVALUE_I64 (repr (signed i1)))
       | TYPE_I 32, DVALUE_I32 i1, TYPE_I 64 =>
-        mret (DVALUE_I64 (Int64.repr (Int32.signed i1)))
+        mret (DVALUE_I64 (repr (signed i1)))
       | _, _, _ => failwith "ill typed-conv"
       end
     | Bitcast =>
@@ -255,8 +255,8 @@ Fixpoint eval_exp (top:option dtyp) (o:exp) {struct o} : Trace dvalue :=
 
   | EXP_Bool b    =>
     match b with
-    | true  => mret (DVALUE_I1 Int1.one)
-    | false => mret (DVALUE_I1 Int1.zero)
+    | true  => mret (DVALUE_I1 one)
+    | false => mret (DVALUE_I1 zero)
     end
 
   | EXP_Null => mret (DVALUE_Addr A.null)
@@ -461,7 +461,7 @@ Definition step (s:state) : Trace result :=
     'dv <- eval_exp (Some (eval_typ t)) op; 
     'br <- match dv with 
             | DVALUE_I1 comparison_bit =>
-              if Int1.eq comparison_bit Int1.one then
+              if eq comparison_bit one then
                 mret br1
               else
                 mret br2


### PR DESCRIPTION
Currently this just wraps the CompCert types so we don't need to duplicate as much complex code.

Can probably clean this up still. Had to update some of the Lemmas in Renaming.v... Can also get rid of integer_op if we can get rid of it in Renaming.v. Not sure how much this affects the renaming proof.