### PR TITLE
implicit intepreter errors via `results`

### DIFF
--- a/src/ml/driver.ml
+++ b/src/ml/driver.ml
@@ -69,9 +69,10 @@ let process_ll_file path file =
   let _ = Platform.verb @@ Printf.sprintf "* processing file: %s\n" path in
   let ll_ast = parse_file path in
   let _ = if !interpret then begin
-      let dv = Interpreter.interpret ll_ast in
-      Printf.printf "Program terminated with: %s\n" (Interpreter.print_dvalue dv)
-    end
+              match Interpreter.interpret ll_ast with
+              | Ok dv -> Printf.printf "Program terminated with: %s\n" (Interpreter.print_dvalue dv)
+              | Error msg -> failwith msg
+            end
   in
   let ll_ast' = transform ll_ast in
   let vll_file = Platform.gen_name !Platform.output_path file ".v.ll" in
@@ -95,5 +96,4 @@ let process_files files =
 let run_ll_file path =
   let _ = Platform.verb @@ Printf.sprintf "* running file: %s\n" path in
   let ll_ast = parse_file path in
-  let res = Interpreter.interpret ll_ast in
-  res
+  Interpreter.interpret ll_ast

--- a/src/ml/test.ml
+++ b/src/ml/test.ml
@@ -59,7 +59,12 @@ let pp_test_of_dir dir =
         List.map (fun f -> (f, fun () -> parse_pp_test f)) (files_of_dir dir))
 
 let run_dvalue_test (test:IO.DV.dvalue -> bool) path =
-  if not (test (run_ll_file path)) then failwith (path ^ " test failed"); ()
+  let res =
+    match run_ll_file path with
+    | Error _ -> false
+    | Ok dv -> test dv
+  in
+  if not res then failwith (path ^ " test failed"); ()
 
 let poison_tests =
   ["../tests/llvm-arith/i1/add_nsw.ll";


### PR DESCRIPTION
Using 'result' types to implicitly return interpretation errors from `Interpreter.interpret`.
Arguably this is more developer-friendly API for 3rd party projects.
