### PR TITLE
mli file for interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,9 @@ src/ml/.merlin
 *.fls
 *.ml~
 examples.mli
-*.mli
 *.gz
 src/ml/extracted/*.ml
+src/ml/extracted/*.mli
 src/ml/extracted/STAMP
 src/.depend
 output

--- a/src/ml/libvellvm/interpreter.mli
+++ b/src/ml/libvellvm/interpreter.mli
@@ -1,0 +1,11 @@
+;; open TopLevel.IO
+
+val pp_addr : Format.formatter -> Memory.A.addr -> unit
+
+val pp_dvalue : Format.formatter -> DV.dvalue -> unit
+
+val interpret: ((LLVMAst.block list) LLVMAst.toplevel_entity list) -> (DV.dvalue, string) result
+
+val step: (DV.dvalue coq_Trace) -> (DV.dvalue, string) result
+
+val debug_flag: bool ref


### PR DESCRIPTION
missing MLI file for `interpeter` module.