### PR TITLE
Add UB event + spread poison

### DIFF
--- a/poison.org
+++ b/poison.org
@@ -1,5 +1,25 @@
 * When does poison cause undefined behaviour?
 
   - Branching on poison is undefined behaviour.
+    + select does NOT raise UB.
   - Store to poison address is UB
   - Load from poison address is UB
+
+* Evaluation and poison
+
+  Evaluation of expressions depending on poison should yield poison as
+  well... This mostly appears in DynamicValues.v, like for instance in
+  eval_icmp... Normally this would result in a type error being raised
+  if the types don't match up, but poison erases type information...
+
+* Select and poison
+
+  If any operand of select is poison the result is poison.
+
+  "An instruction that depends on a poison value, produces a poison value itself."
+
+  Even if the select chooses the non-poison value.
+
+* Vectors and poison
+
+  Considered pointwise, I think.

--- a/poison.org
+++ b/poison.org
@@ -1,0 +1,5 @@
+* When does poison cause undefined behaviour?
+
+  - Branching on poison is undefined behaviour.
+  - Store to poison address is UB
+  - Load from poison address is UB

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ COQEXEC="$(COQBIN)coqtop" -q -w none $(COQINCLUDES) -batch -load-vernac-source
 MENHIR=menhir
 CP=cp
 
-COQFILES := Error LLVMAst Util Misc AstLib Dom CFG CFGProp MemoryAddress DynamicTypes DynamicValues LLVMEvents TypeUtil Denotation DenotationProp Memory IntrinsicsDefinitions Intrinsics Renaming DeadInstr Transform Local Global Stack TransformTypes TopLevel Numeric/Archi Numeric/Coqlib Numeric/Fappli_IEEE_extra Numeric/Floats Numeric/Integers
+COQFILES := Error UndefinedBehaviour Numeric/Archi Numeric/Coqlib Numeric/Fappli_IEEE_extra Numeric/Integers Numeric/Floats Util LLVMAst Misc AstLib Dom CFG CFGProp MemoryAddress DynamicTypes DynamicValues LLVMEvents TypeUtil IntrinsicsDefinitions Intrinsics Denotation DenotationProp Memory Renaming DeadInstr Transform Local Global Stack TransformTypes TopLevel
 
 OLLVMFILES := 
 

