### PR TITLE
Removing Extlib's Show in favor for Ceres's Serialize

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/InteractionTrees"]
 	path = lib/InteractionTrees
 	url = https://github.com/DeepSpec/InteractionTrees.git
+[submodule "lib/coq-ceres"]
+	path = lib/coq-ceres
+	url = https://github.com/Lysxia/coq-ceres.git

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,11 @@ itrees:
 	git submodule update --init
 	make -C $(ITREEDIR)
 
-.PHONY: extracted itrees
+ceres:
+	git submodule update --init
+	make -C $(CERESDIR)
+
+.PHONY: extracted itrees ceres
 extracted: $(EXTRACTDIR)/STAMP $(VOFILES)
 
 $(EXTRACTDIR)/STAMP: $(VOFILES) $(EXTRACTDIR)/Extract.v
@@ -51,7 +55,7 @@ $(EXTRACTDIR)/STAMP: $(VOFILES) $(EXTRACTDIR)/Extract.v
 	@echo "COQC $*.v"
 	@$(COQC) -dump-glob doc/$(*F).glob $*.v
 
-depend: itrees $(VFILES) 
+depend: itrees ceres $(VFILES) 
 	@echo "Analyzing Coq dependencies"
 	@$(COQDEP) $^ > .depend
 
@@ -83,6 +87,7 @@ clean:
 	rm -f vellvm
 	rm -f doc/coq2html.ml doc/coq2html doc/*.cm? doc/*.o
 	make -C $(ITREEDIR) clean
+	make -C $(CERESDIR) clean
 
 doc/coq2html: 
 	make -C ../lib/coq2html

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,8 +7,9 @@ MLDIR = ml
 EXTRACTDIR = ml/extracted
 
 ITREEDIR=../lib/InteractionTrees
+CERESDIR=../lib/coq-ceres
 
-COQINCLUDES=$(foreach d, $(COQDIR), -R $(d) Vellvm) -R $(EXTRACTDIR) Extract -R $(ITREEDIR)/theories/ ITree
+COQINCLUDES=$(foreach d, $(COQDIR), -R $(d) Vellvm) -R $(EXTRACTDIR) Extract -R $(ITREEDIR)/theories/ ITree -R $(CERESDIR)/theories/ Ceres
 COQC="$(COQBIN)coqc" -q $(COQINCLUDES) $(COQCOPTS)
 COQDEP="$(COQBIN)coqdep" $(COQINCLUDES)
 COQEXEC="$(COQBIN)coqtop" -q -w none $(COQINCLUDES) -batch -load-vernac-source

--- a/src/_CoqProject
+++ b/src/_CoqProject
@@ -1,3 +1,4 @@
 -Q coq Vellvm
 -R coq Vellvm
 -R ../lib/InteractionTrees/theories ITree
+-R ../lib/coq-ceres/theories Ceres

--- a/src/coq/Denotation.v
+++ b/src/coq/Denotation.v
@@ -388,7 +388,7 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
            (top:option dtyp) (o:exp dtyp) {struct o} : itree exp_E uvalue :=
         let eval_texp '(dt,ex) := denote_exp (Some dt) ex
         in
-        debug ("Evaluating expression " ++ to_string o);;
+        debug ("Evaluating expression: " ++ to_string o);;
         match o with
         | EXP_Ident i =>
           translate lookup_E_to_exp_E (lookup_id i)

--- a/src/coq/Denotation.v
+++ b/src/coq/Denotation.v
@@ -16,7 +16,6 @@ From Coq Require Import
 Require Import Integers Floats.
 
 From ExtLib Require Import
-     Programming.Show
      Structures.Monads
      Structures.Functor
      Eqv.
@@ -38,6 +37,8 @@ From Vellvm Require Import
      TypeUtil
      Handlers.Intrinsics.
 
+Require Import Ceres.Ceres.
+
 (* YZ: Undesirable dependency on Handlers/Intrinsics: move [intrinsic_exp] somewhere else? *)
 
 Import Sum.
@@ -45,7 +46,6 @@ Import Subevent.
 Import EqvNotation.
 Import ListNotations.
 Import MonadNotation.
-Import ShowNotation.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
@@ -388,7 +388,7 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
            (top:option dtyp) (o:exp dtyp) {struct o} : itree exp_E uvalue :=
         let eval_texp '(dt,ex) := denote_exp (Some dt) ex
         in
-        (* debug ("Evaluating expression " ++ to_string o);; *)
+        debug ("Evaluating expression " ++ to_string o);;
         match o with
         | EXP_Ident i =>
           translate lookup_E_to_exp_E (lookup_id i)
@@ -909,196 +909,3 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
                 ) _ (Call dt f_value args).
 End Denotation.
 
-  (****************************** SCRAPYARD ******************************)
-
-  (* Code related to environment unused for global env that are static.
-     Should be reused to handle locals.
-   *)
-(*
-Definition env  := ENV.t dvalue.
-
-Definition env_of_assoc {A} (l:list (raw_id * A)) : ENV.t A :=
-  List.fold_left (fun e '(k,v) => ENV.add k v e) l (@ENV.empty A).
-
-
-  Fixpoint string_of_env' (e:list (raw_id * dvalue)) :=
-    match e with
-    | [] => empty
-    | (lid, _)::rest => ((to_string lid) << " " << (string_of_env' rest))%show
-    end.
-
-  Instance show_env : Show env := fun env => string_of_env' (ENV.elements env).
-  Definition add_env := ENV.add.
-*)
-  (* Code related to the previous structure of states.
-     Will likely not be reused as is. The structure of states should now be
-     defined by successive states monads introduced by sucessive handlers.
-   *)
-(*
-  Inductive frame : Type :=
-  | KRet      (e:env) (id:local_id) (q:pc)
-  | KRet_void (e:env) (p:pc)
-  .
-  Definition stack := list frame.
-
-  Definition state := (genv * pc * env * stack)%type.
-
-  Definition pc_of (s:state) :=
-    let '(g, p, e, k) := s in p.
-
-  Definition env_of (s:state) :=
-    let '(g, p, e, k) := s in e.
-
-  Definition stack_of (s:state) :=
-    let '(g, p, e, k) := s in k.
-*)
-
-  (* Code related to manipulating the stack frame during a return *)
-  (* Should be mostly irrelevant, but needs to be pondered. *)
-  (* The local env aspect should be handled by interpreting Locals into
-   a stack of environment. The ret terminator introduces a special pop
-   event when denoted.
-   The id part, hosting the returned value, should be handled by being given
-   to the denotation of the Call instruction: it is a call event, expected a
-   dvalue, followed by the appropriate store event.
-   The program counter part should be irrelevant in this style of semantics.
-   *)
-
-    (* match k with *)
-    (* | [] => halt dv        *)
-    (* | (KRet e' id p') :: k' => cont (g, p', add_env id dv e', k') *)
-    (* | _ => raise_p pc "IMPOSSIBLE: Ret op in non-return configuration"  *)
-    (* end *)
-
-  (* match k with *)
-    (* | [] => halt DVALUE_None *)
-    (* | (KRet_void e' p')::k' => cont (g, p', e', k') *)
-    (* | _ => raise_p pc "IMPOSSIBLE: Ret void in non-return configuration" *)
-    (* end *)
-
-
-(* Defining the Global Environment ------------------------------------------------------- *)
-(*
-
-*)
-(* Assumes that the entry-point function is named "fname" and that it takes
-   no parameters *)
-
-(* COMMENTING OUT
-Definition init_state (fname:string) : itree (failureE +' debugE) state :=
-  g <- build_global_environment ;;
-  fentry <- trywith ("INIT: no function named " ++ fname) (find_function_entry CFG (Name fname)) ;;
-  let 'FunctionEntry ids pc_f := fentry in
-    ret (g, pc_f, (@ENV.empty dvalue), []).
-
-CoFixpoint step_sem (r:result) : itree (failureE +' debugE) dvalue :=
-  match r with
-  | Done v => ret v
-  | Step s => x <- step s ;; ITreeDefinition.Tau (step_sem x)
-  end.
-
-(* TODO: move elsewhere? *)
-Fixpoint combine_lists_err {A B:Type} (l1:list A) (l2:list B) : err (list (A * B)) :=
-  match l1, l2 with
-  | [], [] => ret []
-  | x::xs, y::ys =>
-    l <- combine_lists_err xs ys ;;
-    ret ((x,y)::l)
-  | _, _ => failwith "combine_lists_err: different lenth lists"
-  end.
-
-END OF COMMENTING OUT *)
-(*
-YZ : Should not be used anymore?
-Inductive result :=
-| Done (v:dvalue)
-| Step (s:state)
-.
-
-Definition raise_p {X} (p:pc) s : itree (failureE +' debugE) X := raise (s ++ " in block: " ++ (to_string p)).
-Definition cont (s:state)  : itree (failureE +' debugE) result := ret (Step s).
-Definition halt (v:dvalue) : itree (failureE +' debugE) result := ret (Done v).
-
- *)
-(*
-Definition jump (fid:function_id) (bid_src:block_id) (bid_tgt:block_id) (g:genv) (e_init:env) (k:stack) : itree (failureE +' debugE) result :=
-  let eval_phi (e:env) '(iid, Phi t ls) :=
-      match assoc RawIDOrd.eq_dec bid_src ls with
-      | Some op =>
-        let dt := eval_typ t in
-        dv <- denote_exp g (Some dt) op ;;
-        ret (add_env iid dv e)
-      | None => raise ("jump: phi node doesn't include block " ++ to_string bid_src )
-      end
-  in
-  debug ("jumping to: " ++ to_string bid_tgt) ;;
-  match find_block_entry CFG fid bid_tgt with
-  | None => raise ("jump: target block " ++ to_string bid_tgt ++ " not found")
-  | Some (BlockEntry phis pc_entry) =>
-      e_out <- monad_fold_right eval_phi phis e_init ;;
-      cont (g, pc_entry, e_out, k)
-  end.
- *)
-
-    (* YZ: where will this pc_next be relevant now? Likely when looping I think. *)
-    (* do pc_next <- trywith "no fallthrough instruction" (incr_pc CFG pc) ;; *)
-    (* match (pt pc), insn  with *)
-
-(* YZ : How should we do handle phi nodes?
-       Seems like option 4 is the way to go.
-       OPTION 1:
-       [| block|]: (block_id * block_id) -> itreeE (block_id * block_id)
-       i.e. We treat elementary blocks as having several entry point, one per
-       adress from which we jumped into it.
-       OPTION 2:
-       We actually perform the semantics of phi nodes at the end of the denotation
-       of the jumping block.
-       i.e. : if b1 := jmp b2 and b2 := x = phi (b1,1; b3,3)
-       then [b1] = send (LocalWrite x 1);; ret b2
-       and of course we do not denote phi nodes first when denoting blocks.
-       Issue (?) Doesn't it break modularity? Can we still loop to tie those things
-       together?
-       OPTION 3:
-       Could the semantics of the phi node use a special event asking the environment
-       where it comes from, and the semantics of the ret using a special event telling
-       the world it's jumping?
-       That kinda implies that now we have two level of handling the control flow of a
-       single function, but avoids both ugly pairs and is completely modular.
-       OPTION 4:
-       Actually, it might be in the function provided to [loop] when denoting
-       a collection of blocks that this should take place so that there is no
-       need for a new effect, it's just that the jmp one does more work.
-     *)
-(*
-      match (find_function_entry CFG fid) with
-      | Some fnentry =>
-        let 'FunctionEntry ids pc_f := fnentry in
-        bs <- combine_lists_err ids dvs ;;
-        let env := env_of_assoc bs in
-        match pt with
-        | IVoid _ =>
-          (debug "pushed void stack frame") ;;
-          cont (g, pc_f, env, (KRet_void e pc_next::k))
-        | IId id =>
-          (debug "pushed non-void stack frame") ;;
-          cont (g, pc_f, env, (KRet e id pc_next::k))
-        end
-      | None =>
-        (* This must have been a registered external function  *)
-        (* We _don't_ push a itree stack frame, since the external *)
-        (* call takes place in one "atomic" step. *)
-
-        match fid with
-        | Name s =>
-          match pt with
-          | IVoid _ =>  (* void externals don't return a value *)
-            vis (Call (eval_typ t) s dvs) (fun dv => cont (g, pc_next, e, k))
-
-                   | IId id => (* non-void externals are assumed to be type correct and bind a value *)
-                     vis (Call (eval_typ t) s dvs)
-                         (fun dv => cont (g, pc_next, add_env id dv e, k))
-                   end
-                 | _ => raise ("step: no function " (* ++ (string_of fid) *))
-                 end
-      end
-       *)

--- a/src/coq/DynamicTypes.v
+++ b/src/coq/DynamicTypes.v
@@ -53,9 +53,9 @@ Inductive dtyp : Set :=
 Section hiding_notation.
   Local Open Scope sexp_scope.
 
-  Fixpoint serialize_dtyp' (dt:dtyp) :=
+  Fixpoint serialize_dtyp' (dt:dtyp): sexp atom :=
     match dt with
-    | DTYPE_I sz     => [Raw "i" ; to_sexp sz]
+    | DTYPE_I sz     => Raw ("i" ++ to_string sz)
     | DTYPE_Pointer  => Raw "ptr"
     | DTYPE_Void     => Raw "dvoid"
     | DTYPE_Half     => Raw "half"
@@ -67,14 +67,14 @@ Section hiding_notation.
     | DTYPE_Metadata  => Raw "metadata"
     | DTYPE_X86_mmx   => Raw "x86_mmx"
     | DTYPE_Array sz t
-      => [Raw "[" ; to_sexp sz ; Raw " x " ; serialize_dtyp' t ; Raw "]"]
+      => [Raw "[" ; to_sexp sz ; Raw "x" ; serialize_dtyp' t ; Raw "]"]
     | DTYPE_Struct fields
       => [Raw "{" ; to_sexp (List.map (fun x => [serialize_dtyp' x ; Raw ","]) fields) ; Raw "}"]
     | DTYPE_Packed_struct fields
       => [Raw "packed{" ; to_sexp (List.map (fun x => [serialize_dtyp' x ; Raw ","]) fields) ; Raw "}"]
     | DTYPE_Opaque => Raw "opaque"
     | DTYPE_Vector sz t
-      => [Raw "<" ; to_sexp sz ; Raw " x " ; serialize_dtyp' t ; Raw ">"]  (* TODO: right notation? *)
+      => [Raw "<" ; to_sexp sz ; Raw "x" ; serialize_dtyp' t ; Raw ">"]  (* TODO: right notation? *)
     end.
 
   Global Instance serialize_dtyp : Serialize dtyp := serialize_dtyp'.

--- a/src/coq/DynamicTypes.v
+++ b/src/coq/DynamicTypes.v
@@ -67,14 +67,14 @@ Section hiding_notation.
     | DTYPE_Metadata  => Raw "metadata"
     | DTYPE_X86_mmx   => Raw "x86_mmx"
     | DTYPE_Array sz t
-      => [Raw "[" ; to_sexp sz ; Raw "x" ; serialize_dtyp' t ; Raw "]"]
+      => [Raw ("[" ++ to_string sz) ; Raw "x" ; serialize_dtyp' t ; Raw "]"]
     | DTYPE_Struct fields
       => [Raw "{" ; to_sexp (List.map (fun x => [serialize_dtyp' x ; Raw ","]) fields) ; Raw "}"]
     | DTYPE_Packed_struct fields
       => [Raw "packed{" ; to_sexp (List.map (fun x => [serialize_dtyp' x ; Raw ","]) fields) ; Raw "}"]
     | DTYPE_Opaque => Raw "opaque"
     | DTYPE_Vector sz t
-      => [Raw "<" ; to_sexp sz ; Raw "x" ; serialize_dtyp' t ; Raw ">"]  (* TODO: right notation? *)
+      => [Raw ("<" ++ to_string sz) ; Raw "x" ; serialize_dtyp' t ; Raw ">"]  (* TODO: right notation? *)
     end.
 
   Global Instance serialize_dtyp : Serialize dtyp := serialize_dtyp'.

--- a/src/coq/DynamicValues.v
+++ b/src/coq/DynamicValues.v
@@ -295,30 +295,30 @@ Section hiding_notation.
 
   Global Instance serialize_dvalue : Serialize dvalue := serialize_dvalue'.
 
-  Fixpoint serialize_uvalue' (uv:uvalue) : sexp atom :=
+  Fixpoint serialize_uvalue' (pre post: string) (uv:uvalue): sexp atom :=
     match uv with
-    | UVALUE_Addr a => S.Raw "address" (* TODO: insist that memory models can print addresses? *)
-    | UVALUE_I1 x => S.Raw "uvalue(i1)"
-    | UVALUE_I8 x => S.Raw "uvalue(i8)"
-    | UVALUE_I32 x => S.Raw "uvalue(i32)"
-    | UVALUE_I64 x => S.Raw "uvalue(i64)"
-    | UVALUE_Double x => S.Raw "uvalue(double)"
-    | UVALUE_Float x => S.Raw "uvalue(float)"
-    | UVALUE_Poison => S.Raw "poison"
-    | UVALUE_None => S.Raw "none"
+    | UVALUE_Addr a => S.Raw (pre ++ "address" ++ post) (* TODO: insist that memory models can print addresses? *)
+    | UVALUE_I1 x => S.Raw (pre ++ "uvalue(i1)" ++ post)
+    | UVALUE_I8 x => S.Raw (pre ++ "uvalue(i8)" ++ post)
+    | UVALUE_I32 x => S.Raw (pre ++ "uvalue(i32)" ++ post)
+    | UVALUE_I64 x => S.Raw (pre ++ "uvalue(i64)" ++ post)
+    | UVALUE_Double x => S.Raw (pre ++ "uvalue(double)" ++ post)
+    | UVALUE_Float x => S.Raw (pre ++ "uvalue(float)" ++ post)
+    | UVALUE_Poison => S.Raw (pre ++ "poison" ++ post)
+    | UVALUE_None => S.Raw (pre ++ "none" ++ post)
     | UVALUE_Struct fields
-      => [S.Raw "{" ; to_sexp (List.map (fun x => [serialize_uvalue' x ; S.Raw ","]) fields) ; S.Raw "}"]
+      => [S.Raw "{" ; to_sexp (List.map (serialize_uvalue' "" ",") fields) ; S.Raw "}"]
     | UVALUE_Packed_struct fields
-      => [S.Raw "packed{" ; to_sexp (List.map (fun x => [serialize_uvalue' x ; S.Raw ","]) fields) ; S.Raw "}"]
+      => [S.Raw "packed{" ; to_sexp (List.map (serialize_uvalue' "" ",") fields) ; S.Raw "}"]
     | UVALUE_Array elts
-      => [S.Raw "[" ; to_sexp (List.map (fun x => [serialize_uvalue' x ; S.Raw ","]) elts) ; S.Raw "]"]
+      => [S.Raw "[" ; to_sexp (List.map (serialize_uvalue' "" ",") elts) ; S.Raw "]"]
     | UVALUE_Vector elts
-      => [S.Raw "<" ; to_sexp (List.map (fun x => [serialize_uvalue' x ; S.Raw  ","]) elts) ; S.Raw ">"]
+      => [S.Raw "<" ; to_sexp (List.map (serialize_uvalue' "" ",") elts) ; S.Raw ">"]
     | UVALUE_Undef t => [S.Raw "undef(" ; to_sexp t ; S.Raw ")"]
-    | UVALUE_IBinop iop v1 v2 => [S.Raw "(" ; serialize_uvalue' v1 ; S.Raw " " ; to_sexp iop ; S.Raw " " ; serialize_uvalue' v2 ; S.Raw ")"]
-    | UVALUE_ICmp cmp v1 v2 => [S.Raw "(" ; serialize_uvalue' v1 ; S.Raw " " ; to_sexp cmp ; S.Raw " " ; serialize_uvalue' v2 ; S.Raw ")"]
-    | UVALUE_FBinop fop _ v1 v2 => [S.Raw "(" ; serialize_uvalue' v1 ; S.Raw " " ; to_sexp fop ; S.Raw " " ; serialize_uvalue' v2 ; S.Raw ")"]
-    | UVALUE_FCmp cmp v1 v2 => [S.Raw "(" ; serialize_uvalue' v1 ; S.Raw " " ; to_sexp cmp ; S.Raw " " ; serialize_uvalue' v2 ; S.Raw ")"]
+    | UVALUE_IBinop iop v1 v2 => [serialize_uvalue' "(" "" v1; to_sexp iop ; serialize_uvalue' "" ")" v2]
+    | UVALUE_ICmp cmp v1 v2 => [serialize_uvalue' "(" "" v1; to_sexp cmp; serialize_uvalue' "" ")" v2]
+    | UVALUE_FBinop fop _ v1 v2 => [serialize_uvalue' "(" "" v1; to_sexp fop; serialize_uvalue' "" ")" v2]
+    | UVALUE_FCmp cmp v1 v2 => [serialize_uvalue' "(" "" v1; to_sexp cmp; serialize_uvalue' "" ")" v2]
     (* | UVALUE_Conversion       (conv:conversion_type) (v:uvalue) (t_to:dtyp) *)
     (* | UVALUE_GetElementPtr    (t:dtyp) (ptrval:uvalue) (idxs:list (uvalue)) (* TODO: do we ever need this? GEP raises an event? *) *)
     (* | UVALUE_ExtractElement   (vec: uvalue) (idx: uvalue) *)
@@ -330,7 +330,7 @@ Section hiding_notation.
     | _ => S.Raw "TODO: show_uvalue"
     end.
 
-  Global Instance serialize_uvalue : Serialize uvalue := serialize_uvalue'.
+  Global Instance serialize_uvalue : Serialize uvalue := serialize_uvalue' "" "".
 
 End hiding_notation.
 

--- a/src/coq/Error.v
+++ b/src/coq/Error.v
@@ -8,14 +8,13 @@
  *   3 of the License, or (at your option) any later version.                 *
  ---------------------------------------------------------------------------- *)
 
-Require Import String.
+From Coq Require Import String.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.EitherMonad.
 
 From ITree Require Import
      ITree
      Events.Exception.
-
 
 Definition err T := sum string T.
 

--- a/src/coq/Handlers/Global.v
+++ b/src/coq/Handlers/Global.v
@@ -2,11 +2,10 @@ From Coq Require Import
      String.
 
 From ExtLib Require Import
-     Programming.Show
      Structures.Monads
      Structures.Maps.
 
-From ITree Require Import 
+From ITree Require Import
      ITree
      Events.State.
 
@@ -17,6 +16,8 @@ From Vellvm Require Import
      DynamicValues
      LLVMEvents
      Error.
+
+Require Import Ceres.Ceres.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
@@ -29,7 +30,8 @@ Section Globals.
   Variable (k v:Type).
   Context {map : Type}.
   Context {M: Map k v map}.
-  Context {SK : Show k}.
+  Context {SK : Serialize k}.
+
   Definition handle_global {E} `{FailureE -< E} : (GlobalE k v) ~> stateT map (itree E) :=
     fun _ e env =>
       match e with
@@ -58,4 +60,3 @@ Section Globals.
   End PARAMS.
 
 End Globals.
-

--- a/src/coq/Handlers/Intrinsics.v
+++ b/src/coq/Handlers/Intrinsics.v
@@ -39,17 +39,17 @@ Set Contextual Implicit.
    LLVM _intrinsic_ functions are used like ordinary function calls, but
    they have a special interpretation.
 
-     - any global identifier that starts with the prefix "llvm." is 
-       considered to be an intrinsic function 
+     - any global identifier that starts with the prefix "llvm." is
+       considered to be an intrinsic function
 
      - intrinsic functions must be delared in the global scope (to ascribe them types)
 
-     - it is _illegal_ to take the address of an intrinsic function (they do not 
-       always map directly to external functions, e.g. arithmetic intrinsics may 
-       be lowered directly to in-lined assembly on platforms that support the 
+     - it is _illegal_ to take the address of an intrinsic function (they do not
+       always map directly to external functions, e.g. arithmetic intrinsics may
+       be lowered directly to in-lined assembly on platforms that support the
        operations natively.
 
-   As a consequence of the above, it is possible to _statically_ determine 
+   As a consequence of the above, it is possible to _statically_ determine
    that a call is an invocation of an intrinsic by looking for instructions
    of the form:
         call t @llvm._ (args...)
@@ -57,7 +57,7 @@ Set Contextual Implicit.
 
 (* This function extracts the string of the form [llvm._] from an LLVM expression.
    It returns None if the expression is not an intrinsic definition.
-*) 
+*)
 Definition intrinsic_ident (id:ident) : option string :=
   match id with
   | ID_Global (Name s) =>
@@ -88,13 +88,13 @@ Module Make(A:MemoryAddress.ADDRESS)(LLVMIO: LLVM_INTERACTIONS(A)).
 
 
   (* Interprets Call events found in the given association list by their
-     semantic functions.  
+     semantic functions.
 
-     SAZ: This definition is trickier than one wants it to be because of the 
-     dependent pattern matching.  The index of the IntrinsicE constructor need to 
+     SAZ: This definition is trickier than one wants it to be because of the
+     dependent pattern matching.  The index of the IntrinsicE constructor need to
      be used to coerce the result back to the general ITree type.
 
-     We solve it by using the "Convoy Pattern" (see Chlipala's CPDT).  
+     We solve it by using the "Convoy Pattern" (see Chlipala's CPDT).
 
      IntrinsicE ~> LLVM _MCFG1
    *)
@@ -112,7 +112,7 @@ Module Make(A:MemoryAddress.ADDRESS)(LLVMIO: LLVM_INTERACTIONS(A)).
       match e in IntrinsicE Y return X = Y -> itree L0 Y with
       | (Intrinsic _ fname args) =>
           match assoc Strings.String.string_dec fname defs_assoc with
-          | Some f => fun pf => 
+          | Some f => fun pf =>
                        match f args with
                        | inl msg => raise msg
                        | inr result => Ret result

--- a/src/coq/Handlers/Local.v
+++ b/src/coq/Handlers/Local.v
@@ -2,11 +2,10 @@ From Coq Require Import
      String.
 
 From ExtLib Require Import
-     Programming.Show
      Structures.Monads
      Structures.Maps.
 
-From ITree Require Import 
+From ITree Require Import
      ITree
      Events.State.
 
@@ -17,6 +16,8 @@ From Vellvm Require Import
      DynamicValues
      LLVMEvents
      Error.
+
+Require Import Ceres.Ceres.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
@@ -29,7 +30,7 @@ Section Locals.
   Variable (k v:Type).
   Context {map : Type}.
   Context {M: Map k v map}.
-  Context {SK : Show k}.
+  Context {SK : Serialize k}.
   Definition handle_local {E} `{FailureE -< E} : (LocalE k v) ~> stateT map (itree E) :=
       fun _ e env =>
         match e with
@@ -58,4 +59,3 @@ Section Locals.
     End PARAMS.
 
 End Locals.
-

--- a/src/coq/Handlers/Memory.v
+++ b/src/coq/Handlers/Memory.v
@@ -26,7 +26,6 @@ Import Basics.Basics.Monads.
 From ExtLib Require Import
      Structures.Monads
      Programming.Eqv
-     Programming.Show
      Data.String.
 
 From Vellvm Require Import
@@ -40,6 +39,8 @@ From Vellvm Require Import
      Coqlib
      Numeric.Integers
      Numeric.Floats.
+
+Require Import Ceres.Ceres.
 
 Import MonadNotation.
 Import EqvNotation.
@@ -68,6 +69,7 @@ End A.
 Module Make(LLVMEvents: LLVM_INTERACTIONS(A)).
   Import LLVMEvents.
   Import DV.
+  Open Scope list.
 
   Definition addr := A.addr.
 

--- a/src/coq/Handlers/Pick.v
+++ b/src/coq/Handlers/Pick.v
@@ -3,7 +3,6 @@ From Coq Require Import
      String.
 
 From ExtLib Require Import
-     Programming.Show
      Structures.Monads
      Structures.Maps.
 

--- a/src/coq/Handlers/Stack.v
+++ b/src/coq/Handlers/Stack.v
@@ -3,11 +3,10 @@ From Coq Require Import
      String.
 
 From ExtLib Require Import
-     Programming.Show
      Structures.Monads
      Structures.Maps.
 
-From ITree Require Import 
+From ITree Require Import
      ITree
      Events.State.
 
@@ -19,6 +18,8 @@ From Vellvm Require Import
      LLVMEvents
      Local
      Error.
+
+Require Import Ceres.Ceres.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
@@ -32,7 +33,7 @@ Section StackMap.
   Variable (k v:Type).
   Context {map : Type}.
   Context {M: Map k v map}.
-  Context {SK : Show k}.
+  Context {SK : Serialize k}.
 
   Definition stack := list map.
 

--- a/src/coq/IntrinsicsDefinitions.v
+++ b/src/coq/IntrinsicsDefinitions.v
@@ -16,14 +16,13 @@ From ExtLib Require Import
      Programming.Eqv
      Data.String.
 
-From Vellvm Require Import 
+From Vellvm Require Import
      LLVMEvents
      LLVMAst
      Error
      Coqlib
      Numeric.Integers
      Numeric.Floats.
-
 
 From ITree Require Import
      ITree.
@@ -93,21 +92,21 @@ Definition defined_intrinsics_decls :=
   [ fabs_32_decl; fabs_64_decl; memcpy_8_decl ].
 
 (* This functor module provides a way to (extensibly) add the semantic behavior
-   for intrinsics defined outside of the core Vellvm operational semantics.  
+   for intrinsics defined outside of the core Vellvm operational semantics.
 
-   Internally, invocation of an intrinsic looks no different than that of an 
-   external function call, so each LLVM intrinsic instruction should produce 
+   Internally, invocation of an intrinsic looks no different than that of an
+   external function call, so each LLVM intrinsic instruction should produce
    a Call effect.
 
-   Each intrinsic is identified by its name (a string) and its denotation is 
-   given by a function from a list of dynamic values to a dynamic value (or 
-   possibly an error).  
+   Each intrinsic is identified by its name (a string) and its denotation is
+   given by a function from a list of dynamic values to a dynamic value (or
+   possibly an error).
 
    NOTE: The intrinsics that can be defined at this layer of the semantics
    cannot affect the core interpreter state or the memory model.  This layer is
    useful for implementing "pure value" intrinsics like floating point
    operations, etc.  Also note that such intrinsics cannot themselves generate
-   any other effects.  
+   any other effects.
 
 *)
 Module Make(A:MemoryAddress.ADDRESS)(LLVMIO: LLVM_INTERACTIONS(A)).
@@ -116,13 +115,13 @@ Module Make(A:MemoryAddress.ADDRESS)(LLVMIO: LLVM_INTERACTIONS(A)).
   Import LLVMIO.
   Import DV.
 
-  (* Each (pure) intrinsic is defined by a function of the following type. 
+  (* Each (pure) intrinsic is defined by a function of the following type.
 
-   - each intrinsic should "morally" be a total function: assuming the LLVM program 
-     is well formed, the intrisnic should always produce an LLVM value (which itself 
+   - each intrinsic should "morally" be a total function: assuming the LLVM program
+     is well formed, the intrisnic should always produce an LLVM value (which itself
      might be poison or undef)
 
-   - error should be returned only in the case that the LLVM program is ill-formed 
+   - error should be returned only in the case that the LLVM program is ill-formed
      (e.g. if the wrong number and/or type of arguments is given to the intrinsic)
 
    *)

--- a/src/coq/LLVMAst.v
+++ b/src/coq/LLVMAst.v
@@ -23,7 +23,7 @@
 (*  ------------------------------------------------------------------------- *)
 
 Require Import Floats.
-Require Import List String Ascii ZArith.
+From Coq Require Import List String Ascii ZArith.
 Require Import Vellvm.Util.
 
 Import ListNotations.
@@ -47,25 +47,25 @@ Inductive linkage : Set :=
 | LINKAGE_Weak_odr
 | LINKAGE_External
 .
-      
+
 Inductive dll_storage : Set :=
 | DLLSTORAGE_Dllimport
 | DLLSTORAGE_Dllexport
-.      
+.
 
 Inductive visibility : Set :=
 | VISIBILITY_Default
 | VISIBILITY_Hidden
 | VISIBILITY_Protected
 .
-    
+
 Inductive cconv : Set :=
 | CC_Ccc
 | CC_Fastcc
 | CC_Coldcc
 | CC_Cc (cc:int)
 .
-        
+
 Inductive param_attr : Set :=
 | PARAMATTR_Zeroext
 | PARAMATTR_Signext
@@ -82,7 +82,7 @@ Inductive param_attr : Set :=
 | PARAMATTR_Nonnull
 | PARAMATTR_Dereferenceable (a:int)
 .
-                            
+
 Inductive fn_attr : Set :=
 | FNATTR_Alignstack (a:int)
 | FNATTR_Alwaysinline
@@ -126,7 +126,7 @@ Inductive thread_local_storage : Set :=
 
 
 Inductive raw_id : Set :=
-| Name (s:string)     (* Named identifiers are strings: %argc, %val, %x, @foo, @bar etc. *)  
+| Name (s:string)     (* Named identifiers are strings: %argc, %val, %x, @foo, @bar etc. *)
 | Anon (n:int)        (* Anonymous identifiers must be sequentially numbered %0, %1, %2, etc. *)
 | Raw  (n:int)        (* Used for code generation -- serializes as %_RAW_0 %_RAW_1 etc. *)
 .
@@ -154,7 +154,7 @@ Inductive typ : Set :=
 | TYPE_Fp128
 | TYPE_Ppc_fp128
 (* | TYPE_Label  label is not really a type *)
-(* | TYPE_Token -- used with exceptions *)    
+(* | TYPE_Token -- used with exceptions *)
 | TYPE_Metadata
 | TYPE_X86_mmx
 | TYPE_Array (sz:int) (t:typ)
@@ -199,18 +199,18 @@ Section TypedSyntax.
 Definition tident : Set := (T * ident)%type.
 
 
-(* NOTES: 
+(* NOTES:
   This datatype is more permissive than legal in LLVM:
      - it allows identifiers to appear nested inside of "constant expressions"
-       that is OK as long as we validate the syntax as "well-formed" before 
+       that is OK as long as we validate the syntax as "well-formed" before
        trying to give it semantics
 
   NOTES:
-   - Integer expressions: llc parses large integer exps and converts them to some 
+   - Integer expressions: llc parses large integer exps and converts them to some
      internal form (based on integer size?)
-   
-   - Float constants: these are always parsed as 64-bit representable floats 
-     using ocamls float_of_string function. The parser converts float literals 
+
+   - Float constants: these are always parsed as 64-bit representable floats
+     using ocamls float_of_string function. The parser converts float literals
      to 32-bit values using the type information available in the syntax.
 
      -- TODO: 128-bit, 16-bit, other float formats?
@@ -223,7 +223,7 @@ Definition tident : Set := (T * ident)%type.
    - OP_  prefix denotes syntax that requires further evaluation
  *)
 Inductive exp : Set :=
-| EXP_Ident   (id:ident)  
+| EXP_Ident   (id:ident)
 | EXP_Integer (x:int)
 | EXP_Float   (f:float32)  (* 32-bit floating point values *)
 | EXP_Double  (f:float)    (* 64-bit floating point values *)
@@ -237,7 +237,7 @@ Inductive exp : Set :=
 | EXP_Packed_struct   (fields: list (T * exp))
 | EXP_Array           (elts: list (T * exp))
 | EXP_Vector          (elts: list (T * exp))
-| OP_IBinop           (iop:ibinop) (t:T) (v1:exp) (v2:exp)  
+| OP_IBinop           (iop:ibinop) (t:T) (v1:exp) (v2:exp)
 | OP_ICmp             (cmp:icmp)   (t:T) (v1:exp) (v2:exp)
 | OP_FBinop           (fop:fbinop) (fm:list fast_math) (t:T) (v1:exp) (v2:exp)
 | OP_FCmp             (cmp:fcmp)   (t:T) (v1:exp) (v2:exp)
@@ -262,13 +262,13 @@ Inductive instr_id : Set :=
 Inductive phi : Set :=
 | Phi  (t:T) (args:list (block_id * exp))
 .
-       
+
 Inductive instr : Set :=
 | INSTR_Comment (msg:string)
 | INSTR_Op   (op:exp)                        (* INVARIANT: op must be of the form SV (OP_ ...) *)
 | INSTR_Call (fn:texp) (args:list texp)      (* CORNER CASE: return type is void treated specially *)
-| INSTR_Alloca (t:T) (nb: option texp) (align:option int) 
-| INSTR_Load  (volatile:bool) (t:T) (ptr:texp) (align:option int)       
+| INSTR_Alloca (t:T) (nb: option texp) (align:option int)
+| INSTR_Load  (volatile:bool) (t:T) (ptr:texp) (align:option int)
 | INSTR_Store (volatile:bool) (val:texp) (ptr:texp) (align:option int)
 | INSTR_Fence
 | INSTR_AtomicCmpXchg
@@ -283,7 +283,7 @@ Inductive terminator : Set :=
 (* Types in branches are TYPE_Label constant *)
 | TERM_Ret        (v:texp)
 | TERM_Ret_void
-| TERM_Br         (v:texp) (br1:block_id) (br2:block_id) 
+| TERM_Br         (v:texp) (br1:block_id) (br2:block_id)
 | TERM_Br_1       (br:block_id)
 | TERM_Switch     (v:texp) (default_dest:block_id) (brs: list (texp * block_id))
 | TERM_IndirectBr (v:texp) (brs:list block_id) (* address * possible addresses (labels) *)
@@ -312,7 +312,7 @@ Record global : Set :=
 Record declaration : Set :=
   mk_declaration
   {
-    dc_name        : function_id;  
+    dc_name        : function_id;
     dc_type        : T;    (* INVARIANT: should be TYPE_Function (ret_t * args_t) *)
     dc_param_attrs : list param_attr * list (list param_attr); (* ret_attrs * args_attrs *)
     dc_linkage     : option linkage;
@@ -404,4 +404,3 @@ Arguments m_globals {_} _.
 Arguments m_declarations {_} _.
 Arguments m_definitions {_} _.
 End TypedSyntax.
-

--- a/src/coq/LLVMEvents.v
+++ b/src/coq/LLVMEvents.v
@@ -20,7 +20,6 @@ From Coq Require Import
 From ExtLib Require Import
      Core.RelDec
      Programming.Eqv
-     Programming.Show
      Structures.Monads.
 
 From ITree Require Import

--- a/src/coq/TopLevel.v
+++ b/src/coq/TopLevel.v
@@ -177,13 +177,12 @@ Definition build_L0 (mcfg : CFG.mcfg dtyp) : itree L0 res_L0 :=
   D.denote_mcfg defns DTYPE_Void addr main_args.
 
 (* Interpretation of the global environment *)
-(* TODO YZ: Why do we need to provide this instance explicitly? *)
 Definition build_L1 (trace : itree L0 res_L0) : itree L1 res_L1 :=
-             @interp_global _ _ _ _ show_raw_id _ _ _ _ _ trace [].
+             interp_global trace [].
 
 (* Interpretation of the local environment: map and stack *)
 Definition build_L2 (trace : itree L1 res_L1) : itree L2 res_L2 :=
-  interp_local_stack (@handle_local raw_id uvalue _ _ show_raw_id _ _) trace ([], []).
+  interp_local_stack (@handle_local _ _ _ _ _ _ _) trace ([], []).
 
 (* Interpretation of the memory *)
 Definition build_L3 (trace : itree L2 res_L2) : itree L3 res_L3 :=

--- a/src/ml/extracted/Extract.v
+++ b/src/ml/extracted/Extract.v
@@ -7,7 +7,7 @@ Require ExtrOcamlString.
 Require ExtrOcamlIntConv.
 
 Extraction Language Ocaml.
-Extraction Blacklist String List Char Core Z.
+Extraction Blacklist String List Char Core Z Format.
 
 
 (* strings ------------------------------------------------------------------ *)

--- a/src/ml/libvellvm/llvm_printer.ml
+++ b/src/ml/libvellvm/llvm_printer.ml
@@ -6,7 +6,7 @@ open Format
 
 let of_str = Camlcoq.camlstring_of_coqstring
 let to_int = Camlcoq.Z.to_int
-let float_of_coqfloat = Camlcoq.camlfloat_of_coqfloat               
+let float_of_coqfloat = Camlcoq.camlfloat_of_coqfloat
 
 (* TODO: Use pp_option everywhere instead of inlined matching *)
 let pp_option ppf f o =
@@ -368,21 +368,21 @@ and exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
 and inst_exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
   fun ppf vv ->
     match vv with
-  | EXP_Ident _ 
-  | EXP_Integer _ 
+  | EXP_Ident _
+  | EXP_Integer _
   | EXP_Float _
-  | EXP_Double _      
-  | EXP_Hex _         
-  | EXP_Bool _    
-  | EXP_Null      
-  | EXP_Undef     
+  | EXP_Double _
+  | EXP_Hex _
+  | EXP_Bool _
+  | EXP_Null
+  | EXP_Undef
   | EXP_Array _
-  | EXP_Vector _  
+  | EXP_Vector _
   | EXP_Struct _
   | EXP_Packed_struct _
-  | EXP_Zero_initializer 
+  | EXP_Zero_initializer
   | EXP_Cstring _ -> assert false   (* there should be no "raw" exps as instructions *)
-  
+
   | OP_IBinop (op, t, v1, v2) ->
      fprintf ppf "%a %a %a, %a"
              ibinop op
@@ -524,7 +524,7 @@ and instr : Format.formatter -> (LLVMAst.typ LLVMAst.instr) -> unit =
 and branch_label : Format.formatter -> LLVMAst.raw_id -> unit =
   fun ppf id ->
     pp_print_string ppf "label %"; pp_print_string ppf (str_of_raw_id id)
-    
+
 
 and terminator : Format.formatter -> (LLVMAst.typ LLVMAst.terminator) -> unit =
   fun ppf ->
@@ -578,7 +578,7 @@ and instr_id : Format.formatter -> LLVMAst.instr_id -> unit =
     function
     | IId id  -> fprintf ppf "%%%s = " (str_of_raw_id id)
     | IVoid n -> fprintf ppf "; void instr %d" (to_int n); pp_force_newline ppf ()
-  
+
 and texp ppf (t, v) = fprintf ppf "%a %a" typ t exp v
 
 and tident ppf (t, v) = fprintf ppf "%a %a" typ t ident v
@@ -642,7 +642,7 @@ and global : Format.formatter -> (LLVMAst.typ LLVMAst.global) -> unit =
 and declaration : Format.formatter -> (LLVMAst.typ LLVMAst.declaration) -> unit =
   fun ppf ->
   fun { dc_name = i
-      ; dc_type 
+      ; dc_type
       ; dc_param_attrs = (ret_attrs, args_attrs)
       ; dc_linkage
       ; dc_visibility
@@ -685,8 +685,8 @@ and declaration : Format.formatter -> (LLVMAst.typ LLVMAst.declaration) -> unit 
     (match dc_align with
        Some x -> fprintf ppf "align %d " (to_int x) | _ -> ()) ;
     (match dc_gc with
-       Some x -> fprintf ppf "gc \"%s\" " (of_str x) | _ -> ()) 
-    
+       Some x -> fprintf ppf "gc \"%s\" " (of_str x) | _ -> ())
+
 and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.definition -> unit =
   fun ppf ->
   fun ({ df_prototype =


### PR DESCRIPTION
This pull request adresses #107 by removing altogether the use of Show.
It instead relies on the Ceres library that maintains a representation as S-expressions.
The pull request is _not_ yet ready to be merged as the conversion to string returns a representation of the S-expression, we need a small pretty-printer on top of it.