### PR TITLE
Comments

### DIFF
--- a/src/coq/CFGProp.v
+++ b/src/coq/CFGProp.v
@@ -197,6 +197,7 @@ Definition instr_uses (i:instr) : (list ident) :=
   | INSTR_Alloca t (Some tv) align => texp_uses tv
   | INSTR_Load  volatile t ptr align => texp_uses ptr
   | INSTR_Store volatile val ptr align => (texp_uses val) ++ (texp_uses ptr)
+  | INSTR_Comment _
   | INSTR_Fence 
   | INSTR_AtomicCmpXchg
   | INSTR_AtomicRMW

--- a/src/coq/LLVMAst.v
+++ b/src/coq/LLVMAst.v
@@ -323,6 +323,7 @@ Record block : Set :=
       blk_phis  : list (local_id * phi);
       blk_code  : code;
       blk_term  : instr_id * terminator;
+      blk_comments : option (list string)
     }.
 
 Record definition (FnBody:Set) :=

--- a/src/coq/LLVMAst.v
+++ b/src/coq/LLVMAst.v
@@ -247,6 +247,7 @@ Inductive phi : Set :=
 .
        
 Inductive instr : Set :=
+| INSTR_Comment (msg:string)
 | INSTR_Op   (op:exp)                        (* INVARIANT: op must be of the form SV (OP_ ...) *)
 | INSTR_Call (fn:texp) (args:list texp)      (* CORNER CASE: return type is void treated specially *)
 | INSTR_Alloca (t:typ) (nb: option texp) (align:option int) 
@@ -346,6 +347,7 @@ Inductive metadata : Set :=
 .
 
 Inductive toplevel_entity (FnBody:Set) : Set :=
+| TLE_Comment         (msg:string)
 | TLE_Target          (tgt:string)
 | TLE_Datalayout      (layout:string)
 | TLE_Declaration     (decl:declaration)

--- a/src/coq/Renaming.v
+++ b/src/coq/Renaming.v
@@ -340,7 +340,8 @@ Definition swap_block (id1 id2:raw_id) (b:block) : block :=
   mk_block (swap id1 id2 (blk_id b))
            (swap id1 id2 (blk_phis b))
            (swap id1 id2 (blk_code b))
-           (swap id1 id2 (blk_term b)).
+           (swap id1 id2 (blk_term b))
+           (blk_comments b).
 Hint Unfold swap_block.  
 Instance swap_of_block : Swap block := swap_block.
 Hint Unfold swap_of_block.

--- a/src/coq/Renaming.v
+++ b/src/coq/Renaming.v
@@ -255,6 +255,7 @@ Definition swap_instr (id1 id2:raw_id) (ins:instr) : instr :=
     INSTR_Load volatile (swap id1 id2 t) (swap id1 id2 ptr) align
   | INSTR_Store volatile val ptr align =>
     INSTR_Store volatile (swap id1 id2 val) (swap id1 id2 ptr) align
+  | INSTR_Comment _
   | INSTR_Fence
   | INSTR_AtomicCmpXchg
   | INSTR_AtomicRMW