--- a/src/coq/CFG.v
+++ b/src/coq/CFG.v
@@ -23,10 +23,11 @@ Import EqvNotation.
 Import MonadNotation.
 Open Scope monad_scope.
 (* SAZ: This notation doesn't seem to be in the opam coq-ext-lib yet. *)
+(*
 Notation "' pat <- c1 ;; c2" :=
     (@pbind _ _ _ _ _ c1 (fun x => match x with pat => c2 end))
     (at level 100, pat pattern, c1 at next level, right associativity) : monad_scope.
-
+*)
 
 (* SAZ: The notion of pc, and many other things in this file is now obsolete *)
 (* program counter denotes an instruction with a block of a function -------- *)

--- a/src/coq/Denotation.v
+++ b/src/coq/Denotation.v
@@ -115,48 +115,84 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
         match t1, x, t2 with
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_I 1 =>
           ret (DVALUE_I1 (repr (unsigned i1)))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_I 1 =>
+          ret DVALUE_Poison
         | DTYPE_I 32, DVALUE_I32 i1, DTYPE_I 1 =>
           ret (DVALUE_I1 (repr (unsigned i1)))
+        | DTYPE_I 32, DVALUE_Poison, DTYPE_I 1 =>
+          ret DVALUE_Poison
         | DTYPE_I 32, DVALUE_I32 i1, DTYPE_I 8 =>
           ret (DVALUE_I8 (repr (unsigned i1)))
+        | DTYPE_I 32, DVALUE_Poison, DTYPE_I 8 =>
+          ret DVALUE_Poison
         | DTYPE_I 64, DVALUE_I64 i1, DTYPE_I 1 =>
           ret (DVALUE_I1 (repr (unsigned i1)))
+        | DTYPE_I 64, DVALUE_Poison, DTYPE_I 1 =>
+          ret DVALUE_Poison
         | DTYPE_I 64, DVALUE_I64 i1, DTYPE_I 8 =>
           ret (DVALUE_I8 (repr (unsigned i1)))
+        | DTYPE_I 64, DVALUE_Poison, DTYPE_I 8 =>
+          ret DVALUE_Poison
         | DTYPE_I 64, DVALUE_I64 i1, DTYPE_I 32 =>
           ret (DVALUE_I32 (repr (unsigned i1)))
+        | DTYPE_I 64, DVALUE_Poison, DTYPE_I 32 =>
+          ret DVALUE_Poison
         | _, _, _ => raise "ill typed-conv"
         end
       | Zext =>
         match t1, x, t2 with
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_I 8 =>
           ret (DVALUE_I8 (repr (unsigned i1)))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_I 8 =>
+          ret DVALUE_Poison
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_I 32 =>
           ret (DVALUE_I32 (repr (unsigned i1)))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_I 32 =>
+          ret DVALUE_Poison
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_I 64 =>
           ret (DVALUE_I64 (repr (unsigned i1)))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_I 64 =>
+          ret DVALUE_Poison
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_I 32 =>
           ret (DVALUE_I32 (repr (unsigned i1)))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_I 32 =>
+          ret DVALUE_Poison
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_I 64 =>
           ret (DVALUE_I64 (repr (unsigned i1)))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_I 64 =>
+          ret DVALUE_Poison
         | DTYPE_I 32, DVALUE_I32 i1, DTYPE_I 64 =>
           ret (DVALUE_I64 (repr (unsigned i1)))
+        | DTYPE_I 32, DVALUE_Poison, DTYPE_I 64 =>
+          ret DVALUE_Poison
         | _, _, _ => raise "ill typed-conv"
         end
       | Sext =>
         match t1, x, t2 with
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_I 8 =>
           ret (DVALUE_I8 (repr (signed i1)))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_I 8 =>
+          ret DVALUE_Poison
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_I 32 =>
           ret (DVALUE_I32 (repr (signed i1)))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_I 32 =>
+          ret DVALUE_Poison
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_I 64 =>
           ret (DVALUE_I64 (repr (signed i1)))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_I 64 =>
+          ret DVALUE_Poison
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_I 32 =>
           ret (DVALUE_I32 (repr (signed i1)))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_I 32 =>
+          ret DVALUE_Poison
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_I 64 =>
           ret (DVALUE_I64 (repr (signed i1)))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_I 64 =>
+          ret DVALUE_Poison
         | DTYPE_I 32, DVALUE_I32 i1, DTYPE_I 64 =>
           ret (DVALUE_I64 (repr (signed i1)))
+        | DTYPE_I 32, DVALUE_Poison, DTYPE_I 64 =>
+          ret DVALUE_Poison
         | _, _, _ => raise "ill typed-conv"
         end
       | Bitcast =>
@@ -165,33 +201,51 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
           if bits1 =? bits2 then ret x else raise "unequal bitsize in cast"
         | DTYPE_Pointer, DVALUE_Addr a, DTYPE_Pointer =>
           ret (DVALUE_Addr a) 
+        | DTYPE_Pointer, DVALUE_Poison, DTYPE_Pointer =>
+          ret DVALUE_Poison
         | _, _, _ => raise "ill-typed_conv"
         end
       | Uitofp =>
         match t1, x, t2 with
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_Float =>
           ret (DVALUE_Float (Float32.of_intu (repr (unsigned i1))))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_Float =>
+          ret DVALUE_Poison
 
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_Float =>
           ret (DVALUE_Float (Float32.of_intu (repr (unsigned i1))))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_Float =>
+          ret DVALUE_Poison
 
         | DTYPE_I 32, DVALUE_I32 i1, DTYPE_Float =>
           ret (DVALUE_Float (Float32.of_intu (repr (unsigned i1))))
+        | DTYPE_I 32, DVALUE_Poison, DTYPE_Float =>
+          ret DVALUE_Poison
 
         | DTYPE_I 64, DVALUE_I64 i1, DTYPE_Float =>
           ret (DVALUE_Float (Float32.of_intu (repr (unsigned i1))))
+        | DTYPE_I 64, DVALUE_Poison, DTYPE_Float =>
+          ret DVALUE_Poison
 
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_Double =>
           ret (DVALUE_Double (Float.of_longu (repr (unsigned i1))))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_Double =>
+          ret DVALUE_Poison
 
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_Double =>
           ret (DVALUE_Double (Float.of_longu (repr (unsigned i1))))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_Double =>
+          ret DVALUE_Poison
 
         | DTYPE_I 32, DVALUE_I32 i1, DTYPE_Double =>
           ret (DVALUE_Double (Float.of_longu (repr (unsigned i1))))
+        | DTYPE_I 32, DVALUE_Poison, DTYPE_Double =>
+          ret DVALUE_Poison
               
         | DTYPE_I 64, DVALUE_I64 i1, DTYPE_Double =>
           ret (DVALUE_Double (Float.of_longu (repr (unsigned i1))))
+        | DTYPE_I 64, DVALUE_Poison, DTYPE_Double =>
+          ret DVALUE_Poison
 
         | _, _, _ => raise "ill typed Uitofp"
         end
@@ -199,27 +253,43 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
         match t1, x, t2 with
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_Float =>
           ret (DVALUE_Float (Float32.of_intu (repr (signed i1))))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_Float =>
+          ret DVALUE_Poison
 
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_Float =>
           ret (DVALUE_Float (Float32.of_intu (repr (signed i1))))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_Float =>
+          ret DVALUE_Poison
 
         | DTYPE_I 32, DVALUE_I32 i1, DTYPE_Float =>
           ret (DVALUE_Float (Float32.of_intu (repr (signed i1))))
+        | DTYPE_I 32, DVALUE_Poison, DTYPE_Float =>
+          ret DVALUE_Poison
 
         | DTYPE_I 64, DVALUE_I64 i1, DTYPE_Float =>
           ret (DVALUE_Float (Float32.of_intu (repr (signed i1))))
+        | DTYPE_I 64, DVALUE_Poison, DTYPE_Float =>
+          ret DVALUE_Poison
 
         | DTYPE_I 1, DVALUE_I1 i1, DTYPE_Double =>
           ret (DVALUE_Double (Float.of_longu (repr (signed i1))))
+        | DTYPE_I 1, DVALUE_Poison, DTYPE_Double =>
+          ret DVALUE_Poison
 
         | DTYPE_I 8, DVALUE_I8 i1, DTYPE_Double =>
           ret (DVALUE_Double (Float.of_longu (repr (signed i1))))
+        | DTYPE_I 8, DVALUE_Poison, DTYPE_Double =>
+          ret DVALUE_Poison
 
         | DTYPE_I 32, DVALUE_I32 i1, DTYPE_Double =>
           ret (DVALUE_Double (Float.of_longu (repr (signed i1))))
+        | DTYPE_I 32, DVALUE_Poison, DTYPE_Double =>
+          ret DVALUE_Poison
               
         | DTYPE_I 64, DVALUE_I64 i1, DTYPE_Double =>
           ret (DVALUE_Double (Float.of_longu (repr (signed i1))))
+        | DTYPE_I 64, DVALUE_Poison, DTYPE_Double =>
+          ret DVALUE_Poison
 
         | _, _, _ => raise "ill typed Sitofp"
         end 

--- a/src/coq/DynamicValues.v
+++ b/src/coq/DynamicValues.v
@@ -24,6 +24,7 @@ From Vellvm Require Import
      AstLib
      MemoryAddress
      Error
+     UndefinedBehaviour
      Util.
 
 Require Import Integers Floats.

--- a/src/coq/Error.v
+++ b/src/coq/Error.v
@@ -29,5 +29,3 @@ Arguments trywith _ _ _ _ _: simpl nomatch.
 Definition failwith {A:Type} {F} `{Monad F} `{MonadExc string F} (s:string) : F A := raise s.
 Hint Unfold failwith.
 Arguments failwith _ _ _ _: simpl nomatch.
-
-

--- a/src/coq/Intrinsics.v
+++ b/src/coq/Intrinsics.v
@@ -22,6 +22,7 @@ From Vellvm Require Import
      LLVMAst
      LLVMEvents
      Error
+     UndefinedBehaviour
      IntrinsicsDefinitions.
 
 From ITree Require Import
@@ -127,7 +128,7 @@ Module Make(A:MemoryAddress.ADDRESS)(LLVMIO: LLVM_INTERACTIONS(A)).
   Definition extcall_trigger : Handler CallE _CFG :=
   fun X e => trigger e.
 
-  Definition rest_trigger : Handler (LLVMGEnvE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' DebugE +' FailureE) _CFG :=
+  Definition rest_trigger : Handler (LLVMGEnvE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' DebugE +' FailureE +' UndefinedBehaviourE) _CFG :=
     fun X e => trigger e.
 
   Definition interpret_intrinsics: forall R, LLVM _CFG R -> LLVM _CFG R  :=

--- a/src/coq/LLVMEvents.v
+++ b/src/coq/LLVMEvents.v
@@ -33,7 +33,8 @@ From Vellvm Require Import
      MemoryAddress
      DynamicTypes
      DynamicValues
-     Error.
+     Error
+     UndefinedBehaviour.
 
 
 Set Implicit Arguments.
@@ -127,9 +128,9 @@ YZ NOTE: It makes sense for [MemoryIntrinsicE] to actually live in [MemoryE]. Ho
   Definition LLVMEnvE := (LocalE raw_id dvalue).
   Definition LLVMStackE := (StackE raw_id dvalue).
 
-  Definition conv_E := MemoryE +' DebugE +' FailureE.
+  Definition conv_E := MemoryE +' DebugE +' FailureE +' UndefinedBehaviourE.
   Definition lookup_E := LLVMGEnvE +' LLVMEnvE.
-  Definition exp_E := LLVMGEnvE +' LLVMEnvE +' MemoryE +' DebugE +' FailureE.
+  Definition exp_E := LLVMGEnvE +' LLVMEnvE +' MemoryE +' DebugE +' FailureE +' UndefinedBehaviourE.
 
   Definition lookup_E_to_exp_E : lookup_E ~> exp_E :=
     fun T e =>
@@ -150,7 +151,7 @@ YZ NOTE: It makes sense for [MemoryIntrinsicE] to actually live in [MemoryE]. Ho
     fun T e => inr1 e.
 
   (* Core effects - no distinction between "internal" and "external" calls. *)
-  Definition _CFG := CallE +' IntrinsicE +' LLVMGEnvE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' DebugE +' FailureE.
+  Definition _CFG := CallE +' IntrinsicE +' LLVMGEnvE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' DebugE +' FailureE +' UndefinedBehaviourE.
       
   Definition _funE_to_CFG : fun_E ~> _CFG :=
     fun R e =>
@@ -192,13 +193,13 @@ YZ NOTE: It makes sense for [MemoryIntrinsicE] to actually live in [MemoryE]. Ho
     fun T e => @_funE_to_CFG T (instr_E_to_fun_E (exp_E_to_instr_E e)).
   
   (* For multiple CFG, after interpreting [GlobalE] *)
-  Definition _MCFG1 := CallE +' IntrinsicE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' DebugE +' FailureE.
+  Definition _MCFG1 := CallE +' IntrinsicE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' DebugE +' FailureE +' UndefinedBehaviourE.
 
   (* For multiple CFG, after interpreting [LocalE] *)
-  Definition _MCFG2 := CallE +' IntrinsicE +' MemoryE +' DebugE +' FailureE.
+  Definition _MCFG2 := CallE +' IntrinsicE +' MemoryE +' DebugE +' FailureE +' UndefinedBehaviourE.
 
   (* For multiple CFG, after interpreting [LocalE] and [MemoryE] and [IntrinsicE] that are memory intrinsics *)
-  Definition _MCFG3 := CallE +' DebugE +' FailureE.
+  Definition _MCFG3 := CallE +' DebugE +' FailureE +' UndefinedBehaviourE.
   Hint Unfold LLVM _CFG _MCFG1 _MCFG2 _MCFG3.
 
   
@@ -213,7 +214,6 @@ YZ NOTE: It makes sense for [MemoryIntrinsicE] to actually live in [MemoryE]. Ho
 
   Definition debug {E} `{DebugE -< E} (msg : string) : itree E unit :=
     trigger (Debug msg).
-
 
 End LLVM_INTERACTIONS.
 

--- a/src/coq/Renaming.v
+++ b/src/coq/Renaming.v
@@ -22,6 +22,7 @@ From ITree Require Import
 
 From Vellvm Require Import 
      Error
+     UndefinedBehaviour
      Util
      LLVMAst
      AstLib
@@ -522,6 +523,7 @@ Module RENAMING
   Instance swap_of_IntrinsicE {X} : Swap (IntrinsicE X) := fun id1 id2 x => x.
   Instance swap_of_DebugE {X} : Swap (DebugE X) := fun id1 id2 x => x.
   Instance swap_of_FailureE {X} : Swap (FailureE X) := fun id1 id2 x => x.
+  Instance swap_of_UndefinedBehaviourE {X} : Swap (UndefinedBehaviourE X) := fun id1 id2 x => x.
   Hint Unfold swap_of_MemoryE swap_of_StackE swap_of_LocalE swap_of_GlobalE swap_of_CallE swap_of_IntrinsicE swap_of_DebugE FailureE.
 
   Instance swap_of_sum {A B} `{Swap A} `{Swap B}: Swap (A + B) :=

--- a/src/coq/Stack.v
+++ b/src/coq/Stack.v
@@ -95,4 +95,3 @@ Section StackMap.
     *)
 
 End StackMap.
-        

--- a/src/coq/TopLevel.v
+++ b/src/coq/TopLevel.v
@@ -106,6 +106,7 @@ Definition eval_typ (CFG:CFG.mcfg typ) (t:typ) : dtyp :=
 Definition normalize_types (CFG:(CFG.mcfg typ)) : (CFG.mcfg dtyp) :=
   TransformTypes.fmap_mcfg _ _ (eval_typ CFG) CFG.
 
+
 Definition run_with_memory (prog: list (toplevel_entity typ (list (block typ)))) :
   option (LLVM _MCFG3 (M.memory * ((local_env * stack) * (global_env * dvalue)))) :=
     let scfg := Vellvm.AstLib.modul_of_toplevel_entities _ prog in

--- a/src/coq/UndefinedBehaviour.v
+++ b/src/coq/UndefinedBehaviour.v
@@ -1,0 +1,55 @@
+From Coq Require Import String.
+
+From ITree Require Import
+     ITree
+     Events.Exception.
+
+From Vellvm Require Import
+     Error.
+
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.EitherMonad.
+
+
+(* Undefined behaviour carries a string. *)
+Variant UndefinedBehaviourE : Type -> Type :=
+| ThrowUB : string -> UndefinedBehaviourE void.
+
+
+(** Since the output type of [ThrowUB] is [void], we can make it an action
+    with any return type. *)
+Definition throwUB {E : Type -> Type} `{UndefinedBehaviourE -< E} {X}
+           (e : string)
+  : itree E X
+  := vis (ThrowUB e) (fun v : void => match v with end).
+
+Definition raiseUB {E} {A} `{UndefinedBehaviourE -< E} (msg : string) : itree E A :=
+  throwUB msg.
+
+Inductive UB_or_Err T :=
+| UB : string -> UB_or_Err T
+| Err : string -> UB_or_Err T
+| Norm : T -> UB_or_Err T
+.
+
+Arguments UB [T].
+Arguments Err [T].
+Arguments Norm [T].
+
+Instance Monad_ub_or_err : Monad UB_or_Err :=
+  { ret := fun _ v => Norm v
+  ; bind := fun _ _ c1 c2 => match c1 with
+                          | UB s => UB s
+                          | Err s => Err s
+                          | Norm v => c2 v
+                          end
+  }.
+
+Instance MonadExc_ub_or_err : MonadExc string UB_or_Err :=
+  { raise := fun _ e => Err e
+  ; catch := fun _ c h => match c with
+                       | UB s => UB s
+                       | Err s => h s
+                       | x => x
+                       end
+  }.

--- a/src/ml/libvellvm/interpreter.ml
+++ b/src/ml/libvellvm/interpreter.ml
@@ -74,7 +74,11 @@ let rec step (m : ('a TopLevel.IO._MCFG3, TopLevel.M.memory * ((TopLevel.local_e
          step (k (Obj.magic DV.DVALUE_None)))
 
   (* The failE effect is a failure *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 f), _) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 f)), _) ->
+    Error (Camlcoq.camlstring_of_coqstring f)
+
+  (* The UndefinedBehaviourE effect is a failure *)
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 f)), _) ->
     Error (Camlcoq.camlstring_of_coqstring f)
 
   (* The only visible effects from LLVMIO that should propagate to the interpreter are:


### PR DESCRIPTION
Hello!

First off, I think travis is failing because it's selecting ocaml 4.08.0, and Coq 8.8.2 (it needs <4.08)... So, if somebody else could confirm that this builds that would be great!

Otherwise this adds the UB event. There's a `poison.org` file that briefly documents some choices.

This also goes through and makes sure poison propagates through different operations, so this should cover #101 in addition to #100.

One thing that I'm unsure of... We don't have any static type checking, do we? If so, some things that previously raised an error which said "blah was ill typed" will now spread poison. E.g., in `eval_icmp`:

```
  Definition eval_icmp icmp v1 v2 : err dvalue :=
    match v1, v2 with
    | DVALUE_I1 i1, DVALUE_I1 i2 => ret (eval_int_icmp icmp i1 i2)
    | DVALUE_I8 i1, DVALUE_I8 i2 => ret (eval_int_icmp icmp i1 i2)
    | DVALUE_I32 i1, DVALUE_I32 i2 => ret (eval_int_icmp icmp i1 i2)
    | DVALUE_I64 i1, DVALUE_I64 i2 => ret (eval_int_icmp icmp i1 i2)
    | DVALUE_Poison, DVALUE_Poison => ret DVALUE_Poison
    | DVALUE_Poison, _ => if is_DVALUE_IX v2 then ret DVALUE_Poison else failwith "ill_typed-iop"
    | _, DVALUE_Poison => if is_DVALUE_IX v1 then ret DVALUE_Poison else failwith "ill_typed-iop"
    | _, _ => failwith "ill_typed-icmp"
    end.
```

Perhaps a small next step is to write a type checker? Or does one already exist and I just don't see it?