### PR TITLE
switch to `dune` as build system instead of `ocamlbuild`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ src/ml/extracted/*.ml
 src/ml/extracted/STAMP
 src/.depend
 output
+/src/ml/extracted/.merlin

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
   - opam install -y --verbose -j ${NJOBS} ocamlfind camlp5 ${EXTRA_OPAM} 
   - opam install -y --verbose -j ${NJOBS} coq-ext-lib
   - opam install -y --verbose -j ${NJOBS} coq-paco
+  - opam install -y --verbose -j ${NJOBS} dune
 
 script:
   - eval $(opam config env)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ University of Pennsylvania as part of the DeepSpec project.
     - ext-lib    (installed via, e.g. opam install coq-ext-lib)
     - paco       (installed via, e.g. opam install coq-paco)
   - ocamlc : version 4.04    (probably works with 4.02 or later)
-  - OPAM packages: ocamlbuild, menhir, [optional: llvm  (for llvm v. 3.8)]
+  - OPAM packages: dune, menhir, [optional: llvm  (for llvm v. 3.8)]
 
 Compilation:
 

--- a/src/CRelationClasses.mli.patch
+++ b/src/CRelationClasses.mli.patch
@@ -1,0 +1,11 @@
+--- ml/extracted/CRelationClasses.mli	2018-10-08 20:41:02.000000000 -0700
++++ src/CRelationClasses.mli	2018-10-08 20:41:05.000000000 -0700
+@@ -104,7 +104,7 @@
+ val flip_Equivalence :
+   ('a1, 'a2) coq_Equivalence -> ('a1, 'a2) coq_Equivalence
+ 
+-val eq_equivalence : ('a1, __) coq_Equivalence
++val eq_equivalence : (__, __) coq_Equivalence
+ 
+ val iff_equivalence : (__, __) coq_Equivalence
+ 

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,12 +27,13 @@ all:
 
 coq: $(VOFILES)
 
-extracted: $(EXTRACTDIR)/STAMP
+extracted: $(EXTRACTDIR)/STAMP $(VOFILES)
 
 $(EXTRACTDIR)/STAMP: $(VOFILES) $(EXTRACTDIR)/Extract.v
 	@echo "Extracting"
 	rm -f $(EXTRACTDIR)/*.ml $(EXTRACTDIR)/*.mli
 	$(COQEXEC) $(EXTRACTDIR)/Extract.v
+	patch -p0 < CRelationClasses.mli.patch
 	touch $(EXTRACTDIR)/STAMP
 
 
@@ -46,25 +47,16 @@ depend: $(VFILES)
 	@$(COQDEP) $^ > .depend
 
 
+.PHONY: clean test qc restore
 
-# Directories containing plain Caml code
-OCAMLDIRS= $(EXTRACTDIR) $(MLDIR) 
-
-COMMA=,
-OCAMLINCLUDES=$(patsubst %,-I %, $(OCAMLDIRS))
-print-ocaml-includes:
-	@echo $(OCAMLINCLUDES)
-
-OCAMLLIBS := unix,str
-
-.PHONY: clean main.native test qc restore
-
-main.native: 
+_build/default/main.exe: 
 	@echo "Compiling Vellvm"
-	ocamlbuild -r -use-menhir -yaccflag --explain $(OCAMLINCLUDES) -libs $(OCAMLLIBS) main.native
+	dune build ml/main.exe
 
-vellvm: main.native
-	cp main.native vellvm
+EXE=_build/default/ml/main.exe
+
+vellvm: $(EXE)
+	cp $(EXE) vellvm
 
 test: vellvm
 	./vellvm --test-pp-dir ../tests/ll
@@ -77,7 +69,7 @@ clean:
 	rm -f $(VOFILES)
 	rm -rf doc/html doc/*.glob
 	rm -f $(EXTRACTDIR)/STAMP $(EXTRACTDIR)/*.ml $(EXTRACTDIR)/*.mli
-	ocamlbuild -clean
+	dune clean
 	rm -rf output
 	rm -f vellvm
 	rm -f doc/coq2html.ml doc/coq2html doc/*.cm? doc/*.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,6 +27,7 @@ all:
 
 coq: $(VOFILES)
 
+.PHONY: extracted
 extracted: $(EXTRACTDIR)/STAMP $(VOFILES)
 
 $(EXTRACTDIR)/STAMP: $(VOFILES) $(EXTRACTDIR)/Extract.v
@@ -49,11 +50,11 @@ depend: $(VFILES)
 
 .PHONY: clean test qc restore
 
-_build/default/main.exe: 
+EXE=_build/default/ml/main.exe
+
+$(EXE): extracted
 	@echo "Compiling Vellvm"
 	dune build ml/main.exe
-
-EXE=_build/default/ml/main.exe
 
 vellvm: $(EXE)
 	cp $(EXE) vellvm

--- a/src/ml/dune
+++ b/src/ml/dune
@@ -1,8 +1,8 @@
 (env
  (dev
-  (flags (:standard -g -w -9-27-34-32-39-33-20-50)))
+  (flags (:standard -g -w -27-34-32-39-33-20-50)))
  (release
-  (flags (:standard -O3 -w -9-27-34-32-39-33-20-50))))
+  (flags (:standard -O3 -w -27-34-32-39-33-20-50))))
   
 (menhir
  (flags --explain)

--- a/src/ml/dune
+++ b/src/ml/dune
@@ -1,0 +1,18 @@
+(env
+ (dev
+  (flags (:standard -g -w -9-27-34-32-39-33-20-50)))
+ (release
+  (flags (:standard -O3 -w -9-27-34-32-39-33-20-50))))
+  
+(menhir
+ (flags --explain)
+ (modules llvm_parser)
+)
+
+(ocamllex llvm_lexer)
+
+(executables
+ (names main)
+  (libraries extracted unix str)
+  )
+

--- a/src/ml/dune-project
+++ b/src/ml/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.2)
+(using menhir 1.0)

--- a/src/ml/extracted/dune
+++ b/src/ml/extracted/dune
@@ -1,0 +1,5 @@
+(library
+  (name extracted)
+  (wrapped false)
+  (synopsis "ML code extracted from Coq")
+  )

--- a/src/ml/llvm_printer.ml
+++ b/src/ml/llvm_printer.ml
@@ -624,6 +624,11 @@ and global : Format.formatter -> LLVMAst.global -> unit =
     g_visibility = visibility;
     g_dll_storage = gdll;
 
+    g_thread_local;
+    g_unnamed_addr;
+    g_addrspace;
+    g_externally_initialized;
+
     g_section = s;
     g_align = a;
   } -> fprintf ppf "@%s = "  (str_of_raw_id g_ident);
@@ -700,6 +705,8 @@ and definition : Format.formatter -> (LLVMAst.block list) LLVMAst.definition -> 
            ; dc_align
            ; dc_gc
            }
+       ; df_args
+       ; df_instrs
        } as df) ->
     let (ret_t, args_t) = get_function_type dc_type in
     let typ_attr_id =


### PR DESCRIPTION
Dune is arguably a more capable and modern build system for OCaml projects and I suggest to switch to it for OCaml builds.

An additional motivation for this changes is to be able to include VELLVM in other projects as a submodule. Since dune builds are composable, it will be easier to build it as a part other project builds.

Tested with the following configurations:
  1. dune-1.2.1, coq-8.8.1, and opam-1.2
  1. dune-1.4.0, coq-8.8.2, and opam-2.0.1