@@ -370,6 +371,7 @@ Hint Unfold swap_of_metadata.
 
 Definition swap_toplevel_entity {FnBody:Set} `{SF:Swap FnBody} (id1 id2:raw_id) (tle:toplevel_entity FnBody) :=
   match tle with
+  | TLE_Comment msg => tle
   | TLE_Target tgt => TLE_Target (swap id1 id2 tgt)
   | TLE_Datalayout layout => TLE_Datalayout (swap id1 id2 layout)
   | TLE_Declaration decl => TLE_Declaration (swap id1 id2 decl)

--- a/src/ml/llvm_parser.mly
+++ b/src/ml/llvm_parser.mly
@@ -365,7 +365,7 @@ df_blocks:
                                     | Some s -> (IId s, inst))
                        body
                 in
-                {blk_id = l; blk_phis; blk_code; blk_term=(IVoid (void_ctr.get ()), term)})
+                {blk_id = l; blk_phis; blk_code; blk_term=(IVoid (void_ctr.get ()), term); blk_comments=None})
 	bs
     }
 

--- a/src/ml/llvm_parser.mly
+++ b/src/ml/llvm_parser.mly
@@ -116,6 +116,7 @@ let phi_id s : raw_id =
    | Some s -> s
 
 let id_of = function
+  | INSTR_Comment _
   | INSTR_Store _
   | INSTR_Unreachable
   | INSTR_Fence

--- a/src/ml/llvm_printer.ml
+++ b/src/ml/llvm_printer.ml
@@ -750,7 +750,11 @@ and definition : Format.formatter -> (LLVMAst.block list) LLVMAst.definition -> 
     pp_print_char ppf '}' ;
 
 and block : Format.formatter -> LLVMAst.block -> unit =
-  fun ppf {blk_id=lbl; blk_phis=phis; blk_code=b; blk_term=(_,t)} ->
+  fun ppf {blk_id=lbl; blk_phis=phis; blk_code=b; blk_term=(_,t); blk_comments=c} ->
+    begin match c with
+    | None -> ()
+    | Some cs ->  pp_print_list ~pp_sep:pp_force_newline comment ppf cs ;
+    end;
     begin match lbl with
       | Anon i -> fprintf ppf "; <label> %d" (to_int i)
       | Name s -> (pp_print_string ppf (of_str s); pp_print_char ppf ':')
@@ -765,6 +769,8 @@ and block : Format.formatter -> LLVMAst.block -> unit =
     pp_force_newline ppf () ;
     terminator ppf t;
     pp_close_box ppf ()
+and comment : Format.formatter -> char list -> unit =
+  fun ppf s -> fprintf ppf "; %s" (of_str s)
 
 and modul : Format.formatter -> (LLVMAst.block list) LLVMAst.modul -> unit =
   fun ppf m ->

--- a/src/ml/llvm_printer.ml
+++ b/src/ml/llvm_printer.ml
@@ -754,6 +754,7 @@ and block : Format.formatter -> LLVMAst.block -> unit =
     begin match c with
     | None -> ()
     | Some cs ->  pp_print_list ~pp_sep:pp_force_newline comment ppf cs ;
+                  pp_force_newline ppf ()
     end;
     begin match lbl with
       | Anon i -> fprintf ppf "; <label> %d" (to_int i)

--- a/src/ml/llvm_printer.ml
+++ b/src/ml/llvm_printer.ml
@@ -475,6 +475,8 @@ and instr : Format.formatter -> LLVMAst.instr -> unit =
   fun ppf ->
   function
 
+  | INSTR_Comment msg ->  fprintf ppf "; %s" (of_str msg)
+
   | INSTR_Op v -> inst_exp ppf v
 
   | INSTR_Call (tv, tvl) ->
@@ -587,6 +589,7 @@ and toplevel_entities : Format.formatter -> (LLVMAst.block list) LLVMAst.topleve
 and toplevel_entity : Format.formatter -> (LLVMAst.block list) LLVMAst.toplevel_entity -> unit =
   fun ppf ->
   function
+  | TLE_Comment msg            -> fprintf ppf "; %s" (of_str msg)
   | TLE_Target s               -> fprintf ppf "target triple = \"%s\"" (of_str s)
   | TLE_Datalayout s           -> fprintf ppf "target datalayout = \"%s\"" (of_str s)
   | TLE_Source_filename s      -> fprintf ppf "source_filename = \"%s\"" (of_str s)


### PR DESCRIPTION
Per https://github.com/vellvm/vellvm/issues/71 this PR adds some places where comments could be inserted. In particular:

1. In top-level constructs (`TLE_Comment`)
2. In `code` section (`INSTR_Comment`)
3. In blocks, before the label (`blck_comments` record field)

I've tested it in my development which uses Vellvm and this works as expected and makes generated code easier to read and debug.

Comments added to AST and pretty-printed to IR. However, IR parsing does not add comments entries to AST.