### PR TITLE
updates for coq-itree 1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/coq2html"]
 	path = lib/coq2html
 	url = https://github.com/xavierleroy/coq2html.git
-[submodule "lib/InteractionTrees"]
-	path = lib/InteractionTrees
-	url = https://github.com/DeepSpec/InteractionTrees.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   - opam install -y --verbose -j ${NJOBS} coq-ext-lib
   - opam install -y --verbose -j ${NJOBS} coq-flocq
   - opam install -y --verbose -j ${NJOBS} coq-paco
+  - opam install -y --verbose -j ${NJOBS} coq-itree
   - opam install -y --verbose -j ${NJOBS} dune
   - opam install -y --verbose -j ${NJOBS} menhir
   - opam upgrade -y --verbose -j ${NJOBS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,5 @@ install:
 script:
   - eval $(opam config env)
   - opam config var root
-  - make -C lib/InteractionTrees
   - make -C src/
   - cd src && ./vellvm --test

--- a/README.md
+++ b/README.md
@@ -62,11 +62,7 @@ University of Pennsylvania as part of the DeepSpec project.
 Compilation:
 
 1. clone the vellvm git repo with `--recurse-submodule` option (`git clone --recurse-submodules`)
-2. compile 3rd party libraries:
-   1. Compile InteractionTrees
-	  - run `make` from the InteractionTrees directory  (do _not_ use `setup.sh`
-        since that will clone another copy of paco and we already assume ext-lib exists)
-3. run `make` in the /src directory
+2. run `make` in the /src directory
 
 # Running
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ University of Pennsylvania as part of the DeepSpec project.
     - ext-lib    (installed via, e.g. opam install coq-ext-lib)
     - paco       (installed via, e.g. opam install coq-paco)
     - flocq      (installed via, e.g. opam install coq-flocq, see note below) 
-  - ocamlc : version 4.04    (probably works with 4.03 or later)
+    - itree      (installed via, e.g. opam install coq-itree)
+- ocamlc : version 4.04    (probably works with 4.03 or later)
   - OPAM packages: dune, menhir, [optional: llvm  (for llvm v. 3.8)]
 
 Compilation:

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ COQLIBDIR = ../lib
 MLDIR = ml
 EXTRACTDIR = ml/extracted
 
-COQINCLUDES=$(foreach d, $(COQDIR), -R $(d) Vellvm) -R $(EXTRACTDIR) Extract -R $(COQLIBDIR)/InteractionTrees/theories ITree
+COQINCLUDES=$(foreach d, $(COQDIR), -R $(d) Vellvm) -R $(EXTRACTDIR) Extract
 COQC="$(COQBIN)coqc" -q $(COQINCLUDES) $(COQCOPTS)
 COQDEP="$(COQBIN)coqdep" $(COQINCLUDES)
 COQEXEC="$(COQBIN)coqtop" -q -w none $(COQINCLUDES) -batch -load-vernac-source

--- a/src/_CoqProject
+++ b/src/_CoqProject
@@ -1,3 +1,2 @@
 -Q coq Vellvm
 -R coq Vellvm
--R ../lib/InteractionTrees/theories ITree

--- a/src/coq/Intrinsics.v
+++ b/src/coq/Intrinsics.v
@@ -79,12 +79,12 @@ Module Make(A:MemoryAddress.ADDRESS)(LLVMIO: LLVM_INTERACTIONS(A)).
             | inl msg => raise msg
             | inr result => Ret result
             end
-          | None => fun pf => (eq_rect X (fun a => LLVM (failureE +' debugE) a) (ITree.send e)) dvalue pf
+          | None => fun pf => (eq_rect X (fun a => LLVM (failureE +' debugE) a) (ITree.trigger e)) dvalue pf
           end
-        | Store _ _ => fun pf  => (eq_rect X (fun a => LLVM (failureE +' debugE) a) (ITree.send e)) unit pf
-        | _ => fun pf  => (eq_rect X (fun a => LLVM (failureE +' debugE) a) (ITree.send e)) dvalue pf
+        | Store _ _ => fun pf  => (eq_rect X (fun a => LLVM (failureE +' debugE) a) (ITree.trigger e)) unit pf
+        | _ => fun pf  => (eq_rect X (fun a => LLVM (failureE +' debugE) a) (ITree.trigger e)) dvalue pf
         end eq_refl
-      | inr1 _ => ITree.send e
+      | inr1 _ => ITree.trigger e
       end.
         
   Definition evaluate_intrinsics (intrinsic_def : intrinsic_definitions)

--- a/src/coq/LLVMIO.v
+++ b/src/coq/LLVMIO.v
@@ -25,7 +25,7 @@ From ExtLib Require Import
 
 From ITree Require Import 
      ITree
-     Effects.Exception.
+     Events.Exception.
 
 From Vellvm Require Import
      Util
@@ -131,7 +131,7 @@ Variant debugE : Type -> Type :=
 | Debug : string -> debugE unit.
 
 Definition debug {E} `{debugE -< E} (msg : string) : itree E unit :=
-  send (Debug msg).
+  trigger (Debug msg).
 
 Definition debug_hom {E} (R : Type) (e : debugE R) : itree E R :=
   match e with

--- a/src/coq/Memory.v
+++ b/src/coq/Memory.v
@@ -18,8 +18,8 @@ From Coq Require Import
 From ITree Require Import
      ITree
      Basics.Basics
-     Effects.Exception
-     Effects.State.
+     Events.Exception
+     Events.State.
 
 From ExtLib Require Import
      Structures.Monads

--- a/src/coq/StepSemantics.v
+++ b/src/coq/StepSemantics.v
@@ -33,7 +33,7 @@ From Vellvm Require Import
      TypeUtil.
 
 Import Sum.
-Import OpenSum.
+Import Subevent.
 Import EqvNotation.
 Import ListNotations.
 Import MonadNotation.


### PR DESCRIPTION
coq-itree 1.0.0 should be released soon.  This pull request still keeps InteractionTrees as a submodule, but updates the rest of the code to be compatible.