### PR TITLE
Float print in hex

### DIFF
--- a/src/coq/AstLib.v
+++ b/src/coq/AstLib.v
@@ -398,7 +398,8 @@ Inductive value : Set :=
   Variable P : exp -> Prop.
   Hypothesis IH_Ident   : forall (id:ident), P ((EXP_Ident id)).
   Hypothesis IH_Integer : forall (x:int), P ((EXP_Integer x)).
-  Hypothesis IH_Float   : forall (f:float), P ((EXP_Float f)).
+  Hypothesis IH_Float   : forall (f:float32), P ((EXP_Float f)).
+  Hypothesis IH_Double  : forall (f:float), P ((EXP_Double f)).  
   Hypothesis IH_Hex     : forall (h:float), P ((EXP_Hex h)).  
   Hypothesis IH_Bool    : forall (b:bool), P ((EXP_Bool b)).
   Hypothesis IH_Null    : P ((EXP_Null )).
@@ -431,6 +432,7 @@ Inductive value : Set :=
     - apply IH_Ident.
     - apply IH_Integer.
     - apply IH_Float.
+    - apply IH_Double.      
     - apply IH_Hex.      
     - apply IH_Bool.
     - apply IH_Null.

--- a/src/coq/CFGProp.v
+++ b/src/coq/CFGProp.v
@@ -155,7 +155,8 @@ Fixpoint exp_uses (v:exp) : list ident :=
   match v with
   | EXP_Ident id => [id]
   | EXP_Integer _
-  | EXP_Float _ 
+  | EXP_Float _
+  | EXP_Double _               
   | EXP_Hex _        
   | EXP_Bool _
   | EXP_Null

--- a/src/coq/LLVMAst.v
+++ b/src/coq/LLVMAst.v
@@ -31,7 +31,8 @@ Open Scope string_scope.
 Open Scope list_scope.
 
 Definition int := Z.
-Definition float := Floats.float.  (* -bit floating point value *)
+Definition float := Floats.float.  (* 64-bit floating point value *)
+Definition float32 := Floats.float32.
 
 Inductive linkage : Set :=
 | LINKAGE_Private
@@ -191,17 +192,22 @@ Definition tident : Set := (typ * ident)%type.
 (* NOTES: 
   This datatype is more permissive than legal in LLVM:
      - it allows identifiers to appear nested inside of "constant expressions"
+       that is OK as long as we validate the syntax as "well-formed" before 
+       trying to give it semantics
 
   NOTES:
    - Integer expressions: llc parses large integer exps and converts them to some 
      internal form (based on integer size?)
    
    - Float constants: these are always parsed as 64-bit representable floats 
-     using ocamls float_of_string function.  If they are used in LLVM as 32-bit 
-     rather than 64-bit floats, they are converted when evaluated.
+     using ocamls float_of_string function. The parser converts float literals 
+     to 32-bit values using the type information available in the syntax.
+
+     -- TODO: 128-bit, 16-bit, other float formats?
 
    - Hex constants: these are always parsed as 0x<16-digit> 64-bit exps and
-     bit-converted to ocaml's 64-bit float representation.
+     bit-converted to ocaml's 64-bit float representation.  If they are
+     evaluated at 32-bit float types, they are converted during evaluation.
 
    - EXP_ prefix denotes syntax that LLVM calls a "value"
    - OP_  prefix denotes syntax that requires further evaluation
@@ -209,8 +215,9 @@ Definition tident : Set := (typ * ident)%type.
 Inductive exp : Set :=
 | EXP_Ident   (id:ident)  
 | EXP_Integer (x:int)
-| EXP_Float   (f:float)
-| EXP_Hex     (f:float)  (* See LLVM documentation about hex float constants. *)
+| EXP_Float   (f:float32)  (* 32-bit floating point values *)
+| EXP_Double  (f:float)    (* 64-bit floating point values *)
+| EXP_Hex     (f:float)    (* See LLVM documentation about hex float constants. *)
 | EXP_Bool    (b:bool)
 | EXP_Null
 | EXP_Zero_initializer

--- a/src/coq/Renaming.v
+++ b/src/coq/Renaming.v
@@ -205,6 +205,7 @@ Fixpoint swap_exp (id1 id2:raw_id) (e:exp) : exp :=
   | EXP_Ident id => EXP_Ident (swap id1 id2 id)
   | EXP_Integer _
   | EXP_Float   _
+  | EXP_Double  _                
   | EXP_Hex     _
   | EXP_Bool    _
   | EXP_Null

--- a/src/coq/StepSemantics.v
+++ b/src/coq/StepSemantics.v
@@ -313,11 +313,18 @@ Fixpoint eval_exp (top:option dtyp) (o:exp) {struct o} : LLVM (failureE +' debug
   | EXP_Float x   =>
     match top with
     | None => raise "eval_exp given untyped EXP_Float"
-    | Some DTYPE_Float  =>  ret (DVALUE_Float (Float32.of_double x))
+    | Some DTYPE_Float  =>  ret (DVALUE_Float x)
+    | _ => raise "bad type for constant float"
+    end
+
+  | EXP_Double x   =>
+    match top with
+    | None => raise "eval_exp given untyped EXP_Float"
     | Some DTYPE_Double =>  ret (DVALUE_Double x)
     | _ => raise "bad type for constant float"
     end
 
+      
   | EXP_Hex x     =>
     match top with
     | None => raise "eval_exp given untyped EXP_Hex"

--- a/src/ml/libvellvm/llvm_printer.ml
+++ b/src/ml/libvellvm/llvm_printer.ml
@@ -577,8 +577,16 @@ and instr_id : Format.formatter -> LLVMAst.instr_id -> unit =
     | IId id  -> fprintf ppf "%%%s = " (str_of_raw_id id)
     | IVoid n -> fprintf ppf "; void instr %d" (to_int n); pp_force_newline ppf ()
   
+and float_fmt : Format.formatter -> LLVMAst.exp -> unit =
+  fun ppf v ->
+  match v with
+  | EXP_Float f -> fprintf ppf "0x%lx" (Int32.bits_of_float (float_of_coqfloat f))
+  | _ -> fprintf ppf "%a" exp v (* Default to printing whatever, e.g., identifiers like %1 *)
 
-and texp ppf (t, v) = fprintf ppf "%a %a" typ t exp v
+and texp ppf (t, v) =
+  match t with
+  | TYPE_Float -> fprintf ppf "%a %a" typ t float_fmt v
+  | _ ->  fprintf ppf "%a %a" typ t exp v
 
 and tident ppf (t, v) = fprintf ppf "%a %a" typ t ident v
 

--- a/src/ml/libvellvm/llvm_printer.ml
+++ b/src/ml/libvellvm/llvm_printer.ml
@@ -266,8 +266,8 @@ and exp : Format.formatter -> LLVMAst.exp -> unit =
     match vv with
   | EXP_Ident i           -> ident ppf i
   | EXP_Integer i         -> pp_print_int ppf (to_int i)
-  | EXP_Float f           -> pp_print_float ppf (float_of_coqfloat f)
-  | EXP_Hex h             -> fprintf ppf "0x%Lx" (Int64.bits_of_float (float_of_coqfloat h))
+  | EXP_Float f           -> fprintf ppf "0x%LX" (Int64.bits_of_float (float_of_coqfloat f))
+  | EXP_Hex h             -> fprintf ppf "0x%LX" (Int64.bits_of_float (float_of_coqfloat h))
   | EXP_Bool b            -> pp_print_bool ppf b
   | EXP_Null              -> pp_print_string ppf "null"
   | EXP_Undef             -> pp_print_string ppf "undef"
@@ -577,16 +577,7 @@ and instr_id : Format.formatter -> LLVMAst.instr_id -> unit =
     | IId id  -> fprintf ppf "%%%s = " (str_of_raw_id id)
     | IVoid n -> fprintf ppf "; void instr %d" (to_int n); pp_force_newline ppf ()
   
-and float_fmt : Format.formatter -> LLVMAst.exp -> unit =
-  fun ppf v ->
-  match v with
-  | EXP_Float f -> fprintf ppf "0x%lx" (Int32.bits_of_float (float_of_coqfloat f))
-  | _ -> fprintf ppf "%a" exp v (* Default to printing whatever, e.g., identifiers like %1 *)
-
-and texp ppf (t, v) =
-  match t with
-  | TYPE_Float -> fprintf ppf "%a %a" typ t float_fmt v
-  | _ ->  fprintf ppf "%a %a" typ t exp v
+and texp ppf (t, v) = fprintf ppf "%a %a" typ t exp v
 
 and tident ppf (t, v) = fprintf ppf "%a %a" typ t ident v
 

--- a/src/ml/libvellvm/llvm_printer.ml
+++ b/src/ml/libvellvm/llvm_printer.ml
@@ -266,8 +266,9 @@ and exp : Format.formatter -> LLVMAst.exp -> unit =
     match vv with
   | EXP_Ident i           -> ident ppf i
   | EXP_Integer i         -> pp_print_int ppf (to_int i)
-  | EXP_Float f           -> fprintf ppf "0x%LX" (Int64.bits_of_float (float_of_coqfloat f))
-  | EXP_Hex h             -> fprintf ppf "0x%LX" (Int64.bits_of_float (float_of_coqfloat h))
+  | EXP_Float f           -> fprintf ppf "0x%lX" (Camlcoq.camlint_of_coqint(Floats.Float32.to_bits f))
+  | EXP_Double f          -> fprintf ppf "0x%LX" (Camlcoq.camlint64_of_coqint(Floats.Float.to_bits f))
+  | EXP_Hex h             -> fprintf ppf "0x%LX" (Camlcoq.camlint64_of_coqint(Floats.Float.to_bits h))
   | EXP_Bool b            -> pp_print_bool ppf b
   | EXP_Null              -> pp_print_string ppf "null"
   | EXP_Undef             -> pp_print_string ppf "undef"
@@ -370,6 +371,7 @@ and inst_exp : Format.formatter -> LLVMAst.exp -> unit =
   | EXP_Ident _ 
   | EXP_Integer _ 
   | EXP_Float _
+  | EXP_Double _      
   | EXP_Hex _         
   | EXP_Bool _    
   | EXP_Null      

--- a/src/ml/llvm_lexer.mll
+++ b/src/ml/llvm_lexer.mll
@@ -28,8 +28,8 @@
   let of_str = Camlcoq.camlstring_of_coqstring
   let coq_of_int = Camlcoq.Z.of_sint
   let coq_of_int64 = Camlcoq.Z.of_sint64  
-  let coqfloat_of_float f = Floats.Float.of_bits(Camlcoq.coqint_of_camlint64(Int64.bits_of_float f))
-  
+  let coqfloat_of_float f = Floats.Float.of_bits(Camlcoq.coqint_of_camlint64(Int64.bits_of_float f))  
+
   exception Lex_error_unterminated_string of Lexing.position
 
   let kw = function
@@ -302,10 +302,8 @@ rule token = parse
 
   (* constants *)
   | ('-'? digit+) as d            { INTEGER (coq_of_int64 (Int64.of_string d)) }
-  | ('-'? digit* '.' digit+) as d { FLOAT (coqfloat_of_float (float_of_string d)) }
-  | ('-'? digit ('.' digit+)? 'e' ('+'|'-') digit+) as d
-                                { let f = float_of_string d in
-                                  FLOAT (coqfloat_of_float f) }
+  | ('-'? digit* '.' digit+) as d { FLOAT d } 
+  | ('-'? digit ('.' digit+)? 'e' ('+'|'-') digit+) as d { FLOAT d }
   | ('0''x' hexdigit+) as d     { HEXCONSTANT (coqfloat_of_float (Int64.float_of_bits (Int64.of_string d))) }			
   | '"'                         { STRING (string (Buffer.create 10) lexbuf) }
 

--- a/tests/llvm-arith/float/double_literal.ll
+++ b/tests/llvm-arith/float/double_literal.ll
@@ -1,0 +1,3 @@
+define double @main(i8 %argc, i8** %arcv) {
+  ret double 125.31999999999999317878973670303821563720703125
+}

--- a/tests/llvm-arith/float/float_literal.ll
+++ b/tests/llvm-arith/float/float_literal.ll
@@ -1,0 +1,3 @@
+define float @main(i8 %argc, i8** %arcv) {
+  ret float 125.31999969482421875
+}

--- a/tests/llvm-arith/float/hex_float_literal.ll
+++ b/tests/llvm-arith/float/hex_float_literal.ll
@@ -1,0 +1,3 @@
+define float @main(i8 %argc, i8** %arcv) {
+  ret float 0x42faa3d700000000
+}


### PR DESCRIPTION
Addressing issue #95. This might need a little bit of extra work.

Also this fixes the old hex printing (apparently %Lx doesn't work, you have to use %LX).

I encountered some oddities here. Described below.

    LangRef describes this here:

    https://llvm.org/docs/LangRef.html#simple-constants

    Initially I thought I would just take the hexadecimal representation of
    the float. I.e., I would write out a good 32-bits worth of hexadecimal. So, in
    our example 125.32 would become:

    0x42faa3d7

    (https://www.exploringbinary.com/floating-point-converter/)

    However, LLVM says:

    > When using the hexadecimal form, constants of types half, float, and
    > double are represented using the 16-digit form shown above (which
    > matches the IEEE754 representation for double); half and float values
    > must, however, be exactly representable as IEEE 754 half and single
    > precision, respectively.

    So, I *have* to use 64-bits worth of hexadecimal. Which... Fine? I
    thought it might be:

    0x0000000042faa3d7

    It's not. And it's also not:

    0x42faa3d700000000

    It's actually, according to a C program I wrote...

    0x405f547ae0000000

    Which makes sense because the double is:

    0x405f547ae147ae14

    So, they're lopping off the bottom 7 hex digits, leaving us with
    36-bits remaining. Why 36 and not 32? Because doubles have 11
    exponent bits, and floats have 8. So we actually have the mantisa
    shifted over by 3 bits (and there's an extra 0 bit because 35 isn't a multiple of 4).

Ultimately this conversion seems to work (it all makes sense now, but it wasn't obvious to me at first glance), but I'm wondering if we should explicitly lop off the bits for. It sounds like @vzaliva might be altering the `EXP_Float` values, so this might still cause problems unless we do that? It's an easy change to make, but if we don't need it, maybe that's better? Thoughts?