### PR TITLE
Pretty printer for the internal coq representation of the ast

### DIFF
--- a/src/coq/AstLib.v
+++ b/src/coq/AstLib.v
@@ -397,35 +397,35 @@ Inductive value : Set :=
  *)
   Variable T : Set.
   Variable P : (exp T) -> Prop.
-  Hypothesis IH_Ident   : forall (id:ident), P ((EXP_Ident T id)).
-  Hypothesis IH_Integer : forall (x:int), P ((EXP_Integer T x)).
-  Hypothesis IH_Float   : forall (f:float32), P ((EXP_Float T f)).
-  Hypothesis IH_Double  : forall (f:float), P ((EXP_Double T f)).
-  Hypothesis IH_Hex     : forall (h:float), P ((EXP_Hex T h)).
-  Hypothesis IH_Bool    : forall (b:bool), P ((EXP_Bool T b)).
-  Hypothesis IH_Null    : P ((EXP_Null T)).
-  Hypothesis IH_Zero_initializer : P ((EXP_Zero_initializer T)).
-  Hypothesis IH_Cstring : forall (s:string), P ((EXP_Cstring T s)).
-  Hypothesis IH_Undef   : P ((EXP_Undef T)).
-  Hypothesis IH_Struct  : forall (fields: list (T * exp T)), (forall p, In p fields -> P (snd p)) -> P ((EXP_Struct T fields)).
-  Hypothesis IH_Packed_struct : forall (fields: list (T * exp T)), (forall p, In p fields -> P (snd p)) -> P ((EXP_Packed_struct T fields)).
-  Hypothesis IH_Array   : forall (elts: list (T * exp T)), (forall p, In p elts -> P (snd p)) -> P ((EXP_Array T elts)).
-  Hypothesis IH_Vector  : forall (elts: list (T * exp T)), (forall p, In p elts -> P (snd p)) -> P ((EXP_Vector T elts)).
-  Hypothesis IH_IBinop  : forall (iop:ibinop) (t:T) (v1:exp T) (v2:exp T), P v1 -> P v2 -> P ((OP_IBinop T iop t v1 v2)).
-  Hypothesis IH_ICmp    : forall (cmp:icmp)   (t:T) (v1:exp T) (v2:exp T), P v1 -> P v2 -> P ((OP_ICmp T cmp t v1 v2)).
-  Hypothesis IH_FBinop  : forall (fop:fbinop) (fm:list fast_math) (t:T) (v1:exp T) (v2:exp T), P v1 -> P v2 -> P ((OP_FBinop T fop fm t v1 v2)).
-  Hypothesis IH_FCmp    : forall (cmp:fcmp)   (t:T) (v1:exp T) (v2:exp T), P v1 -> P v2 -> P ((OP_FCmp T cmp t v1 v2)).
-  Hypothesis IH_Conversion : forall (conv:conversion_type) (t_from:T) (v:exp T) (t_to:T), P v -> P ((OP_Conversion T conv t_from v t_to)).
+  Hypothesis IH_Ident   : forall (id:ident), P ((EXP_Ident id)).
+  Hypothesis IH_Integer : forall (x:int), P ((EXP_Integer x)).
+  Hypothesis IH_Float   : forall (f:float32), P ((EXP_Float f)).
+  Hypothesis IH_Double  : forall (f:float), P ((EXP_Double f)).
+  Hypothesis IH_Hex     : forall (h:float), P ((EXP_Hex h)).
+  Hypothesis IH_Bool    : forall (b:bool), P ((EXP_Bool b)).
+  Hypothesis IH_Null    : P ((EXP_Null)).
+  Hypothesis IH_Zero_initializer : P ((EXP_Zero_initializer)).
+  Hypothesis IH_Cstring : forall (s:string), P ((EXP_Cstring s)).
+  Hypothesis IH_Undef   : P ((EXP_Undef)).
+  Hypothesis IH_Struct  : forall (fields: list (T * (exp T))), (forall p, In p fields -> P (snd p)) -> P ((EXP_Struct fields)).
+  Hypothesis IH_Packed_struct : forall (fields: list (T * (exp T))), (forall p, In p fields -> P (snd p)) -> P ((EXP_Packed_struct fields)).
+  Hypothesis IH_Array   : forall (elts: list (T * (exp T))), (forall p, In p elts -> P (snd p)) -> P ((EXP_Array elts)).
+  Hypothesis IH_Vector  : forall (elts: list (T * (exp T))), (forall p, In p elts -> P (snd p)) -> P ((EXP_Vector elts)).
+  Hypothesis IH_IBinop  : forall (iop:ibinop) (t:T) (v1:exp T) (v2:exp T), P v1 -> P v2 -> P ((OP_IBinop iop t v1 v2)).
+  Hypothesis IH_ICmp    : forall (cmp:icmp)   (t:T) (v1:exp T) (v2:exp T), P v1 -> P v2 -> P ((OP_ICmp cmp t v1 v2)).
+  Hypothesis IH_FBinop  : forall (fop:fbinop) (fm:list fast_math) (t:T) (v1:exp T) (v2:exp T), P v1 -> P v2 -> P ((OP_FBinop fop fm t v1 v2)).
+  Hypothesis IH_FCmp    : forall (cmp:fcmp)   (t:T) (v1:exp T) (v2:exp T), P v1 -> P v2 -> P ((OP_FCmp cmp t v1 v2)).
+  Hypothesis IH_Conversion : forall (conv:conversion_type) (t_from:T) (v:exp T) (t_to:T), P v -> P ((OP_Conversion conv t_from v t_to)).
   Hypothesis IH_GetElementPtr : forall (t:T) (ptrval:(T * exp T)) (idxs:list (T * exp T)),
-      P (snd ptrval) -> (forall p, In p idxs -> P (snd p)) -> P ((OP_GetElementPtr T t ptrval idxs)).
-  Hypothesis IH_ExtractElement: forall (vec:(T * exp T)) (idx:(T * exp T)), P (snd vec) -> P (snd idx) -> P ((OP_ExtractElement T vec idx)).
+      P (snd ptrval) -> (forall p, In p idxs -> P (snd p)) -> P ((OP_GetElementPtr t ptrval idxs)).
+  Hypothesis IH_ExtractElement: forall (vec:(T * exp T)) (idx:(T * exp T)), P (snd vec) -> P (snd idx) -> P ((OP_ExtractElement vec idx)).
   Hypothesis IH_InsertElement : forall (vec:(T * exp T)) (elt:(T * exp T)) (idx:(T * exp T)),
-      P (snd vec) -> P (snd elt) -> P (snd idx) -> P ((OP_InsertElement T vec elt idx)).
+      P (snd vec) -> P (snd elt) -> P (snd idx) -> P ((OP_InsertElement vec elt idx)).
   Hypothesis IH_ShuffleVector : forall (vec1:(T * exp T)) (vec2:(T * exp T)) (idxmask:(T * exp T)),
-      P (snd vec1) -> P (snd vec2 ) -> P (snd idxmask) -> P ((OP_ShuffleVector T vec1 vec2 idxmask)).
-  Hypothesis IH_ExtractValue  : forall (vec:(T * exp T)) (idxs:list int), P (snd vec) -> P ((OP_ExtractValue T vec idxs)).
-  Hypothesis IH_InsertValue   : forall (vec:(T * exp T)) (elt:(T * exp T)) (idxs:list int), P (snd vec) -> P (snd elt) -> P ((OP_InsertValue T vec elt idxs)).
-  Hypothesis IH_Select        : forall (cnd:(T * exp T)) (v1:(T * exp T)) (v2:(T * exp T)), P (snd cnd) -> P (snd v1) -> P (snd v2) -> P ((OP_Select T cnd v1 v2)).
+      P (snd vec1) -> P (snd vec2 ) -> P (snd idxmask) -> P ((OP_ShuffleVector vec1 vec2 idxmask)).
+  Hypothesis IH_ExtractValue  : forall (vec:(T * exp T)) (idxs:list int), P (snd vec) -> P ((OP_ExtractValue vec idxs)).
+  Hypothesis IH_InsertValue   : forall (vec:(T * exp T)) (elt:(T * exp T)) (idxs:list int), P (snd vec) -> P (snd elt) -> P ((OP_InsertValue vec elt idxs)).
+  Hypothesis IH_Select        : forall (cnd:(T * exp T)) (v1:(T * exp T)) (v2:(T * exp T)), P (snd cnd) -> P (snd v1) -> P (snd v2) -> P ((OP_Select cnd v1 v2)).
 
   Lemma exp_ind' : forall (v:exp T), P v.
     fix IH 1.
@@ -671,20 +671,19 @@ Section hiding_notation.
   Global Instance show_block : Show (block T) :=
     { show block :=
         ("Block "
-           << show (blk_id T block) << ": " )
-           << iter_show (List.map show (blk_code T block))
+           << show (blk_id block) << ": " )
+           << iter_show (List.map show (blk_code block))
     }.
 
   Global Instance show_definition_list_block : Show (definition T (list (block T))) :=
-    { show defn := ("defn: " << iter_show (List.map show (df_instrs T _ defn))) }.
+    { show defn := ("defn: " << iter_show (List.map show (df_instrs defn))) }.
 
   Global Instance show_tle_list_block : Show (toplevel_entity T (list (block T))) :=
-   { show tle :=
-       match tle with
-       | TLE_Definition defn => show defn
-       | _ => "string_of_tle_list_block todo"
-       end
-   }.
+    { show tle := match tle with
+                  | TLE_Definition defn => @show _ show_definition_list_block defn
+                  | _ => "string_of_tle_list_block todo"
+                  end
+    }.
 
   End WithShowT.
 End hiding_notation.
@@ -692,74 +691,70 @@ End hiding_notation.
 Section WithType.
   Variable (T:Set).
 
-Definition target_of {X} (tle : toplevel_entity T X) : option string :=
-  match tle with
-  | TLE_Target tgt => Some tgt
-  | _ => None
-  end.
+  Definition target_of {X} (tle : toplevel_entity T X) : option string :=
+    match tle with
+    | TLE_Target tgt => Some tgt
+    | _ => None
+    end.
 
-Definition datalayout_of {X} (tle : toplevel_entity T X) : option string :=
-  match tle with
-  | TLE_Datalayout l => Some l
-  | _ => None
-  end.
+  Definition datalayout_of {X} (tle : toplevel_entity T X) : option string :=
+    match tle with
+    | TLE_Datalayout l => Some l
+    | _ => None
+    end.
 
-Definition filename_of {X} (tle : toplevel_entity T X) : option string :=
-  match tle with
-  | TLE_Source_filename l => Some l
-  | _ => None
-  end.
+  Definition filename_of {X} (tle : toplevel_entity T X) : option string :=
+    match tle with
+    | TLE_Source_filename l => Some l
+    | _ => None
+    end.
 
-Definition globals_of {X} (tle : toplevel_entity T X) : list (global T) :=
-  match tle with
-  | TLE_Global g => [g]
-  | _ => []
-  end.
+  Definition globals_of {X} (tle : toplevel_entity T X) : list (global T) :=
+    match tle with
+    | TLE_Global g => [g]
+    | _ => []
+    end.
 
-Definition declarations_of {X} (tle : toplevel_entity T X) : list (declaration T) :=
-  match tle with
-  | TLE_Declaration d => [d]
-  | _ => []
-  end.
+  Definition declarations_of {X} (tle : toplevel_entity T X) : list (declaration T) :=
+    match tle with
+    | TLE_Declaration d => [d]
+    | _ => []
+    end.
 
-Definition definitions_of {X} (tle : toplevel_entity T X) : list (definition T X) :=
-  match tle with
-  | TLE_Definition d => [d]
-  | _ => []
-  end.
+  Definition definitions_of {X} (tle : toplevel_entity T X) : list (definition T X) :=
+    match tle with
+    | TLE_Definition d => [d]
+    | _ => []
+    end.
 
-Definition type_defs_of {X} (tle : toplevel_entity T X) : list (ident * T) :=
-  match tle with
-  | TLE_Type_decl id t => [(id,t)]
-  | _ => []
-  end.
+  Definition type_defs_of {X} (tle : toplevel_entity T X) : list (ident * T) :=
+    match tle with
+    | TLE_Type_decl id t => [(id,t)]
+    | _ => []
+    end.
 
+  Definition modul_of_toplevel_entities {X} (tles : list (toplevel_entity T X)) : modul T X :=
+    {|
+      m_name := find_map filename_of tles;
+      m_target := find_map target_of tles;
+      m_datalayout := find_map datalayout_of tles;
+      m_type_defs := flat_map type_defs_of tles;
+      m_globals := flat_map globals_of tles;
+      m_declarations := flat_map declarations_of tles;
+      m_definitions := flat_map definitions_of tles;
+    |}.
 
-Definition modul_of_toplevel_entities {X} (tles : list (toplevel_entity T X)) : modul T X :=
-  {|
-    m_name := find_map filename_of tles;
-    m_target := find_map target_of tles;
-    m_datalayout := find_map datalayout_of tles;
-    m_type_defs := flat_map type_defs_of tles;
-    m_globals := flat_map globals_of tles;
-    m_declarations := flat_map declarations_of tles;
-    m_definitions := flat_map definitions_of tles;
-  |}.
+  (* Identifiers ----------------------------------------------------------- *)
+  Class Ident (X:Set) := ident_of : X -> ident.
 
+  Global Instance ident_of_block : Ident (block T) := fun (b:block T) => ID_Local (@blk_id T b).
+  Global Instance ident_of_global : Ident (global T) := fun (g:global T) => ID_Global (@g_ident T g).
+  Global Instance ident_of_declaration : Ident (declaration T) := fun (d:declaration T) => ID_Global (@dc_name T d).
+  Global Instance ident_of_definition : forall X, Ident (definition T X) := fun X => fun (d:definition T X) => ident_of (@df_prototype T _ d).
 
+  Definition globals {X} (m:modul T X) : list ident :=
+    map ident_of (m_globals m)
+        ++ map ident_of (m_declarations m)
+        ++ map ident_of (m_definitions m).
 
-
-(* Identifiers ----------------------------------------------------------- *)
-Class Ident (X:Set) := ident_of : X -> ident.
-
-Global Instance ident_of_block : Ident (block T) := fun (b:block _) => ID_Local (blk_id T b).
-Global Instance ident_of_global : Ident (global T) := fun (g:global _) => ID_Global (g_ident T g).
-Global Instance ident_of_declaration : Ident (declaration T) := fun (d:declaration _) => ID_Global (dc_name T d).
-Global Instance ident_of_definition : forall X, Ident (definition T X) := fun X => fun (d:definition T X) => ident_of (df_prototype T _ d).
-
-
-Definition globals {X} (m:modul T X) : list ident :=
-           map ident_of (m_globals T _ m)
-        ++ map ident_of (m_declarations T _ m)
-        ++ map ident_of (m_definitions T _ m).
 End WithType.

--- a/src/coq/CFGProp.v
+++ b/src/coq/CFGProp.v
@@ -28,7 +28,7 @@ Proof.
   destruct (block_to_cmd b pt); simpl in H; try solve [inversion H].
   destruct p. destruct o; try inversion H.
   simpl. split; reflexivity.
-Qed.  
+Qed.
  *)
 Section WithType.
   Variable (T:Set).
@@ -39,12 +39,12 @@ Proof.
   intros CFG fid br phis p H.
   unfold find_block_entry in H.
   destruct (find_function T CFG fid); simpl in H; try solve [inversion H].
-  destruct (find_block T (blks T (df_instrs T (cfg T) d)) br); simpl in H; try solve [inversion H].
+  destruct (find_block T (blks T (df_instrs d)) br); simpl in H; try solve [inversion H].
   destruct b. unfold block_to_entry in H. simpl in H. inversion H.
   simpl. reflexivity.
-Qed.  
-  
-    
+Qed.
+
+
 
 (* syntactic structure ------------------------------------------------------ *)
 (*
@@ -72,7 +72,7 @@ Proof.
   induction H1; intros cd2 H2; simpl in *; auto.
   - subst. subst. auto.
   - eapply has_code_cons; eauto.
-Qed.    
+Qed.
 
 Lemma CFG_has_code_app_inv :
   forall CFG P pc1 (cd1 cd2:code)
@@ -96,7 +96,7 @@ Definition CFG_has_pc (CFG:mcfg) (p:pc) : Prop :=
   exists cmd, fetch CFG p = Some cmd.
 
 Definition CFG_fun_has_block_id (CFG:mcfg) (fid:function_id) (bid:block_id) phis (p:pc) : Prop :=
-  find_block_entry CFG fid bid = Some (BlockEntry phis p) /\ CFG_has_pc CFG p. 
+  find_block_entry CFG fid bid = Some (BlockEntry phis p) /\ CFG_has_pc CFG p.
 
 
 Inductive CFG_fun_has_terminator_lbls (CFG:mcfg) (fid:function_id) : terminator -> Prop :=
@@ -115,7 +115,7 @@ Inductive CFG_fun_has_terminator_lbls (CFG:mcfg) (fid:function_id) : terminator 
 .
 (* TODO:  Add these cases:
   | TERM_Switch     (v:tvalue) (default_dest:block_id) (brs: list (tvalue * block_id))
-  | TERM_IndirectBr 
+  | TERM_IndirectBr
   | TERM_Invoke     (fnptrval:tident) (args:list tvalue) (to_label:block_id) (unwind_label:block_id)
   .
 *)
@@ -133,7 +133,7 @@ Inductive CFG_has_terminator_at (CFG:mcfg) : pc -> instr_id -> terminator -> Pro
 Inductive CFG_fun_has_block (CFG:mcfg) (fid:function_id) (b:block) phis : Prop :=
 | CFG_fun_has_block_intro:
     forall
-      (HFind: find_block_entry CFG fid (blk_id b) = Some (BlockEntry phis (blk_entry_pc fid b)))      
+      (HFind: find_block_entry CFG fid (blk_id b) = Some (BlockEntry phis (blk_entry_pc fid b)))
       (Hcode: CFG_has_code_at CFG (fun q => q = blk_term_pc fid b) (blk_entry_pc fid b) (blk_code b))
       (Hterm: CFG_has_terminator_at CFG (blk_term_pc fid b) (blk_term_id b) (blk_terminator b))
     ,
@@ -160,8 +160,8 @@ Fixpoint exp_uses (v:exp T) : list ident :=
   | EXP_Ident id => [id]
   | EXP_Integer _
   | EXP_Float _
-  | EXP_Double _               
-  | EXP_Hex _        
+  | EXP_Double _
+  | EXP_Hex _
   | EXP_Bool _
   | EXP_Null
   | EXP_Zero_initializer
@@ -196,14 +196,14 @@ Definition phi_uses (i:phi T) : (list ident) :=
 (* over-approximation: may include the same identifier more than once *)
 Definition instr_uses (i:instr T) : (list ident) :=
   match i with
-  | INSTR_Op op => exp_uses op                         
+  | INSTR_Op op => exp_uses op
   | INSTR_Call (_, op) args => (exp_uses op) ++ (List.flat_map texp_uses args)
   | INSTR_Alloca t None align => []
   | INSTR_Alloca t (Some tv) align => texp_uses tv
   | INSTR_Load  volatile t ptr align => texp_uses ptr
   | INSTR_Store volatile val ptr align => (texp_uses val) ++ (texp_uses ptr)
   | INSTR_Comment _
-  | INSTR_Fence 
+  | INSTR_Fence
   | INSTR_AtomicCmpXchg
   | INSTR_AtomicRMW
   | INSTR_Unreachable
@@ -230,26 +230,26 @@ Definition cmd_uses_local (g:cfg) (p:pt) (id:local_id) : Prop :=
   | Some (Jump _ t) => In (ID_Local id) (terminator_uses t)
   | None => False
   end.
-*)             
+*)
 
 (* Which labels does a terminator mention *)
 Definition lbls (t:terminator T) : list block_id :=
   match t with
-  | TERM_Ret _        
+  | TERM_Ret _
   | TERM_Ret_void   => []
-  | TERM_Br _ l1 l2 => [l1; l2] 
-  | TERM_Br_1 l => [l] 
+  | TERM_Br _ l1 l2 => [l1; l2]
+  | TERM_Br_1 l => [l]
   | TERM_Switch _ l brs => l::(List.map (fun x => snd x) brs)
   | TERM_IndirectBr _ brs => brs
   | TERM_Resume _    => []
-  | TERM_Invoke  _ _ l1 l2 => [l1; l2] 
+  | TERM_Invoke  _ _ l1 l2 => [l1; l2]
   end.
 
 (*
 
-(* Well-formed SSA-form CFGs 
-   - the initial pt denotes a command  
-   - fallthrough closure: each fallthrough pt maps to a command 
+(* Well-formed SSA-form CFGs
+   - the initial pt denotes a command
+   - fallthrough closure: each fallthrough pt maps to a command
    - jump closure: each label used in a terminator leads to a
      block within the same function body.
    - every use of an identifier is dominated by the id's definition
@@ -304,7 +304,7 @@ Definition wf_use (g:cfg) (ids:list ident) (p:pt) : Prop :=
 
 (** *** Well-formed phi nodes *)
 (**  Consider [ %x = phi [lbl1:v1, ...,lbln:vn] ].  This is well formed
-     when every predecessor block with terminator program point p' 
+     when every predecessor block with terminator program point p'
      has a label associated with exp v.  Moreover, if v uses an id then
      the definition of the uid strictly dominates p'.
 *)
@@ -334,14 +334,14 @@ Inductive wf_cmd (g:cfg) (p:pt) : cmd -> Prop :=
 | wf_jump : forall (bn:block_id) (t:terminator)
               (Huse: wf_use g (terminator_uses t) p)
               (Hlbls: Forall (fun tgt => exists p', exists xs, exists q,
-                             (phis g tgt) = Some (Phis p' xs q) 
+                             (phis g tgt) = Some (Phis p' xs q)
                              /\ wf_phis g p' q p' xs
                       )
                       (lbls t)),
     wf_cmd g p (Jump bn t).
 
 
-(* TODO: do we have to worry about locals shadowing function parameters? 
+(* TODO: do we have to worry about locals shadowing function parameters?
    Could add: forall lid, In (ID_Local lid) (glbl CFG) -> (code CFG) (IId lid) = None
 
    - also, somewhere probably need that globals and function parameters are distinct
@@ -349,11 +349,11 @@ Inductive wf_cmd (g:cfg) (p:pt) : cmd -> Prop :=
 
 Definition wf_cfg (CFG : cfg) : Prop :=
   pt_exists CFG (init CFG)
-  /\ forall p, ~ edge_pt CFG p (init CFG)            
+  /\ forall p, ~ edge_pt CFG p (init CFG)
   /\ (forall p cmd, (code CFG p) = Some cmd -> wf_cmd CFG p cmd)
 .
 
-            
+
 Lemma wf_cfg_edge_pt : forall g p1 p2,
     wf_cfg g -> pt_exists g p1 -> edge_pt g p1 p2 -> pt_exists g p2.
 Proof.
@@ -362,7 +362,7 @@ Proof.
   inversion H1; subst.
   - apply Hcmd in H. inversion H. exact Hq.
   - apply Hcmd in H.
-    inversion H. subst. 
+    inversion H. subst.
     eapply Forall_forall in Hlbls.
     Focus 2. apply H2.
     destruct Hlbls as [p' [xs' [q [Ha Hb]]]].
@@ -372,13 +372,13 @@ Proof.
     * exists (Inst (INSTR_Phi t0 args) p'0).
       exact H4.
 Unshelve. auto.
-Qed.      
+Qed.
 
 
 (* domination trees --------------------------------------------------------- *)
 
   (* Quite hard to prove this:
-      - need to know that Dom can be definied equivalently by quantifying over 
+      - need to know that Dom can be definied equivalently by quantifying over
         all acyclic paths from entry
       - need to know that there are a finite number of acyclic paths (and hence can
         be enumerated)  DFS
@@ -389,19 +389,19 @@ Qed.
   Proof.
     intros g v1 v2.
   Admitted.
-  
+
 
   Inductive vtree (A:Type) : Type :=
   | vnode (v:A) (cs:list (vtree A)).
 
   Arguments vnode {A} _ _.
-  
+
   Inductive dom_tree (g:cfg) : instr_id -> (vtree instr_id) -> Prop :=
   | dom_tree_intro:
-      forall (v:instr_id) (cs:list (vtree instr_id)), 
+      forall (v:instr_id) (cs:list (vtree instr_id)),
         (forall u, IDom g v u -> exists (t:vtree instr_id), In t cs /\ dom_tree g u t) ->
         (forall t, In t cs -> exists u, IDom g v u /\ dom_tree g u t) ->
-        dom_tree g v (vnode v cs). 
+        dom_tree g v (vnode v cs).
 
   Lemma dom_tree_exists : forall (g:cfg), exists (t:vtree instr_id), dom_tree g (init g) t.
   Admitted.

--- a/src/coq/Denotation.v
+++ b/src/coq/Denotation.v
@@ -743,8 +743,8 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
       (* A block ends with a terminator, it either jumps to another block,
          or returns a dynamic value *)
       Definition denote_block (b: block dtyp) : itree instr_E (block_id + uvalue) :=
-        denote_code (blk_code dtyp b);;
-        translate exp_E_to_instr_E (denote_terminator (snd (blk_term dtyp b))).
+        denote_code (blk_code b);;
+        translate exp_E_to_instr_E (denote_terminator (snd (blk_term b))).
 
       (* YZ FIX: no need to push/pop, but do all the assignments afterward *)
       (* One needs to be careful when denoting phi-nodes: they all must
@@ -816,7 +816,7 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
                         | Some block_target =>
                           dvs <- map_monad
                               (fun x => translate exp_E_to_instr_E (denote_phi bid x))
-                              (blk_phis _ block_target) ;;
+                              (blk_phis block_target) ;;
                               map_monad (fun '(id,dv) => trigger (LocalWrite id dv)) dvs;;
                               ret (inl bid_target)
                       end
@@ -848,12 +848,12 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
       Definition denote_function (df:definition dtyp (cfg dtyp)) : function_denotation  :=
         fun (args : list dvalue) =>
           (* We match the arguments variables to the inputs *)
-          debug ("Denoting function " ++ to_string (dc_name _ (df_prototype _ _ df)) ++ " with args: " ++ to_string args ++ " against prototype: " ++ to_string (df_args dtyp _ df));;
-          bs <- lift_err ret (combine_lists_err (df_args dtyp _ df) args) ;;
+          debug ("Denoting function " ++ to_string (dc_name (df_prototype df)) ++ " with args: " ++ to_string args ++ " against prototype: " ++ to_string (df_args df));;
+          bs <- lift_err ret (combine_lists_err (df_args df) args) ;;
              (* generate the corresponding writes to the local stack frame *)
           trigger MemPush ;;
           trigger (StackPush (map (fun '(k,v) => (k, dvalue_to_uvalue v)) bs)) ;;
-          rv <- translate instr_E_to_fun_E (denote_cfg (df_instrs dtyp _ df)) ;;
+          rv <- translate instr_E_to_fun_E (denote_cfg (df_instrs df)) ;;
           trigger StackPop ;;
           trigger MemPop ;;
           ret rv.

--- a/src/coq/Handlers/Intrinsics.v
+++ b/src/coq/Handlers/Intrinsics.v
@@ -39,17 +39,17 @@ Set Contextual Implicit.
    LLVM _intrinsic_ functions are used like ordinary function calls, but
    they have a special interpretation.
 
-     - any global identifier that starts with the prefix "llvm." is 
-       considered to be an intrinsic function 
+     - any global identifier that starts with the prefix "llvm." is
+       considered to be an intrinsic function
 
      - intrinsic functions must be delared in the global scope (to ascribe them types)
 
-     - it is _illegal_ to take the address of an intrinsic function (they do not 
-       always map directly to external functions, e.g. arithmetic intrinsics may 
-       be lowered directly to in-lined assembly on platforms that support the 
+     - it is _illegal_ to take the address of an intrinsic function (they do not
+       always map directly to external functions, e.g. arithmetic intrinsics may
+       be lowered directly to in-lined assembly on platforms that support the
        operations natively.
 
-   As a consequence of the above, it is possible to _statically_ determine 
+   As a consequence of the above, it is possible to _statically_ determine
    that a call is an invocation of an intrinsic by looking for instructions
    of the form:
         call t @llvm._ (args...)
@@ -57,7 +57,7 @@ Set Contextual Implicit.
 
 (* This function extracts the string of the form [llvm._] from an LLVM expression.
    It returns None if the expression is not an intrinsic definition.
-*) 
+*)
 Definition intrinsic_ident (id:ident) : option string :=
   match id with
   | ID_Global (Name s) =>
@@ -88,19 +88,19 @@ Module Make(A:MemoryAddress.ADDRESS)(LLVMIO: LLVM_INTERACTIONS(A)).
 
 
   (* Interprets Call events found in the given association list by their
-     semantic functions.  
+     semantic functions.
 
-     SAZ: This definition is trickier than one wants it to be because of the 
-     dependent pattern matching.  The index of the IntrinsicE constructor need to 
+     SAZ: This definition is trickier than one wants it to be because of the
+     dependent pattern matching.  The index of the IntrinsicE constructor need to
      be used to coerce the result back to the general ITree type.
 
-     We solve it by using the "Convoy Pattern" (see Chlipala's CPDT).  
+     We solve it by using the "Convoy Pattern" (see Chlipala's CPDT).
 
      IntrinsicE ~> LLVM _MCFG1
    *)
 
   Definition defs_assoc := List.map (fun '(a,b) =>
-                                  match dc_name typ a with
+                                  match dc_name a with
                                   | Name s => (s,b)
                                   | _ => ("",b)
                                   end
@@ -112,7 +112,7 @@ Module Make(A:MemoryAddress.ADDRESS)(LLVMIO: LLVM_INTERACTIONS(A)).
       match e in IntrinsicE Y return X = Y -> itree L0 Y with
       | (Intrinsic _ fname args) =>
           match assoc Strings.String.string_dec fname defs_assoc with
-          | Some f => fun pf => 
+          | Some f => fun pf =>
                        match f args with
                        | inl msg => raise msg
                        | inr result => Ret result

--- a/src/coq/LLVMAst.v
+++ b/src/coq/LLVMAst.v
@@ -47,25 +47,25 @@ Inductive linkage : Set :=
 | LINKAGE_Weak_odr
 | LINKAGE_External
 .
-      
+
 Inductive dll_storage : Set :=
 | DLLSTORAGE_Dllimport
 | DLLSTORAGE_Dllexport
-.      
+.
 
 Inductive visibility : Set :=
 | VISIBILITY_Default
 | VISIBILITY_Hidden
 | VISIBILITY_Protected
 .
-    
+
 Inductive cconv : Set :=
 | CC_Ccc
 | CC_Fastcc
 | CC_Coldcc
 | CC_Cc (cc:int)
 .
-        
+
 Inductive param_attr : Set :=
 | PARAMATTR_Zeroext
 | PARAMATTR_Signext
@@ -82,7 +82,7 @@ Inductive param_attr : Set :=
 | PARAMATTR_Nonnull
 | PARAMATTR_Dereferenceable (a:int)
 .
-                            
+
 Inductive fn_attr : Set :=
 | FNATTR_Alignstack (a:int)
 | FNATTR_Alwaysinline
@@ -126,7 +126,7 @@ Inductive thread_local_storage : Set :=
 
 
 Inductive raw_id : Set :=
-| Name (s:string)     (* Named identifiers are strings: %argc, %val, %x, @foo, @bar etc. *)  
+| Name (s:string)     (* Named identifiers are strings: %argc, %val, %x, @foo, @bar etc. *)
 | Anon (n:int)        (* Anonymous identifiers must be sequentially numbered %0, %1, %2, etc. *)
 | Raw  (n:int)        (* Used for code generation -- serializes as %_RAW_0 %_RAW_1 etc. *)
 .
@@ -154,7 +154,7 @@ Inductive typ : Set :=
 | TYPE_Fp128
 | TYPE_Ppc_fp128
 (* | TYPE_Label  label is not really a type *)
-(* | TYPE_Token -- used with exceptions *)    
+(* | TYPE_Token -- used with exceptions *)
 | TYPE_Metadata
 | TYPE_X86_mmx
 | TYPE_Array (sz:int) (t:typ)
@@ -194,23 +194,23 @@ Inductive conversion_type : Set :=
 
 Section TypedSyntax.
 
-  Variable (T:Set).
+  Context {T:Set}.
 
-Definition tident : Set := (T * ident)%type.
+  Definition tident : Set := (T * ident)%type.
 
 
-(* NOTES: 
+(* NOTES:
   This datatype is more permissive than legal in LLVM:
      - it allows identifiers to appear nested inside of "constant expressions"
-       that is OK as long as we validate the syntax as "well-formed" before 
+       that is OK as long as we validate the syntax as "well-formed" before
        trying to give it semantics
 
   NOTES:
-   - Integer expressions: llc parses large integer exps and converts them to some 
+   - Integer expressions: llc parses large integer exps and converts them to some
      internal form (based on integer size?)
-   
-   - Float constants: these are always parsed as 64-bit representable floats 
-     using ocamls float_of_string function. The parser converts float literals 
+
+   - Float constants: these are always parsed as 64-bit representable floats
+     using ocamls float_of_string function. The parser converts float literals
      to 32-bit values using the type information available in the syntax.
 
      -- TODO: 128-bit, 16-bit, other float formats?
@@ -223,7 +223,7 @@ Definition tident : Set := (T * ident)%type.
    - OP_  prefix denotes syntax that requires further evaluation
  *)
 Inductive exp : Set :=
-| EXP_Ident   (id:ident)  
+| EXP_Ident   (id:ident)
 | EXP_Integer (x:int)
 | EXP_Float   (f:float32)  (* 32-bit floating point values *)
 | EXP_Double  (f:float)    (* 64-bit floating point values *)
@@ -237,7 +237,7 @@ Inductive exp : Set :=
 | EXP_Packed_struct   (fields: list (T * exp))
 | EXP_Array           (elts: list (T * exp))
 | EXP_Vector          (elts: list (T * exp))
-| OP_IBinop           (iop:ibinop) (t:T) (v1:exp) (v2:exp)  
+| OP_IBinop           (iop:ibinop) (t:T) (v1:exp) (v2:exp)
 | OP_ICmp             (cmp:icmp)   (t:T) (v1:exp) (v2:exp)
 | OP_FBinop           (fop:fbinop) (fm:list fast_math) (t:T) (v1:exp) (v2:exp)
 | OP_FCmp             (cmp:fcmp)   (t:T) (v1:exp) (v2:exp)
@@ -262,13 +262,13 @@ Inductive instr_id : Set :=
 Inductive phi : Set :=
 | Phi  (t:T) (args:list (block_id * exp))
 .
-       
+
 Inductive instr : Set :=
 | INSTR_Comment (msg:string)
 | INSTR_Op   (op:exp)                        (* INVARIANT: op must be of the form SV (OP_ ...) *)
 | INSTR_Call (fn:texp) (args:list texp)      (* CORNER CASE: return type is void treated specially *)
-| INSTR_Alloca (t:T) (nb: option texp) (align:option int) 
-| INSTR_Load  (volatile:bool) (t:T) (ptr:texp) (align:option int)       
+| INSTR_Alloca (t:T) (nb: option texp) (align:option int)
+| INSTR_Load  (volatile:bool) (t:T) (ptr:texp) (align:option int)
 | INSTR_Store (volatile:bool) (val:texp) (ptr:texp) (align:option int)
 | INSTR_Fence
 | INSTR_AtomicCmpXchg
@@ -283,7 +283,7 @@ Inductive terminator : Set :=
 (* Types in branches are TYPE_Label constant *)
 | TERM_Ret        (v:texp)
 | TERM_Ret_void
-| TERM_Br         (v:texp) (br1:block_id) (br2:block_id) 
+| TERM_Br         (v:texp) (br1:block_id) (br2:block_id)
 | TERM_Br_1       (br:block_id)
 | TERM_Switch     (v:texp) (default_dest:block_id) (brs: list (texp * block_id))
 | TERM_IndirectBr (v:texp) (brs:list block_id) (* address * possible addresses (labels) *)
@@ -312,7 +312,7 @@ Record global : Set :=
 Record declaration : Set :=
   mk_declaration
   {
-    dc_name        : function_id;  
+    dc_name        : function_id;
     dc_type        : T;    (* INVARIANT: should be TYPE_Function (ret_t * args_t) *)
     dc_param_attrs : list param_attr * list (list param_attr); (* ret_attrs * args_attrs *)
     dc_linkage     : option linkage;
@@ -339,17 +339,13 @@ Record block : Set :=
       blk_comments : option (list string)
     }.
 
-Record definition (FnBody:Set) :=
+Record definition {FnBody:Set} :=
   mk_definition
   {
     df_prototype   : declaration;
     df_args        : list local_id;
     df_instrs      : FnBody;
   }.
-
-Arguments df_prototype {_} _.
-Arguments df_args {_} _.
-Arguments df_instrs {_} _.
 
 Inductive metadata : Set :=
   | METADATA_Const  (tv:texp)
@@ -360,31 +356,22 @@ Inductive metadata : Set :=
   | METADATA_Node   (mds:list metadata)
 .
 
-Inductive toplevel_entity (FnBody:Set) : Set :=
+Inductive toplevel_entity {FnBody:Set} : Set :=
 | TLE_Comment         (msg:string)
 | TLE_Target          (tgt:string)
 | TLE_Datalayout      (layout:string)
 | TLE_Declaration     (decl:declaration)
-| TLE_Definition      (defn:definition FnBody)
+| TLE_Definition      (defn:@definition FnBody)
 | TLE_Type_decl       (id:ident) (t:T)
 | TLE_Source_filename (s:string)
 | TLE_Global          (g:global)
 | TLE_Metadata        (id:raw_id) (md:metadata)
 | TLE_Attribute_group (i:int) (attrs:list fn_attr)
 .
-Arguments TLE_Target {_} _.
-Arguments TLE_Datalayout {_} _.
-Arguments TLE_Declaration {_} _.
-Arguments TLE_Definition {_} _.
-Arguments TLE_Type_decl {_} _.
-Arguments TLE_Source_filename {_} _.
-Arguments TLE_Global {_} _.
-Arguments TLE_Metadata {_} _.
-Arguments TLE_Attribute_group {_} _ _.
 
-Definition toplevel_entities (FnBody:Set) : Set := list (toplevel_entity FnBody).
+Definition toplevel_entities (FnBody:Set) : Set := list (@toplevel_entity FnBody).
 
-Record modul (FnBody:Set) : Set :=
+Record modul {FnBody:Set} : Set :=
   mk_modul
   {
     m_name: option string;
@@ -393,15 +380,26 @@ Record modul (FnBody:Set) : Set :=
     m_type_defs: list (ident * T);
     m_globals: list global;
     m_declarations: list declaration;
-    m_definitions: list (definition FnBody);
+    m_definitions: list (@definition FnBody);
   }.
 
-Arguments m_name {_} _.
-Arguments m_target {_} _.
-Arguments m_datalayout {_} _.
-Arguments m_type_defs {_} _.
-Arguments m_globals {_} _.
-Arguments m_declarations {_} _.
-Arguments m_definitions {_} _.
 End TypedSyntax.
+
+Arguments exp: clear implicits.
+Arguments block: clear implicits.
+Arguments texp: clear implicits.
+Arguments phi: clear implicits.
+Arguments instr: clear implicits.
+Arguments terminator: clear implicits.
+Arguments code: clear implicits.
+Arguments global: clear implicits.
+Arguments declaration: clear implicits.
+Arguments definition: clear implicits.
+Arguments metadata: clear implicits.
+Arguments toplevel_entity: clear implicits.
+Arguments toplevel_entities: clear implicits.
+Arguments modul: clear implicits.
+
+
+
 

--- a/src/coq/TransformTypes.v
+++ b/src/coq/TransformTypes.v
@@ -8,7 +8,7 @@
  *   3 of the License, or (at your option) any later version.                 *
  ---------------------------------------------------------------------------- *)
 
-From Coq Require Import 
+From Coq Require Import
      ZArith Ascii Strings.String Setoid.
 
 From ExtLib Require Import
@@ -17,7 +17,7 @@ From ExtLib Require Import
      Structures.Functor
      Data.Option.
 
-From Vellvm Require Import 
+From Vellvm Require Import
      Error
      Util
      LLVMAst
@@ -38,121 +38,120 @@ Definition fmap_pair {X} : (T * X) -> (U * X) := fun '(t, x)=> (f t, x).
 Fixpoint fmap_exp (e:exp T) : exp U :=
   let fmap_texp '(t, e) := (f t, fmap_exp e) in
   match e with
-  | EXP_Ident id => EXP_Ident _ id
-  | EXP_Integer x => EXP_Integer _ x
-  | EXP_Float x => EXP_Float _ x
-  | EXP_Double x => EXP_Double _ x
-  | EXP_Hex x => EXP_Hex _ x
-  | EXP_Bool x => EXP_Bool _ x
-  | EXP_Null => EXP_Null _
-  | EXP_Zero_initializer  => EXP_Zero_initializer _
-  | EXP_Cstring x => EXP_Cstring _ x
-  | EXP_Undef => EXP_Undef _ 
+  | EXP_Ident id => EXP_Ident id
+  | EXP_Integer x => EXP_Integer x
+  | EXP_Float x => EXP_Float x
+  | EXP_Double x => EXP_Double x
+  | EXP_Hex x => EXP_Hex x
+  | EXP_Bool x => EXP_Bool x
+  | EXP_Null => EXP_Null
+  | EXP_Zero_initializer  => EXP_Zero_initializer
+  | EXP_Cstring x => EXP_Cstring x
+  | EXP_Undef => EXP_Undef
   | EXP_Struct fields =>
-    EXP_Struct _ (List.map fmap_texp fields)
+    EXP_Struct (List.map fmap_texp fields)
   | EXP_Packed_struct fields =>
-    EXP_Packed_struct _ (List.map fmap_texp fields)    
+    EXP_Packed_struct (List.map fmap_texp fields)
   | EXP_Array elts =>
-    EXP_Array _ (List.map fmap_texp elts)
+    EXP_Array (List.map fmap_texp elts)
   | EXP_Vector elts =>
-    EXP_Vector _ (List.map fmap_texp elts)
+    EXP_Vector (List.map fmap_texp elts)
   | OP_IBinop iop t v1 v2 =>
-    OP_IBinop _ iop (f t) (fmap_exp v1) (fmap_exp v2)
+    OP_IBinop iop (f t) (fmap_exp v1) (fmap_exp v2)
   | OP_ICmp cmp t v1 v2 =>
-    OP_ICmp _ cmp (f t) (fmap_exp v1) (fmap_exp v2)
+    OP_ICmp cmp (f t) (fmap_exp v1) (fmap_exp v2)
   | OP_FBinop fop fm t v1 v2 =>
-    OP_FBinop _ fop fm (f t) (fmap_exp v1) (fmap_exp v2)    
+    OP_FBinop fop fm (f t) (fmap_exp v1) (fmap_exp v2)
   | OP_FCmp cmp t v1 v2 =>
-    OP_FCmp _ cmp (f t) (fmap_exp v1) (fmap_exp v2)    
+    OP_FCmp cmp (f t) (fmap_exp v1) (fmap_exp v2)
   | OP_Conversion conv t_from v t_to =>
-    OP_Conversion _ conv (f t_from) (fmap_exp v) (f t_to)
+    OP_Conversion conv (f t_from) (fmap_exp v) (f t_to)
   | OP_GetElementPtr t ptrval idxs =>
-    OP_GetElementPtr _ (f t) (fmap_texp ptrval) (List.map fmap_texp idxs)
+    OP_GetElementPtr (f t) (fmap_texp ptrval) (List.map fmap_texp idxs)
   | OP_ExtractElement vec idx =>
-    OP_ExtractElement _ (fmap_texp vec) (fmap_texp idx)
+    OP_ExtractElement (fmap_texp vec) (fmap_texp idx)
   | OP_InsertElement  vec elt idx =>
-    OP_InsertElement _ (fmap_texp vec) (fmap_texp elt) (fmap_texp idx)
+    OP_InsertElement (fmap_texp vec) (fmap_texp elt) (fmap_texp idx)
   | OP_ShuffleVector vec1 vec2 idxmask =>
-    OP_ShuffleVector _ (fmap_texp vec1) (fmap_texp vec2) (fmap_texp idxmask)
+    OP_ShuffleVector (fmap_texp vec1) (fmap_texp vec2) (fmap_texp idxmask)
   | OP_ExtractValue  vec idxs =>
-    OP_ExtractValue  _ (fmap_texp vec) idxs
+    OP_ExtractValue  (fmap_texp vec) idxs
   | OP_InsertValue vec elt idxs =>
-    OP_InsertValue _ (fmap_texp vec) (fmap_texp elt) idxs
+    OP_InsertValue (fmap_texp vec) (fmap_texp elt) idxs
   | OP_Select cnd v1 v2 =>
-    OP_Select _ (fmap_texp cnd) (fmap_texp v1) (fmap_texp v2)
+    OP_Select (fmap_texp cnd) (fmap_texp v1) (fmap_texp v2)
   end.
 
 Definition fmap_texp '(t, e) := (f t, fmap_exp e).
 
 Definition fmap_phi (p:phi T) : phi U :=
   match p with
-  | Phi t args => Phi _ (f t) (List.map (fun '(b,e) => (b, fmap_exp e)) args)
+  | Phi t args => Phi (f t) (List.map (fun '(b,e) => (b, fmap_exp e)) args)
   end.
 
 Definition fmap_instr (ins:instr T) : instr U :=
   match ins with
-  | INSTR_Op op => INSTR_Op _ (fmap_exp op)
-  | INSTR_Call fn args => INSTR_Call _ (fmap_texp fn) (List.map fmap_texp args)
+  | INSTR_Op op => INSTR_Op (fmap_exp op)
+  | INSTR_Call fn args => INSTR_Call (fmap_texp fn) (List.map fmap_texp args)
   | INSTR_Alloca t nb align =>
-    INSTR_Alloca _ (f t) (fmap fmap_texp nb) align
+    INSTR_Alloca (f t) (fmap fmap_texp nb) align
   | INSTR_Load volatile t ptr align =>
-    INSTR_Load _ volatile (f t) (fmap_texp ptr) align
+    INSTR_Load volatile (f t) (fmap_texp ptr) align
   | INSTR_Store volatile val ptr align =>
-    INSTR_Store _ volatile (fmap_texp val) (fmap_texp ptr) align
-  | INSTR_Comment c => INSTR_Comment _ c
-  | INSTR_Fence => INSTR_Fence _
-  | INSTR_AtomicCmpXchg => INSTR_AtomicCmpXchg _
-  | INSTR_AtomicRMW => INSTR_AtomicRMW _
-  | INSTR_Unreachable => INSTR_Unreachable _
-  | INSTR_VAArg => INSTR_VAArg _
-  | INSTR_LandingPad => INSTR_LandingPad _
+    INSTR_Store volatile (fmap_texp val) (fmap_texp ptr) align
+  | INSTR_Comment c => INSTR_Comment c
+  | INSTR_Fence => INSTR_Fence
+  | INSTR_AtomicCmpXchg => INSTR_AtomicCmpXchg
+  | INSTR_AtomicRMW => INSTR_AtomicRMW
+  | INSTR_Unreachable => INSTR_Unreachable
+  | INSTR_VAArg => INSTR_VAArg
+  | INSTR_LandingPad => INSTR_LandingPad
   end.
 
 Definition fmap_terminator (trm:terminator T) : terminator U :=
   match trm with
-  | TERM_Ret  v => TERM_Ret _ (fmap_texp v)
-  | TERM_Ret_void => TERM_Ret_void _
-  | TERM_Br v br1 br2 => TERM_Br _ (fmap_texp v) br1 br2
-  | TERM_Br_1 br => TERM_Br_1 _ br
+  | TERM_Ret  v => TERM_Ret (fmap_texp v)
+  | TERM_Ret_void => TERM_Ret_void
+  | TERM_Br v br1 br2 => TERM_Br (fmap_texp v) br1 br2
+  | TERM_Br_1 br => TERM_Br_1 br
   | TERM_Switch  v default_dest brs =>
-    TERM_Switch _ (fmap_texp v) default_dest (List.map (fun '(e,b) => (fmap_texp e, b)) brs)
+    TERM_Switch (fmap_texp v) default_dest (List.map (fun '(e,b) => (fmap_texp e, b)) brs)
   | TERM_IndirectBr v brs =>
-    TERM_IndirectBr _ (fmap_texp v) brs
-  | TERM_Resume v => TERM_Resume _ (fmap_texp v)
+    TERM_IndirectBr (fmap_texp v) brs
+  | TERM_Resume v => TERM_Resume (fmap_texp v)
   | TERM_Invoke fnptrval args to_label unwind_label =>
-    TERM_Invoke _ (fmap_pair fnptrval) (List.map fmap_texp args) to_label unwind_label
+    TERM_Invoke (fmap_pair fnptrval) (List.map fmap_texp args) to_label unwind_label
   end.
 
-
 Definition fmap_global (g:global T) : (global U) :=
-  mk_global _
-      (g_ident _ g)
-      (f (g_typ _ g))
-      (g_constant _ g)
-      (fmap fmap_exp (g_exp _ g))
-      (g_linkage _ g)
-      (g_visibility _ g)
-      (g_dll_storage _ g)
-      (g_thread_local _ g)
-      (g_unnamed_addr _ g)
-      (g_addrspace _ g)
-      (g_externally_initialized _ g)
-      (g_section _ g)
-      (g_align _ g).
+  mk_global
+      (g_ident g)
+      (f (g_typ g))
+      (g_constant g)
+      (fmap fmap_exp (g_exp g))
+      (g_linkage g)
+      (g_visibility g)
+      (g_dll_storage g)
+      (g_thread_local g)
+      (g_unnamed_addr g)
+      (g_addrspace g)
+      (g_externally_initialized g)
+      (g_section g)
+      (g_align g).
 
 Definition fmap_declaration (d:declaration T) : declaration U :=
-  mk_declaration _
-     (dc_name _ d)
-     (f (dc_type _ d))
-     (dc_param_attrs _ d)
-     (dc_linkage _ d)
-     (dc_visibility _ d)
-     (dc_dll_storage _ d)
-     (dc_cconv _ d)
-     (dc_attrs _ d)
-     (dc_section _ d)
-     (dc_align _ d)
-     (dc_gc _ d).
+  mk_declaration
+     (dc_name d)
+     (f (dc_type d))
+     (dc_param_attrs d)
+     (dc_linkage d)
+     (dc_visibility d)
+     (dc_dll_storage d)
+     (dc_cconv d)
+     (dc_attrs d)
+     (dc_section d)
+     (dc_align d)
+     (dc_gc d).
 
 Definition fmap_code (c:code T) : code U :=
   List.map (fun '(id, i) => (id, fmap_instr i)) c.
@@ -161,54 +160,54 @@ Definition fmap_phis (phis:list (local_id * phi T)) : list (local_id * phi U) :=
   List.map (fun '(id, p) => (id, fmap_phi p)) phis.
 
 Definition fmap_block (b:block T) : block U :=
-  mk_block _ (blk_id _ b)
-           (fmap_phis (blk_phis _ b))
-           (fmap_code (blk_code _ b))
-           (fst (blk_term _ b), fmap_terminator (snd (blk_term _ b)))
-           (blk_comments _ b).
+  mk_block (blk_id b)
+           (fmap_phis (blk_phis b))
+           (fmap_code (blk_code b))
+           (fst (blk_term b), fmap_terminator (snd (blk_term b)))
+           (blk_comments b).
 
 
 Definition fmap_definition {X Y:Set} (g : X -> Y) (d:definition T X) : definition U Y :=
-  mk_definition _ _
-    (fmap_declaration (df_prototype _ _ d))
-    (df_args _ _ d)
-    (g (df_instrs _ _ d)).
+  mk_definition _
+    (fmap_declaration (df_prototype d))
+    (df_args d)
+    (g (df_instrs d)).
 
 Fixpoint fmap_metadata (m:metadata T) : metadata U :=
   match m with
-  | METADATA_Const  tv => METADATA_Const _ (fmap_texp tv)
-  | METADATA_Null => METADATA_Null _
-  | METADATA_Id id => METADATA_Id _ id
-  | METADATA_String str => METADATA_String _ str
-  | METADATA_Named strs => METADATA_Named _ strs
-  | METADATA_Node mds => METADATA_Node _ (List.map fmap_metadata mds)
+  | METADATA_Const  tv => METADATA_Const (fmap_texp tv)
+  | METADATA_Null => METADATA_Null
+  | METADATA_Id id => METADATA_Id id
+  | METADATA_String str => METADATA_String str
+  | METADATA_Named strs => METADATA_Named strs
+  | METADATA_Node mds => METADATA_Node (List.map fmap_metadata mds)
   end.
 
 
 Definition fmap_toplevel_entity {X Y:Set} (g : X -> Y) (tle:toplevel_entity T X) : toplevel_entity U Y :=
   match tle with
-  | TLE_Comment msg => TLE_Comment _ _ msg
-  | TLE_Target tgt => TLE_Target _ _ tgt
-  | TLE_Datalayout layout => TLE_Datalayout _ _ layout
-  | TLE_Declaration decl => TLE_Declaration _ _ (fmap_declaration decl)
-  | TLE_Definition defn => TLE_Definition _ _ (fmap_definition g defn)
-  | TLE_Type_decl id t => TLE_Type_decl _ _ id (f t)
-  | TLE_Source_filename s => TLE_Source_filename _ _ s
-  | TLE_Global g => TLE_Global _ _ (fmap_global g)
-  | TLE_Metadata id md => TLE_Metadata _ _ id (fmap_metadata md)
-  | TLE_Attribute_group id attrs => TLE_Attribute_group _ _ id attrs
+  | TLE_Comment msg => TLE_Comment msg
+  | TLE_Target tgt => TLE_Target tgt
+  | TLE_Datalayout layout => TLE_Datalayout layout
+  | TLE_Declaration decl => TLE_Declaration (fmap_declaration decl)
+  | TLE_Definition defn => TLE_Definition (fmap_definition g defn)
+  | TLE_Type_decl id t => TLE_Type_decl id (f t)
+  | TLE_Source_filename s => TLE_Source_filename s
+  | TLE_Global g => TLE_Global (fmap_global g)
+  | TLE_Metadata id md => TLE_Metadata id (fmap_metadata md)
+  | TLE_Attribute_group id attrs => TLE_Attribute_group id attrs
   end.
 
 
 Definition fmap_modul {X Y:Set} (g : X -> Y) (m:modul T X) : modul U Y :=
-  mk_modul _ _
-    (m_name _ _ m)
-    (m_target _ _ m)
-    (m_datalayout _ _ m)
-    (List.map (fun '(i,t) => (i, f t)) (m_type_defs _ _ m))
-    (List.map fmap_global (m_globals _ _ m))
-    (List.map fmap_declaration (m_declarations _ _ m))
-    (List.map (fmap_definition g) (m_definitions _ _ m)).
+  mk_modul _
+    (m_name m)
+    (m_target m)
+    (m_datalayout m)
+    (List.map (fun '(i,t) => (i, f t)) (m_type_defs m))
+    (List.map fmap_global (m_globals m))
+    (List.map fmap_declaration (m_declarations m))
+    (List.map (fmap_definition g) (m_definitions m)).
 
 Definition fmap_cfg (CFG:cfg T) : cfg U :=
   mkCFG _
@@ -219,4 +218,3 @@ Definition fmap_cfg (CFG:cfg T) : cfg U :=
 Definition fmap_mcfg := fmap_modul fmap_cfg.
 
 End WithTU.
-

--- a/src/coq/Transformations/DeadInstr.v
+++ b/src/coq/Transformations/DeadInstr.v
@@ -25,13 +25,13 @@ Definition optimization {T} := definition T (list (block T)) -> definition T (li
 
 Definition optimize {T} (m:modul T (list (block T))) (o:optimization) : modul T (list (block T)) :=
  {|
-  m_name := (m_name _ _ m);
-  m_target := (m_target _ _ m);
-  m_datalayout := (m_datalayout _ _ m);
-  m_type_defs := (m_type_defs _ _ m);
-  m_globals := (m_globals _ _ m);
-  m_declarations := (m_declarations _ _ m);
-  m_definitions := map o (m_definitions _ _ m);
+  m_name := (m_name m);
+  m_target := (m_target m);
+  m_datalayout := (m_datalayout m);
+  m_type_defs := (m_type_defs m);
+  m_globals := (m_globals m);
+  m_declarations := (m_declarations m);
+  m_definitions := map o (m_definitions m);
   |}.
 
 
@@ -45,7 +45,7 @@ Definition correct (P : modul (list block) -> Prop) (o:optimization) :=
     forall (s:state),
       E.obs_error_free (sem m_semantic s) ->
       E.obs_equiv (sem m_semantic s) (sem m_opt_semantic s).
-      
+
 Class RemoveInstr X := remove_instr : instr_id -> X -> X.
 
 Definition remove_instr_block (id:instr_id) (b:block) : block :=
@@ -84,24 +84,24 @@ Require Import paco.
 
 (*
 Lemma obs_error_free_inv :
-  forall (m:mcfg) (s:state), 
+  forall (m:mcfg) (s:state),
     E.obs_error_free (sem m s) ->
     (exists dv, sem m s = E.Fin dv) \/
     (exists s', stepD m s = E.Ret s' /\ E.obs_error_free (sem m s')).
 Proof.
   intros m s H.
-  punfold H. remember (upaco1 obs_error_free_step bot1). remember (sem m s) as d. induction H. 
+  punfold H. remember (upaco1 obs_error_free_step bot1). remember (sem m s) as d. induction H.
   - left. exists v. reflexivity.
   - rewrite sem_match_id in Heqd. unfold sem in Heqd.
-    unfold bind in Heqd. 
+    unfold bind in Heqd.
     destruct (stepD m s).
     + right. exists s0. split; eauto. subst. inversion Heqd. pclearbot. punfold H. subst. pfold. apply H.
     + inversion Heqd.
     + inversion Heqd.
-    + 
-Abort.    
-*)  
-    
+    +
+Abort.
+*)
+
 
 Lemma remove_instr_correct:
   forall (instr:instr_id), correct (remove_instr_applies_module instr) (remove_instr_defn instr).
@@ -111,8 +111,8 @@ Proof.
   intros m m_semantic m_opt_semantic Happlies H0 H1 s Herr. revert s Herr.
   pcofix CIH.
   intros s Herr.
-  
+
 Abort.
-  
-  
+
+
 *)

--- a/src/coq/Transformations/Renaming.v
+++ b/src/coq/Transformations/Renaming.v
@@ -219,12 +219,12 @@ Module RENAMING
     Variable T:Set.
     Context `{ST: Swap T}.
 
-    Global Instance swap_of_tident : Swap (tident T) := swap.
+    Global Instance swap_of_tident : Swap tident := swap.
     Hint Unfold swap_of_tident.
 
     Fixpoint swap_exp (id1 id2:raw_id) (e:exp T) : exp T :=
       match e with
-      | EXP_Ident id => EXP_Ident _ (swap id1 id2 id)
+      | EXP_Ident id => EXP_Ident (swap id1 id2 id)
       | EXP_Integer _
       | EXP_Float   _
       | EXP_Double  _
@@ -235,46 +235,46 @@ Module RENAMING
       | EXP_Cstring _
       | EXP_Undef => e
       | EXP_Struct fields =>
-        EXP_Struct _ (List.map (fun '(t,e) => (swap id1 id2 t, swap_exp id1 id2 e)) fields)
+        EXP_Struct (List.map (fun '(t,e) => (swap id1 id2 t, swap_exp id1 id2 e)) fields)
       | EXP_Packed_struct fields =>
-        EXP_Packed_struct _ (List.map (fun '(t,e) => (swap id1 id2 t, swap_exp id1 id2 e)) fields)
+        EXP_Packed_struct (List.map (fun '(t,e) => (swap id1 id2 t, swap_exp id1 id2 e)) fields)
       | EXP_Array elts =>
-        EXP_Array _ (List.map (fun '(t,e) => (swap id1 id2 t, swap_exp id1 id2 e)) elts)
+        EXP_Array (List.map (fun '(t,e) => (swap id1 id2 t, swap_exp id1 id2 e)) elts)
       | EXP_Vector elts =>
-        EXP_Vector _ (List.map (fun '(t,e) => (swap id1 id2 t, swap_exp id1 id2 e)) elts)
+        EXP_Vector (List.map (fun '(t,e) => (swap id1 id2 t, swap_exp id1 id2 e)) elts)
       | OP_IBinop iop t v1 v2 =>
-        OP_IBinop _ (swap id1 id2 iop) (swap id1 id2 t) (swap_exp id1 id2 v1) (swap_exp id1 id2 v2)
+        OP_IBinop (swap id1 id2 iop) (swap id1 id2 t) (swap_exp id1 id2 v1) (swap_exp id1 id2 v2)
       | OP_ICmp cmp t v1 v2 =>
-        OP_ICmp _ (swap id1 id2 cmp) (swap id1 id2 t) (swap_exp id1 id2 v1) (swap_exp id1 id2 v2)
+        OP_ICmp (swap id1 id2 cmp) (swap id1 id2 t) (swap_exp id1 id2 v1) (swap_exp id1 id2 v2)
       | OP_FBinop fop fm t v1 v2 =>
-        OP_FBinop _ (swap id1 id2 fop) fm (swap id1 id2 t) (swap_exp id1 id2 v1) (swap_exp id1 id2 v2)
+        OP_FBinop (swap id1 id2 fop) fm (swap id1 id2 t) (swap_exp id1 id2 v1) (swap_exp id1 id2 v2)
       | OP_FCmp cmp t v1 v2 =>
-        OP_FCmp _ (swap id1 id2 cmp) (swap id1 id2 t) (swap_exp id1 id2 v1) (swap_exp id1 id2 v2)
+        OP_FCmp (swap id1 id2 cmp) (swap id1 id2 t) (swap_exp id1 id2 v1) (swap_exp id1 id2 v2)
       | OP_Conversion conv t_from v t_to =>
-        OP_Conversion _ conv (swap id1 id2 t_from) (swap_exp id1 id2 v) (swap id1 id2 t_to)
+        OP_Conversion conv (swap id1 id2 t_from) (swap_exp id1 id2 v) (swap id1 id2 t_to)
       | OP_GetElementPtr t ptrval idxs =>
-        OP_GetElementPtr _ (swap id1 id2 t) (swap id1 id2 (fst ptrval), swap_exp id1 id2 (snd ptrval))
+        OP_GetElementPtr (swap id1 id2 t) (swap id1 id2 (fst ptrval), swap_exp id1 id2 (snd ptrval))
                          (List.map (fun '(a,b) => (swap id1 id2 a, swap_exp id1 id2 b)) idxs)
       | OP_ExtractElement vec idx =>
-        OP_ExtractElement _ (swap id1 id2 (fst vec), swap_exp id1 id2 (snd vec))
+        OP_ExtractElement (swap id1 id2 (fst vec), swap_exp id1 id2 (snd vec))
                           (swap id1 id2 (fst idx), swap_exp id1 id2 (snd idx))
       | OP_InsertElement  vec elt idx =>
-        OP_InsertElement _ (swap id1 id2 (fst vec), swap_exp id1 id2 (snd vec))
+        OP_InsertElement (swap id1 id2 (fst vec), swap_exp id1 id2 (snd vec))
                          (swap id1 id2 (fst elt), swap_exp id1 id2 (snd elt))
                          (swap id1 id2 (fst idx), swap_exp id1 id2 (snd idx))
       | OP_ShuffleVector vec1 vec2 idxmask =>
-        OP_ShuffleVector _ (swap id1 id2 (fst vec1), swap_exp id1 id2 (snd vec1))
+        OP_ShuffleVector (swap id1 id2 (fst vec1), swap_exp id1 id2 (snd vec1))
                          (swap id1 id2 (fst vec2), swap_exp id1 id2 (snd vec2))
                          (swap id1 id2 (fst idxmask), swap_exp id1 id2 (snd idxmask))
       | OP_ExtractValue  vec idxs =>
-        OP_ExtractValue  _ (swap id1 id2 (fst vec), swap_exp id1 id2 (snd vec))
+        OP_ExtractValue  (swap id1 id2 (fst vec), swap_exp id1 id2 (snd vec))
                          idxs
       | OP_InsertValue vec elt idxs =>
-        OP_InsertValue _ (swap id1 id2 (fst vec), swap_exp id1 id2 (snd vec))
+        OP_InsertValue (swap id1 id2 (fst vec), swap_exp id1 id2 (snd vec))
                        (swap id1 id2 (fst elt), swap_exp id1 id2 (snd elt))
                        idxs
       | OP_Select cnd v1 v2 =>
-        OP_Select _ (swap id1 id2 (fst cnd), swap_exp id1 id2 (snd cnd))
+        OP_Select (swap id1 id2 (fst cnd), swap_exp id1 id2 (snd cnd))
                   (swap id1 id2 (fst v1), swap_exp id1 id2 (snd v1))
                   (swap id1 id2 (fst v2), swap_exp id1 id2 (snd v2))
       end.
@@ -293,21 +293,21 @@ Module RENAMING
 
     Definition swap_phi (id1 id2:raw_id) (p:phi T) : phi T :=
       match p with
-      | Phi t args => Phi _ (swap id1 id2 t) (swap id1 id2 args)
+      | Phi t args => Phi (swap id1 id2 t) (swap id1 id2 args)
       end.
     Global Instance swap_of_phi : Swap (phi T) := swap_phi.
     Hint Unfold swap_of_phi.
 
     Definition swap_instr (id1 id2:raw_id) (ins:instr T) : instr T :=
       match ins with
-      | INSTR_Op op => INSTR_Op _ (swap id1 id2 op)
-      | INSTR_Call fn args => INSTR_Call _ (swap id1 id2 fn) (swap id1 id2 args)
+      | INSTR_Op op => INSTR_Op (swap id1 id2 op)
+      | INSTR_Call fn args => INSTR_Call (swap id1 id2 fn) (swap id1 id2 args)
       | INSTR_Alloca t nb align =>
-        INSTR_Alloca _ (swap id1 id2 t) (swap id1 id2 nb) align
+        INSTR_Alloca (swap id1 id2 t) (swap id1 id2 nb) align
       | INSTR_Load volatile t ptr align =>
-        INSTR_Load _ volatile (swap id1 id2 t) (swap id1 id2 ptr) align
+        INSTR_Load volatile (swap id1 id2 t) (swap id1 id2 ptr) align
       | INSTR_Store volatile val ptr align =>
-        INSTR_Store _ volatile (swap id1 id2 val) (swap id1 id2 ptr) align
+        INSTR_Store volatile (swap id1 id2 val) (swap id1 id2 ptr) align
       | INSTR_Comment _
       | INSTR_Fence
       | INSTR_AtomicCmpXchg
@@ -321,17 +321,17 @@ Module RENAMING
 
     Definition swap_terminator (id1 id2:raw_id) (trm:terminator T) : terminator T :=
       match trm with
-      | TERM_Ret  v => TERM_Ret _ (swap id1 id2 v)
-      | TERM_Ret_void => TERM_Ret_void _
-      | TERM_Br v br1 br2 => TERM_Br _ (swap id1 id2 v) (swap id1 id2 br1) (swap id1 id2 br2)
-      | TERM_Br_1 br => TERM_Br_1 _ (swap id1 id2 br)
+      | TERM_Ret  v => TERM_Ret (swap id1 id2 v)
+      | TERM_Ret_void => TERM_Ret_void
+      | TERM_Br v br1 br2 => TERM_Br (swap id1 id2 v) (swap id1 id2 br1) (swap id1 id2 br2)
+      | TERM_Br_1 br => TERM_Br_1 (swap id1 id2 br)
       | TERM_Switch  v default_dest brs =>
-        TERM_Switch _ (swap id1 id2 v) (swap id1 id2 default_dest) (swap id1 id2 brs)
+        TERM_Switch (swap id1 id2 v) (swap id1 id2 default_dest) (swap id1 id2 brs)
       | TERM_IndirectBr v brs =>
-        TERM_IndirectBr _ (swap id1 id2 v) (swap id1 id2 brs)
-      | TERM_Resume v => TERM_Resume _ (swap id1 id2 v)
+        TERM_IndirectBr (swap id1 id2 v) (swap id1 id2 brs)
+      | TERM_Resume v => TERM_Resume (swap id1 id2 v)
       | TERM_Invoke fnptrval args to_label unwind_label =>
-        TERM_Invoke _ (swap id1 id2 fnptrval) (swap id1 id2 args) (swap id1 id2 to_label) (swap id1 id2 unwind_label)
+        TERM_Invoke (swap id1 id2 fnptrval) (swap id1 id2 args) (swap id1 id2 to_label) (swap id1 id2 unwind_label)
       end.
     Global Instance swap_of_terminator : Swap (terminator T) := swap_terminator.
     Hint Unfold swap_of_terminator.
@@ -354,71 +354,70 @@ Module RENAMING
     Hint Unfold swap_of_param_attr swap_of_fn_attr swap_of_cconv swap_of_linkage swap_of_visibility swap_of_dll_storage swap_of_thread_local_storage.
 
     Definition swap_global (id1 id2:raw_id) (g:global T) : (global T) :=
-      mk_global _
-                (swap id1 id2 (g_ident _ g))
-                (swap id1 id2 (g_typ _ g))
-                (swap id1 id2 (g_constant _ g))
-                (swap id1 id2 (g_exp _ g))
-                (swap id1 id2 (g_linkage _ g))
-                (swap id1 id2 (g_visibility _ g))
-                (swap id1 id2 (g_dll_storage _ g))
-                (swap id1 id2 (g_thread_local _ g))
-                (swap id1 id2 (g_unnamed_addr _ g))
-                (swap id1 id2 (g_addrspace _ g))
-                (swap id1 id2 (g_externally_initialized _ g))
-                (swap id1 id2 (g_section _ g))
-                (swap id1 id2 (g_align _ g)).
+      mk_global
+                (swap id1 id2 (g_ident g))
+                (swap id1 id2 (g_typ g))
+                (swap id1 id2 (g_constant g))
+                (swap id1 id2 (g_exp g))
+                (swap id1 id2 (g_linkage g))
+                (swap id1 id2 (g_visibility g))
+                (swap id1 id2 (g_dll_storage g))
+                (swap id1 id2 (g_thread_local g))
+                (swap id1 id2 (g_unnamed_addr g))
+                (swap id1 id2 (g_addrspace g))
+                (swap id1 id2 (g_externally_initialized g))
+                (swap id1 id2 (g_section g))
+                (swap id1 id2 (g_align g)).
     Hint Unfold swap_global.
     Global Instance swap_of_global : Swap (global T) := swap_global.
     Hint Unfold swap_of_global.
 
     Definition swap_declaration (id1 id2:raw_id) (d:declaration T) : declaration T :=
-      mk_declaration _
-                     (swap id1 id2 (dc_name _ d))
-                     (swap id1 id2 (dc_type _ d))
-                     (swap id1 id2 (dc_param_attrs _ d))
-                     (swap id1 id2 (dc_linkage _ d))
-                     (swap id1 id2 (dc_visibility _ d))
-                     (swap id1 id2 (dc_dll_storage _ d))
-                     (swap id1 id2 (dc_cconv _ d))
-                     (swap id1 id2 (dc_attrs _ d))
-                     (swap id1 id2 (dc_section _ d))
-                     (swap id1 id2 (dc_align _ d))
-                     (swap id1 id2 (dc_gc _ d)).
+      mk_declaration
+                     (swap id1 id2 (dc_name d))
+                     (swap id1 id2 (dc_type d))
+                     (swap id1 id2 (dc_param_attrs d))
+                     (swap id1 id2 (dc_linkage d))
+                     (swap id1 id2 (dc_visibility d))
+                     (swap id1 id2 (dc_dll_storage d))
+                     (swap id1 id2 (dc_cconv d))
+                     (swap id1 id2 (dc_attrs d))
+                     (swap id1 id2 (dc_section d))
+                     (swap id1 id2 (dc_align d))
+                     (swap id1 id2 (dc_gc d)).
     Hint Unfold swap_declaration.
     Global Instance swap_of_declaration : Swap (declaration T) := swap_declaration.
     Hint Unfold swap_of_declaration.
 
     Definition swap_block (id1 id2:raw_id) (b:block T) : block T :=
-      mk_block _ (swap id1 id2 (blk_id _ b))
-               (swap id1 id2 (blk_phis _ b))
-               (swap id1 id2 (blk_code _ b))
-               (swap id1 id2 (blk_term _ b))
-               (blk_comments _ b).
+      mk_block (swap id1 id2 (blk_id b))
+               (swap id1 id2 (blk_phis b))
+               (swap id1 id2 (blk_code b))
+               (swap id1 id2 (blk_term b))
+               (blk_comments b).
     Hint Unfold swap_block.
     Global Instance swap_of_block : Swap (block T) := swap_block.
     Hint Unfold swap_of_block.
 
     Definition swap_definition {FnBody:Set} `{SF: Swap FnBody} (id1 id2:raw_id) (d:definition T FnBody) : definition T FnBody :=
-      mk_definition _ _
-                    (swap id1 id2 (df_prototype _ _ d))
-                    (swap id1 id2 (df_args _ _ d))
-                    (swap id1 id2 (df_instrs _ _ d)).
+      mk_definition _
+                    (swap id1 id2 (df_prototype d))
+                    (swap id1 id2 (df_args d))
+                    (swap id1 id2 (df_instrs d)).
     Hint Unfold swap_definition.
 
     Global Instance swap_of_definition {FnBody:Set} `{SF:Swap FnBody} : Swap (definition T FnBody) :=
       swap_definition.
     Hint Unfold swap_of_definition.
 
-
     Fixpoint swap_metadata (id1 id2:raw_id) (m:metadata T) : metadata T :=
       match m with
-      | METADATA_Const  tv => METADATA_Const _ (swap id1 id2 tv)
-      | METADATA_Null => METADATA_Null _
-      | METADATA_Id id => METADATA_Id _ (swap id1 id2 id)
-      | METADATA_String str => METADATA_String _ (swap id1 id2 str)
-      | METADATA_Named strs => METADATA_Named _ (swap id1 id2 strs)
-      | METADATA_Node mds => METADATA_Node _ (List.map (swap_metadata id1 id2) mds)
+      | METADATA_Const  tv => METADATA_Const (swap id1 id2 tv)
+      | METADATA_Null => METADATA_Null
+      | METADATA_Id id => METADATA_Id (swap id1 id2 id)
+      | METADATA_String str => METADATA_String (swap id1 id2 str)
+      | METADATA_Named strs => METADATA_Named (swap id1 id2 strs)
+      | METADATA_Node mds => METADATA_Node (List.map (swap_metadata id1 id2) mds)
       end.
     Global Instance swap_of_metadata : Swap (metadata T) := swap_metadata.
     Hint Unfold swap_of_metadata.
@@ -426,15 +425,15 @@ Module RENAMING
     Definition swap_toplevel_entity {FnBody:Set} `{SF:Swap FnBody} (id1 id2:raw_id) (tle:toplevel_entity T FnBody) :=
       match tle with
       | TLE_Comment msg => tle
-      | TLE_Target tgt => TLE_Target _ _ (swap id1 id2 tgt)
-      | TLE_Datalayout layout => TLE_Datalayout _ _ (swap id1 id2 layout)
-      | TLE_Declaration decl => TLE_Declaration _ _ (swap id1 id2 decl)
-      | TLE_Definition defn => TLE_Definition _ _ (swap id1 id2 defn)
-      | TLE_Type_decl id t => TLE_Type_decl _ _ (swap id1 id2 id) (swap id1 id2 t)
-      | TLE_Source_filename s => TLE_Source_filename _ _ (swap id1 id2 s)
-      | TLE_Global g => TLE_Global _ _ (swap id1 id2 g)
-      | TLE_Metadata id md => TLE_Metadata _ _ (swap id1 id2 id) (swap id1 id2 md)
-      | TLE_Attribute_group i attrs => TLE_Attribute_group _ _ (swap id1 id2 i) (swap id1 id2 attrs)
+      | TLE_Target tgt => TLE_Target (swap id1 id2 tgt)
+      | TLE_Datalayout layout => TLE_Datalayout (swap id1 id2 layout)
+      | TLE_Declaration decl => TLE_Declaration (swap id1 id2 decl)
+      | TLE_Definition defn => TLE_Definition (swap id1 id2 defn)
+      | TLE_Type_decl id t => TLE_Type_decl (swap id1 id2 id) (swap id1 id2 t)
+      | TLE_Source_filename s => TLE_Source_filename (swap id1 id2 s)
+      | TLE_Global g => TLE_Global (swap id1 id2 g)
+      | TLE_Metadata id md => TLE_Metadata (swap id1 id2 id) (swap id1 id2 md)
+      | TLE_Attribute_group i attrs => TLE_Attribute_group (swap id1 id2 i) (swap id1 id2 attrs)
       end.
 
     Global Instance swap_of_toplevel_entity {FnBody:Set} `{SF:Swap FnBody} : Swap (toplevel_entity T FnBody) :=
@@ -442,14 +441,14 @@ Module RENAMING
     Hint Unfold swap_of_toplevel_entity.
 
     Definition swap_modul {FnBody:Set} `{SF:Swap FnBody} (id1 id2:raw_id) (m:modul T FnBody) : modul T FnBody :=
-      mk_modul _ _
-               (swap id1 id2 (m_name _ _ m))
-               (swap id1 id2 (m_target _ _ m))
-               (swap id1 id2 (m_datalayout _ _ m))
-               (swap id1 id2 (m_type_defs _ _ m))
-               (swap id1 id2 (m_globals _ _ m))
-               (swap id1 id2 (m_declarations _ _ m))
-               (swap id1 id2 (m_definitions _ _ m)).
+      mk_modul _
+               (swap id1 id2 (m_name m))
+               (swap id1 id2 (m_target m))
+               (swap id1 id2 (m_datalayout m))
+               (swap id1 id2 (m_type_defs m))
+               (swap id1 id2 (m_globals m))
+               (swap id1 id2 (m_declarations m))
+               (swap id1 id2 (m_definitions m)).
     Hint Unfold swap_modul.
 
     Global Instance swap_of_modul {FnBody:Set} `{SF:Swap FnBody} : Swap (modul T FnBody) :=

--- a/src/coq/Transformations/Transform.v
+++ b/src/coq/Transformations/Transform.v
@@ -28,7 +28,7 @@ Definition mangle_ident (id:ident) : ident :=
 
 Section WithT.
   Variable (T : Set).
-  
+
 
 Definition mangle_instr (i:instr_id * instr T) : (instr_id * instr T) :=
   match i with
@@ -42,16 +42,16 @@ Definition mangle_blocks (blks:list (block T)) : list (block T) :=
   List.map mangle_block blks.
 
 Definition mangle_definition (d:definition T (list (block T))) : definition T (list (block T)) :=
-  mk_definition _ _
-  (df_prototype _ _ d)
-  (df_args _ _ d)
-  (mangle_blocks (df_instrs _ _ d))
+  mk_definition _
+  (df_prototype d)
+  (df_args d)
+  (mangle_blocks (df_instrs d))
 .
 
 
 Definition mangle_toplevel_entity (tle : toplevel_entity T (list (block T))) : toplevel_entity T (list (block T)) :=
   match tle with
-  | TLE_Definition d => TLE_Definition _ _ (mangle_definition d)
+  | TLE_Definition d => TLE_Definition (mangle_definition d)
   | _ => tle
   end.
 

--- a/src/ml/ast_printer.ml
+++ b/src/ml/ast_printer.ml
@@ -87,7 +87,7 @@ and ident : Format.formatter -> LLVMAst.ident -> unit =
 and typ : Format.formatter -> LLVMAst.typ -> unit =
   fun ppf ->
   function
-  | TYPE_I i              -> fprintf ppf "TYPE_Int (%d)" (to_int i)
+  | TYPE_I i              -> fprintf ppf "(TYPE_I %d%%Z)" (to_int i)
   | TYPE_Pointer t        -> fprintf ppf "(TYPE_Pointer (%a))" typ t ;
   | TYPE_Void             -> fprintf ppf "TYPE_Void"
   | TYPE_Function (t, tl) -> fprintf ppf "(TYPE_Function (%a) [%a])" typ t (pp_print_list ~pp_sep:pp_sc_space typ) tl
@@ -428,7 +428,7 @@ and phi : Format.formatter -> (LLVMAst.typ LLVMAst.phi) -> unit =
            )) vil
 
 
-and instr : Format.formatter -> (LLVMAst.typ LLVMAst.instr) -> unit = 
+and instr : Format.formatter -> (LLVMAst.typ LLVMAst.instr) -> unit =
   fun ppf ->
   function
 
@@ -562,6 +562,24 @@ and metadata : Format.formatter -> (LLVMAst.typ LLVMAst.metadata) -> unit =
   | METADATA_Named m  -> fprintf ppf "METADAT_Named [%a]"
                            (pp_print_list ~pp_sep:pp_sc_space (fun ppf s -> fprintf ppf "%s" (of_str s))) m
 
+and param_attr : Format.formatter -> LLVMAst.param_attr -> unit =
+  fun ppf ->
+  function
+  | PARAMATTR_Zeroext -> pp_print_string ppf "PARAMATTR_Zeroext"
+  | PARAMATTR_Signext  -> pp_print_string ppf "PARAMATTR_Signext"
+  | PARAMATTR_Inreg -> pp_print_string ppf "PARAMATTR_Inreg"
+  | PARAMATTR_Byval -> pp_print_string ppf "PARAMATTR_Byval"
+  | PARAMATTR_Inalloca -> pp_print_string ppf "PARAMATTR_Inalloca"
+  | PARAMATTR_Sret -> pp_print_string ppf "PARAMATTR_Sret"
+  | PARAMATTR_Align n -> fprintf ppf "PARAMATTR_Align %d" (to_int n)
+  | PARAMATTR_Noalias -> pp_print_string ppf "PARAMATTR_Noalias"
+  | PARAMATTR_Nocapture -> pp_print_string ppf "PARAMATTR_Nocapture"
+  | PARAMATTR_Readonly -> pp_print_string ppf "PARAMATTR_Readonly"
+  | PARAMATTR_Nest -> pp_print_string ppf "PARAMATTR_Nest"
+  | PARAMATTR_Returned  -> pp_print_string ppf "PARAMATTR_Returned"
+  | PARAMATTR_Nonnull -> pp_print_string ppf "PARAMATTR_Nonnull"
+  | PARAMATTR_Dereferenceable n -> fprintf ppf "PARAMATTR_Dereferenceable %d" (to_int n)
+
 and global : Format.formatter -> (LLVMAst.typ LLVMAst.global) -> unit =
   fun ppf ->
   fun {
@@ -571,25 +589,125 @@ and global : Format.formatter -> (LLVMAst.typ LLVMAst.global) -> unit =
     g_exp;
   } -> fprintf ppf "todo"
 
+and linkage : Format.formatter -> LLVMAst.linkage -> unit =
+  fun ppf ->
+  function
+  | LINKAGE_Private -> pp_print_string ppf "LINKAGE_Private"
+  | LINKAGE_Internal -> pp_print_string ppf "LINKAGE_Internal"
+  | LINKAGE_Available_externally -> pp_print_string ppf "LINKAGE_Available_externally"
+  | LINKAGE_Linkonce -> pp_print_string ppf "LINKAGE_Linkonce"
+  | LINKAGE_Weak -> pp_print_string ppf "LINKAGE_Weak"
+  | LINKAGE_Common -> pp_print_string ppf "LINKAGE_Common"
+  | LINKAGE_Appending -> pp_print_string ppf "LINKAGE_Appending"
+  | LINKAGE_Extern_weak -> pp_print_string ppf "LINKAGE_Extern_weak"
+  | LINKAGE_Linkonce_odr -> pp_print_string ppf "LINKAGE_Linkonce_odr"
+  | LINKAGE_Weak_odr -> pp_print_string ppf "LINKAGE_Weak_odr"
+  | LINKAGE_External -> pp_print_string ppf "LINKAGE_External"
+
+and visibility : Format.formatter -> LLVMAst.visibility -> unit =
+  fun ppf ->
+  function
+  | VISIBILITY_Default -> pp_print_string ppf "VISIBILITY_Default"
+  | VISIBILITY_Hidden  -> pp_print_string ppf "VISIBILITY_Hidden"
+  | VISIBILITY_Protected -> pp_print_string ppf "VISIBILITY_Protected"
+
+and dll_storage : Format.formatter -> LLVMAst.dll_storage -> unit =
+  fun ppf ->
+  function
+  | DLLSTORAGE_Dllimport -> pp_print_string ppf "DLLSTORAGE_Dllimport"
+  | DLLSTORAGE_Dllexport -> pp_print_string ppf "DLLSTORAGE_Dllexport"
+
+and cconv : Format.formatter -> LLVMAst.cconv -> unit =
+  fun ppf ->
+  function
+  | CC_Ccc -> pp_print_string ppf "CC_Ccc"
+  | CC_Fastcc -> pp_print_string ppf "CC_Fastcc"
+  | CC_Coldcc -> pp_print_string ppf "CC_Coldcc"
+  | CC_Cc n -> fprintf ppf "CC_Cc %d" (to_int n)
+
+and fn_attr : Format.formatter -> LLVMAst.fn_attr -> unit =
+  fun ppf ->
+  function
+  | FNATTR_Alignstack n -> fprintf ppf "FNATTR_Alignstack %d" (to_int n)
+  | FNATTR_Alwaysinline -> pp_print_string ppf "FNATTR_Alwaysinline"
+  | FNATTR_Builtin -> pp_print_string ppf "FNATTR_Builtin"
+  | FNATTR_Cold -> pp_print_string ppf "FNATTR_Cold"
+  | FNATTR_Inlinehint -> pp_print_string ppf "FNATTR_Inlinehint"
+  | FNATTR_Jumptable -> pp_print_string ppf "FNATTR_Jumptable"
+  | FNATTR_Minsize -> pp_print_string ppf "FNATTR_Minsize"
+  | FNATTR_Naked -> pp_print_string ppf "FNATTR_Naked"
+  | FNATTR_Nobuiltin -> pp_print_string ppf "FNATTR_Nobuiltin"
+  | FNATTR_Noduplicate -> pp_print_string ppf "FNATTR_Noduplicate"
+  | FNATTR_Noimplicitfloat -> pp_print_string ppf "FNATTR_Noimplicitfloat"
+  | FNATTR_Noinline -> pp_print_string ppf "FNATTR_Noinline"
+  | FNATTR_Nonlazybind -> pp_print_string ppf "FNATTR_Nonlazybind"
+  | FNATTR_Noredzone -> pp_print_string ppf "FNATTR_Noredzone"
+  | FNATTR_Noreturn -> pp_print_string ppf "FNATTR_Noreturn"
+  | FNATTR_Nounwind -> pp_print_string ppf "FNATTR_Nounwind"
+  | FNATTR_Optnone -> pp_print_string ppf "FNATTR_Optnone"
+  | FNATTR_Optsize -> pp_print_string ppf "FNATTR_Optsize"
+  | FNATTR_Readnone -> pp_print_string ppf "FNATTR_Readnone"
+  | FNATTR_Readonly -> pp_print_string ppf "FNATTR_Readonly"
+  | FNATTR_Returns_twice -> pp_print_string ppf "FNATTR_Returns_twice"
+  | FNATTR_Sanitize_address -> pp_print_string ppf "FNATTR_Sanitize_address"
+  | FNATTR_Sanitize_memory -> pp_print_string ppf "FNATTR_Sanitize_memory"
+  | FNATTR_Sanitize_thread -> pp_print_string ppf "FNATTR_Sanitize_thread"
+  | FNATTR_Ssp -> pp_print_string ppf "FNATTR_Ssp"
+  | FNATTR_Sspreq -> pp_print_string ppf "FNATTR_Sspreq"
+  | FNATTR_Sspstrong -> pp_print_string ppf "FNATTR_Sspstrong"
+  | FNATTR_Uwtable -> pp_print_string ppf "FNATTR_Uwtable"
+  | FNATTR_String s -> fprintf ppf "FNATTR_String %s" (of_str s)
+  | FNATTR_Key_value (s,s') -> fprintf ppf "FNATTR_Key_value (%s,%s)" (of_str s) (of_str s')
+  | FNATTR_Attr_grp n  -> fprintf ppf "FNATTR_Attr_grp %d" (to_int n)
+
 and declaration : Format.formatter -> (LLVMAst.typ LLVMAst.declaration) -> unit =
   fun ppf ->
   fun { dc_name = i
-      ; dc_type
+      ; dc_type = t
+      ; dc_param_attrs = patt
+      ; dc_linkage = link
+      ; dc_visibility = vis
+      ; dc_dll_storage = ost
+      ; dc_cconv = occ
+      ; dc_attrs = att
+      ; dc_section = osec
+      ; dc_align = oali
+      ; dc_gc = ogc
       } ->
-    let (ret_t, args_t) = get_function_type dc_type in
-    pp_print_string ppf "declare " ;
-    fprintf ppf "%a @%s(%t)"
-      typ ret_t
-      (str_of_raw_id i)
-      (fun ppf -> pp_print_list ~pp_sep:pp_comma_space typ ppf args_t)
+    pp_print_string ppf "{|";
+    pp_open_box ppf 0;
+    fprintf ppf "dc_name := %s;" (str_of_raw_id i);
+    pp_force_newline ppf ();
+    fprintf ppf "dc_type := %a;" typ t;
+    pp_force_newline ppf ();
+    fprintf ppf "dc_param_attrs := ([%a], [%a]);"
+      (pp_print_list ~pp_sep:pp_sc_space param_attr) (fst patt)
+      (pp_print_list (fun ppf l -> fprintf ppf "%a" (pp_print_list ~pp_sep:pp_sc_space param_attr) l)) (snd patt);
+    pp_force_newline ppf ();
+    fprintf ppf "dc_linkage := %a;" (pp_print_option linkage) link;
+    pp_force_newline ppf ();
+    fprintf ppf "dc_visibility := %a;" (pp_print_option visibility) vis;
+    pp_force_newline ppf ();
+    fprintf ppf "dc_dll_storage := %a;" (pp_print_option dll_storage) ost;
+    pp_force_newline ppf ();
+    fprintf ppf "dc_cconv := %a;" (pp_print_option cconv) occ;
+    pp_force_newline ppf ();
+    fprintf ppf "dc_attrs := [%a];" (pp_print_list ~pp_sep:pp_sc_space fn_attr) att;
+    pp_force_newline ppf ();
+    fprintf ppf "dc_section := %a;" (pp_print_option (fun ppf s -> fprintf ppf "%s" (of_str s))) osec;
+    pp_force_newline ppf ();
+    fprintf ppf "dc_align := %a;" (pp_print_option (fun ppf s -> fprintf ppf "%d" (to_int s))) oali;
+    pp_force_newline ppf ();
+    fprintf ppf "dc_gc := %a" (pp_print_option (fun ppf s -> fprintf ppf "%s" (of_str s))) ogc;
+    pp_print_string ppf "|}";
+    pp_close_box ppf ();
 
 and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.definition -> unit =
   fun ppf ->
-  fun ({ df_prototype =
-           { dc_name = i
-           ; dc_type
-           }
-       } as df) ->
+  fun { df_prototype = df
+      ; df_args = args
+      ; df_instrs = ins
+      } ->
     (* let (ret_t, args_t) = get_function_type dc_type in *)
     (* let typ_arg =
      *   fun ppf (t,id) ->
@@ -597,21 +715,16 @@ and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block l
      *     pp_space ppf ();
      *     lident ppf id
      * in *)
-    pp_print_string ppf "TLE_Definition {|";
+    pp_print_string ppf "{|";
     pp_force_newline ppf ();
 
-    pp_print_string ppf "  df_prototype := {| ";
-    pp_open_box ppf 0;
-    fprintf ppf "dc_name := %s;" (str_of_raw_id i);
-    pp_force_newline ppf ();
-    fprintf ppf "dc_type := %a |}" typ dc_type;
-    pp_close_box ppf ();
-    pp_print_string ppf ";";
+    pp_print_string ppf "  df_prototype := ";
+    fprintf ppf "%a;" declaration df;
     pp_force_newline ppf ();
 
     pp_print_string ppf "  df_args := [";
     pp_print_list ~pp_sep:pp_sc_space (fun ppf id -> pp_print_string ppf (str_of_raw_id id))
-      ppf df.df_args;
+      ppf args;
     pp_print_string ppf "];";
 
     pp_force_newline ppf ();
@@ -621,7 +734,7 @@ and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block l
     pp_print_string ppf "[";
     pp_open_box ppf 0;
     pp_print_list ~pp_sep:(fun ppf () -> pp_print_string ppf ";"; pp_force_newline ppf ())
-      block ppf df.df_instrs ;
+      block ppf ins ;
     pp_print_string ppf "]";
     pp_close_box ppf ();
     pp_force_newline ppf ();

--- a/src/ml/ast_printer.ml
+++ b/src/ml/ast_printer.ml
@@ -242,7 +242,7 @@ and exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
 
     | EXP_Zero_initializer  -> pp_print_string ppf "EXP_Zero_initializer"
 
-    | EXP_Cstring s -> fprintf ppf "(EXP_Cstring %s)" (of_str s)
+    | EXP_Cstring s -> fprintf ppf "(EXP_Cstring \"%s\")" (of_str s)
 
     | OP_IBinop (op, t, v1, v2) ->
       fprintf ppf "(OP_IBinop %a %a %a %a)"
@@ -859,8 +859,6 @@ and modul : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))
   pp_print_list ~pp_sep:pp_force_newline global ppf m.m_globals;
   pp_force_newline ppf () ;
 
-  (* Print function declaration only if there is no corresponding
-     function definition *)
   pp_print_list ~pp_sep:pp_force_newline declaration ppf m.m_declarations;
   pp_force_newline ppf () ;
 

--- a/src/ml/ast_printer.ml
+++ b/src/ml/ast_printer.ml
@@ -1,0 +1,581 @@
+(*  ------------------------------------------------------------------------- *)
+(* Adapted for use in Vellvm by Steve Zdancewic (c) 2017                      *)
+(*  ------------------------------------------------------------------------- *)
+
+open Format
+
+let str = Camlcoq.coqstring_of_camlstring
+let of_str = Camlcoq.camlstring_of_coqstring
+let to_int = Camlcoq.Z.to_int
+
+(* TODO: Use pp_option everywhere instead of inlined matching *)
+let pp_option ppf f o =
+  match o with
+  | None -> ()
+  | Some x -> f ppf x
+
+(* Backward compatibility with 4.01.0 *)
+let rec pp_print_list ?(pp_sep = Format.pp_print_cut) pp_v ppf = function
+| [] -> ()
+| v :: vs ->
+    pp_v ppf v; if vs <> [] then (pp_sep ppf ();
+                                  pp_print_list ~pp_sep pp_v ppf vs)
+
+open LLVMAst
+
+let get_function_type dc_type =
+  match dc_type with
+  | TYPE_Function(ret,args) -> (ret,args)
+  | _ -> failwith "not a function type"
+
+let pp_sep str =
+  fun ppf () -> pp_print_string ppf str
+
+let pp_space ppf () = pp_print_char ppf ' '
+
+let pp_comma_space ppf () = pp_print_string ppf ", "
+let pp_sc_space ppf () = pp_print_string ppf "; "
+
+let rec str_of_raw_id : LLVMAst.raw_id -> string =
+    function
+    | Anon i -> Printf.sprintf "Anon %d%%Z" (to_int i)
+    | Name s -> Printf.sprintf "Name \"%s\"" (of_str s)
+    | Raw i -> Printf.sprintf "Raw %d%%Z" (to_int i)
+
+and lident : Format.formatter -> LLVMAst.local_id -> unit =
+  fun ppf i ->
+    fprintf ppf "ID_Local (%s)" (str_of_raw_id i);
+
+and gident : Format.formatter -> LLVMAst.global_id -> unit =
+  fun ppf i ->
+    fprintf ppf "ID_Global (%s)" (str_of_raw_id i);
+
+and ident : Format.formatter -> LLVMAst.ident -> unit =
+
+  (* let ident_format : (string -> int) -> Format.formatter -> string -> unit = *)
+  (* fun finder ppf i -> *)
+  (* if i.[0] >= '0' && i.[0] <= '9' then pp_print_int ppf (finder i) *)
+  (* else pp_print_string ppf i in *)
+
+  fun ppf ->
+  function
+  | ID_Global i -> gident ppf i
+  | ID_Local i  -> lident ppf i
+
+and typ : Format.formatter -> LLVMAst.typ -> unit =
+  fun ppf ->
+  function
+  | TYPE_I i              -> fprintf ppf "TYPE_Int (%d)" (to_int i)
+  | TYPE_Pointer t        -> fprintf ppf "(TYPE_Pointer (%a))" typ t ;
+  | TYPE_Void             -> fprintf ppf "TYPE_Void"
+  | TYPE_Function (t, tl) -> fprintf ppf "(TYPE_Function (%a) [%a])" typ t (pp_print_list ~pp_sep:pp_sc_space typ) tl
+
+  | TYPE_Half             -> fprintf ppf "todo"
+  | TYPE_Float            -> fprintf ppf "todo"
+  | TYPE_Double           -> fprintf ppf "todo"
+  | TYPE_X86_fp80         -> fprintf ppf "todo"
+  | TYPE_Fp128            -> fprintf ppf "todo"
+  | TYPE_Ppc_fp128        -> fprintf ppf "todo"
+  | TYPE_Metadata         -> fprintf ppf "todo"
+  | TYPE_X86_mmx          -> fprintf ppf "todo"
+  | TYPE_Array (i, t)     -> fprintf ppf "todo"
+  | TYPE_Struct tl        -> fprintf ppf "todo"
+  | TYPE_Packed_struct tl -> fprintf ppf "todo"
+  | TYPE_Opaque           -> fprintf ppf "todo"
+  | TYPE_Vector (i, t)    -> fprintf ppf "todo"
+  | TYPE_Identified i     -> fprintf ppf "todo"
+
+and icmp : Format.formatter -> LLVMAst.icmp -> unit =
+  fun ppf icmp ->
+  fprintf ppf ( match icmp with
+                | Eq  -> "Eq"
+                | Ne  -> "Ne"
+                | Ugt -> "Ugt"
+                | Uge -> "Uge"
+                | Ult -> "Ult"
+                | Ule -> "Ule"
+                | Sgt -> "Sgt"
+                | Sge -> "Sge"
+                | Slt -> "Slt"
+                | Sle -> "Sle")
+
+and fcmp : Format.formatter -> LLVMAst.fcmp -> unit =
+  fun ppf fcmp ->
+  fprintf ppf ( match fcmp with
+                | FFalse -> "FFalse"
+                | FOeq   -> "FOeq"
+                | FOgt   -> "FOgt"
+                | FOge   -> "FOge"
+                | FOlt   -> "FOlt"
+                | FOle   -> "FOle"
+                | FOne   -> "FOne"
+                | FOrd   -> "FOrd"
+                | FUno   -> "FUno"
+                | FUeq   -> "FUeq"
+                | FUgt   -> "FUgt"
+                | FUge   -> "FUge"
+                | FUlt   -> "FUlt"
+                | FUle   -> "FUle"
+                | FUne   -> "FUne"
+                | FTrue  -> "FTrue")
+
+and ibinop : Format.formatter -> LLVMAst.ibinop -> unit =
+  fun ppf ->
+  let nuw ppf flag = if flag then fprintf ppf " true " else fprintf ppf " false " in
+  let nsw ppf flag = if flag then fprintf ppf "true)" else fprintf ppf "false)" in
+  let exact ppf flag = if flag then fprintf ppf " true)" else fprintf ppf " false)" in
+   function
+  | Add (nu, ns) -> fprintf ppf "(Add" ; nuw ppf nu ; nsw ppf ns
+  | Sub (nu, ns) -> fprintf ppf "(Sub" ; nuw ppf nu ; nsw ppf ns
+  | Mul (nu, ns) -> fprintf ppf "(Mul" ; nuw ppf nu ; nsw ppf ns
+  | UDiv e       -> fprintf ppf "(UDiv" ; exact ppf e
+  | SDiv e       -> fprintf ppf "(SDiv" ; exact ppf e
+  | URem         -> fprintf ppf "(URem"
+  | SRem         -> fprintf ppf "(SRem"
+  | Shl (nu, ns) -> fprintf ppf "(Shl" ; nuw ppf nu ; nsw ppf ns
+  | LShr e       -> fprintf ppf "(LShr" ; exact ppf e
+  | AShr e       -> fprintf ppf "(AShr" ; exact ppf e
+  | And          -> fprintf ppf "And"
+  | Or           -> fprintf ppf "Or"
+  | Xor          -> fprintf ppf "Xor"
+
+and fbinop =
+  fun ppf fbinop ->
+  fprintf ppf (match fbinop with
+                 | FAdd -> "FAdd"
+                 | FSub -> "FSub"
+                 | FMul -> "FMul"
+                 | FDiv -> "FDiv"
+                 | FRem -> "FRem")
+
+and fast_math =
+  fun ppf fast_math ->
+  pp_print_string ppf (match fast_math with
+                       | Nnan -> "Nnan"
+                       | Ninf -> "Ninf"
+                       | Nsz  -> "Nsz"
+                       | Arcp -> "Arcp"
+                       | Fast -> "Fast")
+
+and conversion_type : Format.formatter -> LLVMAst.conversion_type -> unit =
+  fun ppf conv ->
+  fprintf ppf (match conv with
+               | Trunc    -> "trunc"
+               | Zext     -> "zext"
+               | Sext     -> "Sext"
+               | Fptrunc  -> "Fptrunc"
+               | Fpext    -> "Fpext"
+               | Uitofp   -> "Uitofp"
+               | Sitofp   -> "Sitofp"
+               | Fptoui   -> "Fptoui"
+               | Fptosi   -> "Fptosi"
+               | Inttoptr -> "Inttoptr"
+               | Ptrtoint -> "Ptrtoint"
+               | Bitcast  -> "Bitcast")
+
+and exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
+  fun (ppf:Format.formatter) vv ->
+    match vv with
+    | EXP_Ident i           ->
+      pp_print_string ppf "(EXP_Ident (";
+      ident ppf i;
+      pp_print_string ppf "))";
+
+    | EXP_Integer i         ->
+      fprintf ppf "(EXP_Integer %d%%Z)" (to_int i);
+
+    | EXP_Float f           ->
+      fprintf ppf "todo"
+
+    | EXP_Bool b            -> 
+      fprintf ppf "todo"
+
+    | EXP_Double f          ->
+      fprintf ppf "todo"
+
+    | EXP_Hex h             ->
+      fprintf ppf "todo"
+
+    | EXP_Null              ->
+      pp_print_string ppf "EXP_Null"
+
+    | EXP_Undef             ->
+      pp_print_string ppf "EXP_Undef"
+
+    | EXP_Array tvl         -> fprintf ppf "todo"
+
+    | EXP_Vector tvl        -> fprintf ppf "todo"
+    | EXP_Struct tvl        -> fprintf ppf "todo"
+    | EXP_Packed_struct tvl -> fprintf ppf "todo"
+
+    | EXP_Zero_initializer  -> pp_print_string ppf "EXP_Zero_initializer"
+
+    | EXP_Cstring s -> fprintf ppf "(EXP_Cstring %s)" (of_str s)
+
+    | OP_IBinop (op, t, v1, v2) ->
+      fprintf ppf "(OP_IBinop %a %a %a %a)"
+        ibinop op
+        typ t
+        exp v1
+        exp v2
+
+    | OP_ICmp (c, t, v1, v2) ->
+     fprintf ppf "(OP_ICmp %a %a %a %a)"
+        icmp c
+        typ t
+        exp v1
+        exp v2
+
+  | OP_FBinop (op, f, t, v1, v2) ->
+     fprintf ppf "(OP_FBinop %a todo %a %a %a)"
+        fbinop op
+        typ t
+        exp v1
+        exp v2
+
+  | OP_FCmp (c, t, v1, v2) ->
+     fprintf ppf "(OP_FCmp %a %a %a %a)"
+        fcmp c
+        typ t
+        exp v1
+        exp v2
+
+  | OP_Conversion (c, t1, v, t2) ->
+     fprintf ppf "todo"
+
+  | OP_GetElementPtr (t, tv, tvl) ->
+     fprintf ppf "todo"
+
+  | OP_Select (if_, then_, else_) ->
+     fprintf ppf "todo"
+
+  | OP_ExtractElement (vec, idx) ->
+     fprintf ppf "todo"
+
+  | OP_InsertElement (vec, new_val, idx) ->
+     fprintf ppf "todo"
+
+  | OP_ExtractValue (agg, idx) ->
+     fprintf ppf "todo"
+
+  | OP_InsertValue (agg, new_val, idx) ->
+     fprintf ppf "todo"
+
+  | OP_ShuffleVector (v1, v2, mask) ->
+     fprintf ppf "todo"
+
+and inst_exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
+  fun ppf vv ->
+    match vv with
+  | EXP_Ident _
+  | EXP_Integer _
+  | EXP_Float _
+  | EXP_Double _
+  | EXP_Hex _
+  | EXP_Bool _
+  | EXP_Null
+  | EXP_Undef
+  | EXP_Array _
+  | EXP_Vector _
+  | EXP_Struct _
+  | EXP_Packed_struct _
+  | EXP_Zero_initializer
+  | EXP_Cstring _ -> assert false (* there should be no "raw" exps as instructions *)
+
+  | OP_IBinop (op, t, v1, v2) ->
+      fprintf ppf "(OP_IBinop %a %a %a %a)"
+        ibinop op
+        typ t
+        exp v1
+        exp v2
+
+  | OP_ICmp (c, t, v1, v2) ->
+     fprintf ppf "(OP_ICmp %a %a %a %a)"
+        icmp c
+        typ t
+        exp v1
+        exp v2
+
+  | OP_FBinop (op, f, t, v1, v2) ->
+     fprintf ppf "(OP_FBinop %a todo %a %a %a)"
+        fbinop op
+        typ t
+        exp v1
+        exp v2
+
+  | OP_FCmp (c, t, v1, v2) ->
+     fprintf ppf "(OP_FCmp %a %a %a %a)"
+        fcmp c
+        typ t
+        exp v1
+        exp v2
+
+  | OP_Conversion (c, t1, v, t2) ->
+     fprintf ppf "todo"
+  | OP_GetElementPtr (t, tv, tvl) ->
+     fprintf ppf "todo"
+  | OP_Select (if_, then_, else_) ->
+     fprintf ppf "todo"
+  | OP_ExtractElement (vec, idx) ->
+     fprintf ppf "todo"
+  | OP_InsertElement (vec, new_val, idx) ->
+     fprintf ppf "todo"
+  | OP_ExtractValue (agg, idx) ->
+     fprintf ppf "todo"
+
+  | OP_InsertValue (agg, new_val, idx) ->
+     fprintf ppf "todo"
+
+  | OP_ShuffleVector (v1, v2, mask) ->
+     fprintf ppf "todo"
+
+
+and phi : Format.formatter -> (LLVMAst.typ LLVMAst.phi) -> unit =
+  fun ppf ->
+    function
+    | Phi (t, vil) ->
+      fprintf ppf "Phi %a [%a]"
+        typ t
+        (pp_print_list ~pp_sep:(pp_sep "; ")
+           (fun ppf (i, v) ->
+              fprintf ppf "(%s, " (str_of_raw_id i);
+              exp ppf v;
+              pp_print_string ppf ")"
+           )) vil
+
+
+and instr : Format.formatter -> (LLVMAst.typ LLVMAst.instr) -> unit =
+  fun ppf ->
+  function
+
+  | INSTR_Comment msg ->  fprintf ppf "(INSTR_Comment %s)" (of_str msg)
+
+  | INSTR_Op v ->
+    pp_print_string ppf "(INSTR_Op ";
+    inst_exp ppf v;
+    pp_print_string ppf ")";
+
+  | INSTR_Call (tv, tvl) ->
+     fprintf ppf "(INSTR_Call %a [%a])"
+             texp tv
+             (pp_print_list ~pp_sep:pp_sc_space texp) tvl
+
+  | INSTR_Alloca (t, n, a) ->
+    (match n with
+       None   -> fprintf ppf "(INSTR_Alloca %a None todo)" typ t ;
+     | Some n -> fprintf ppf "(INSTR_Alloca %a (Some %a) todo)" typ t texp n)
+
+  | INSTR_Load (vol, t, tv, a) ->
+    fprintf ppf "(INSTR_Load todo %a %a todo)"
+      typ t
+      texp tv
+
+  | INSTR_Store (vol, v, ptr, a) ->
+    fprintf ppf "(INSTR_Store todo %a %a todo)"
+      texp v
+      texp ptr
+
+  | INSTR_VAArg -> pp_print_string ppf "INSTR_VAarg"
+  | INSTR_LandingPad
+  | INSTR_AtomicCmpXchg
+  | INSTR_AtomicRMW
+  | INSTR_Fence -> assert false
+  | INSTR_Unreachable -> pp_print_string ppf "INSTR_Unreachable"
+
+and branch_label : Format.formatter -> LLVMAst.raw_id -> unit =
+  fun ppf id ->
+    pp_print_string ppf (str_of_raw_id id)
+
+and terminator : Format.formatter -> (LLVMAst.typ LLVMAst.terminator) -> unit =
+  fun ppf ->
+  function
+
+  | TERM_Ret (t, v)       -> fprintf ppf "TERM_Ret %a" texp (t, v)
+
+  | TERM_Ret_void         -> pp_print_string ppf "TERM_Ret_void"
+
+  | TERM_Br (c, i1, i2)   ->
+     fprintf ppf "TERM_Br %a (%a) (%a)" texp c branch_label i1 branch_label i2
+
+  | TERM_Br_1 i          -> fprintf ppf "TERM_Br_1 (%a)" branch_label i
+
+  | TERM_Switch (c, def, cases) ->
+     fprintf ppf "todo"
+
+  | TERM_Resume (t, v) ->
+     fprintf ppf "todo"
+
+  | TERM_IndirectBr (tv, til) ->
+     fprintf ppf "todo"
+
+  | TERM_Invoke (ti, tvl, i2, i3) ->
+     fprintf ppf "todo"
+
+and id_instr : Format.formatter -> (LLVMAst.instr_id * (LLVMAst.typ LLVMAst.instr)) -> unit =
+  fun ppf ->
+    function (id, inst) ->
+      fprintf ppf "(%a, %a)" instr_id id instr inst
+
+and id_phi : Format.formatter -> (LLVMAst.local_id * (LLVMAst.typ LLVMAst.phi)) -> unit =
+  fun ppf ->
+    function (id, p) ->
+      fprintf ppf "(%s, %a)" (str_of_raw_id id) phi p
+
+
+and instr_id : Format.formatter -> LLVMAst.instr_id -> unit =
+  fun ppf ->
+    function
+    | IId id  -> fprintf ppf "IId (%s)" (str_of_raw_id id)
+    | IVoid n -> fprintf ppf "IVoid %d%%Z" (to_int n)
+
+
+and texp ppf (t, v) = fprintf ppf "(%a, %a)" typ t exp v
+
+and tident ppf (t, v) = fprintf ppf "(%a, %a)" typ t ident v
+
+and toplevel_entities : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entities -> unit =
+  fun ppf entries ->
+    pp_print_string ppf "[";
+    pp_print_list ~pp_sep:(fun ppf () -> pp_sc_space ppf (); pp_force_newline ppf ()) toplevel_entity ppf entries;
+    pp_print_string ppf "].";
+    pp_print_flush ppf ();
+
+and toplevel_entity : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity -> unit =
+  fun ppf ->
+  function
+  | TLE_Comment msg            -> fprintf ppf "todo"
+  | TLE_Target s               -> fprintf ppf "todo"
+  | TLE_Datalayout s           -> fprintf ppf "todo"
+  | TLE_Source_filename s      -> fprintf ppf "todo"
+  | TLE_Declaration d          -> declaration ppf d
+  | TLE_Definition d           -> definition ppf d
+  | TLE_Type_decl (i, t)       -> fprintf ppf "todo"
+  | TLE_Global g               -> global ppf g
+  | TLE_Metadata (i, m)        -> fprintf ppf "todo"
+  | TLE_Attribute_group (i, a) -> fprintf ppf "todo"
+
+and metadata : Format.formatter -> (LLVMAst.typ LLVMAst.metadata) -> unit =
+  fun ppf ->
+  function
+  | METADATA_Const v  -> fprintf ppf "todo"
+  | METADATA_Null     -> fprintf ppf "todo"
+  | METADATA_Id i     -> fprintf ppf "todo"
+  | METADATA_String s -> fprintf ppf "todo"
+  | METADATA_Node m   -> fprintf ppf "todo"
+  | METADATA_Named m  -> fprintf ppf "todo"
+
+and global : Format.formatter -> (LLVMAst.typ LLVMAst.global) -> unit =
+  fun ppf ->
+  fun {
+    g_ident;
+    g_typ;
+    g_constant;
+    g_exp;
+  } -> fprintf ppf "todo"
+
+and declaration : Format.formatter -> (LLVMAst.typ LLVMAst.declaration) -> unit =
+  fun ppf ->
+  fun { dc_name = i
+      ; dc_type
+      } ->
+    let (ret_t, args_t) = get_function_type dc_type in
+    pp_print_string ppf "declare " ;
+    fprintf ppf "%a @%s(%t)"
+      typ ret_t
+      (str_of_raw_id i)
+      (fun ppf -> pp_print_list ~pp_sep:pp_comma_space typ ppf args_t)
+
+and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.definition -> unit =
+  fun ppf ->
+  fun ({ df_prototype =
+           { dc_name = i
+           ; dc_type
+           }
+       } as df) ->
+    (* let (ret_t, args_t) = get_function_type dc_type in *)
+    (* let typ_arg =
+     *   fun ppf (t,id) ->
+     *     typ ppf t;
+     *     pp_space ppf ();
+     *     lident ppf id
+     * in *)
+    pp_print_string ppf "TLE_Definition {|";
+    pp_force_newline ppf ();
+
+    pp_print_string ppf "  df_prototype := {| ";
+    pp_open_box ppf 0;
+    fprintf ppf "dc_name := %s;" (str_of_raw_id i);
+    pp_force_newline ppf ();
+    fprintf ppf "dc_type := %a |}" typ dc_type;
+    pp_close_box ppf ();
+    pp_print_string ppf ";";
+    pp_force_newline ppf ();
+
+    pp_print_string ppf "  df_args := [";
+    pp_print_list ~pp_sep:pp_sc_space (fun ppf id -> pp_print_string ppf (str_of_raw_id id))
+      ppf df.df_args;
+    pp_print_string ppf "];";
+
+    pp_force_newline ppf ();
+
+    pp_print_string ppf "  df_instrs := ";
+    pp_force_newline ppf ();
+    pp_print_string ppf "[";
+    pp_open_box ppf 0;
+    pp_print_list ~pp_sep:(fun ppf () -> pp_print_string ppf ";"; pp_force_newline ppf ())
+      block ppf df.df_instrs ;
+    pp_print_string ppf "]";
+    pp_close_box ppf ();
+    pp_force_newline ppf ();
+
+    pp_print_string ppf "|}";
+    pp_print_flush ppf ();
+
+and block : Format.formatter -> LLVMAst.typ LLVMAst.block -> unit =
+  fun ppf {blk_id=lbl; blk_phis=phis; blk_code=b; blk_term=(t_id,t)} ->
+    pp_print_string ppf "{|";
+    pp_force_newline ppf ();
+
+    pp_print_string ppf "  blk_id := ";
+    pp_print_string ppf (str_of_raw_id lbl);
+    pp_print_string ppf ";";
+    pp_force_newline ppf () ;
+
+    pp_print_string ppf "  blk_phis := [";
+    pp_open_box ppf 0;
+    pp_print_list ~pp_sep:(fun ppf () -> pp_print_string ppf ";"; pp_force_newline ppf ())
+      id_phi ppf phis ;
+    pp_close_box ppf ();
+    pp_print_string ppf "];";
+    pp_force_newline ppf () ;
+
+    pp_print_string ppf "  blk_code := [";
+    pp_open_box ppf 0 ;
+    pp_print_list ~pp_sep:(fun ppf () -> pp_print_string ppf ";"; pp_force_newline ppf ();)
+      id_instr ppf b ;
+    pp_print_string ppf "];";
+    pp_close_box ppf ();
+    pp_force_newline ppf () ;
+
+    pp_print_string ppf "  blk_term := ";
+    fprintf ppf "(%a, %a)" instr_id t_id terminator t;
+    pp_force_newline ppf () ;
+
+    pp_print_string ppf "|}";
+
+and modul : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.modul -> unit =
+  fun ppf m ->
+
+  pp_option ppf (fun ppf x -> fprintf ppf "; ModuleID = '%s'" (of_str x)) m.m_name ;
+  pp_force_newline ppf () ;
+
+  pp_print_list ~pp_sep:pp_force_newline global ppf m.m_globals;
+  pp_force_newline ppf () ;
+
+  (* Print function declaration only if there is no corresponding
+     function definition *)
+  pp_print_list ~pp_sep:pp_force_newline declaration ppf m.m_declarations;
+  pp_force_newline ppf () ;
+
+  pp_print_list ~pp_sep:pp_force_newline definition ppf m.m_definitions;
+  pp_force_newline ppf ()

--- a/src/ml/driver.ml
+++ b/src/ml/driver.ml
@@ -11,13 +11,13 @@
 open Printf
 
 let of_str = Camlcoq.camlstring_of_coqstring
-               
+
 let interpret = ref false
 
 let transform (prog : (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity list)
   : (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.toplevel_entity list =
   Transform.transform prog
-  
+
 let print_banner s =
   let rec dashes n = if n = 0 then "" else "-"^(dashes (n-1)) in
   printf "%s %s\n%!" (dashes (79 - (String.length s))) s
@@ -49,15 +49,18 @@ let output_file filename ast =
   toplevel_entities (Format.formatter_of_out_channel channel) ast;
   close_out channel
 
+let output_ast filename ast channel =
+  let open Ast_printer in
+  toplevel_entities channel ast
 
 let string_of_file (f:in_channel) : string =
   let rec _string_of_file (stream:string list) (f:in_channel) : string list=
-    try 
+    try
       let s = input_line f in
       _string_of_file (s::stream) f
     with
       | End_of_file -> stream
-  in 
+  in
     String.concat "\n" (List.rev (_string_of_file [] f))
 
 
@@ -72,7 +75,7 @@ let process_ll_file path file =
   let _ = if !interpret then begin
       let open Format in
       match Interpreter.interpret ll_ast with
-      | Ok dv -> 
+      | Ok dv ->
         Printf.printf "Program terminated with: " ;
         let ppf = std_formatter in
         Interpreter.pp_dvalue ppf dv ;
@@ -89,7 +92,7 @@ let process_ll_file path file =
 
 
 let process_file path =
-  let _ = Printf.printf "Processing: %s\n" path in 
+  let _ = Printf.printf "Processing: %s\n" path in
   let basename, ext = Platform.path_to_basename_ext path in
   begin match ext with
     | "ll" -> process_ll_file path basename

--- a/src/ml/libvellvm/llvm_printer.ml
+++ b/src/ml/libvellvm/llvm_printer.ml
@@ -6,7 +6,7 @@ open Format
 
 let of_str = Camlcoq.camlstring_of_coqstring
 let to_int = Camlcoq.Z.to_int
-let float_of_coqfloat = Camlcoq.camlfloat_of_coqfloat               
+let float_of_coqfloat = Camlcoq.camlfloat_of_coqfloat
 
 (* TODO: Use pp_option everywhere instead of inlined matching *)
 let pp_option ppf f o =
@@ -368,21 +368,21 @@ and exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
 and inst_exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
   fun ppf vv ->
     match vv with
-  | EXP_Ident _ 
-  | EXP_Integer _ 
+  | EXP_Ident _
+  | EXP_Integer _
   | EXP_Float _
-  | EXP_Double _      
-  | EXP_Hex _         
-  | EXP_Bool _    
-  | EXP_Null      
-  | EXP_Undef     
+  | EXP_Double _
+  | EXP_Hex _
+  | EXP_Bool _
+  | EXP_Null
+  | EXP_Undef
   | EXP_Array _
-  | EXP_Vector _  
+  | EXP_Vector _
   | EXP_Struct _
   | EXP_Packed_struct _
-  | EXP_Zero_initializer 
+  | EXP_Zero_initializer
   | EXP_Cstring _ -> assert false   (* there should be no "raw" exps as instructions *)
-  
+
   | OP_IBinop (op, t, v1, v2) ->
      fprintf ppf "%a %a %a, %a"
              ibinop op
@@ -504,8 +504,6 @@ and instr : Format.formatter -> (LLVMAst.typ LLVMAst.instr) -> unit =
 
   | INSTR_VAArg -> pp_print_string ppf "vaarg"
 
-
-
   | INSTR_LandingPad -> assert false
 
   | INSTR_Store (vol, v, ptr, a) ->
@@ -520,11 +518,10 @@ and instr : Format.formatter -> (LLVMAst.typ LLVMAst.instr) -> unit =
   | INSTR_Fence -> assert false
   | INSTR_Unreachable -> pp_print_string ppf "unreachable"
 
-
 and branch_label : Format.formatter -> LLVMAst.raw_id -> unit =
   fun ppf id ->
     pp_print_string ppf "label %"; pp_print_string ppf (str_of_raw_id id)
-    
+
 
 and terminator : Format.formatter -> (LLVMAst.typ LLVMAst.terminator) -> unit =
   fun ppf ->
@@ -578,7 +575,7 @@ and instr_id : Format.formatter -> LLVMAst.instr_id -> unit =
     function
     | IId id  -> fprintf ppf "%%%s = " (str_of_raw_id id)
     | IVoid n -> fprintf ppf "; void instr %d" (to_int n); pp_force_newline ppf ()
-  
+
 and texp ppf (t, v) = fprintf ppf "%a %a" typ t exp v
 
 and tident ppf (t, v) = fprintf ppf "%a %a" typ t ident v
@@ -615,6 +612,7 @@ and metadata : Format.formatter -> (LLVMAst.typ LLVMAst.metadata) -> unit =
                                  (pp_print_list ~pp_sep:pp_comma_space
                                                 (fun ppf i ->
                                                  fprintf ppf "!%s" i)) (List.map of_str m)
+
 and global : Format.formatter -> (LLVMAst.typ LLVMAst.global) -> unit =
   fun ppf ->
   fun {
@@ -642,7 +640,7 @@ and global : Format.formatter -> (LLVMAst.typ LLVMAst.global) -> unit =
 and declaration : Format.formatter -> (LLVMAst.typ LLVMAst.declaration) -> unit =
   fun ppf ->
   fun { dc_name = i
-      ; dc_type 
+      ; dc_type
       ; dc_param_attrs = (ret_attrs, args_attrs)
       ; dc_linkage
       ; dc_visibility
@@ -685,8 +683,8 @@ and declaration : Format.formatter -> (LLVMAst.typ LLVMAst.declaration) -> unit 
     (match dc_align with
        Some x -> fprintf ppf "align %d " (to_int x) | _ -> ()) ;
     (match dc_gc with
-       Some x -> fprintf ppf "gc \"%s\" " (of_str x) | _ -> ()) 
-    
+       Some x -> fprintf ppf "gc \"%s\" " (of_str x) | _ -> ())
+
 and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.definition -> unit =
   fun ppf ->
   fun ({ df_prototype =
@@ -771,6 +769,7 @@ and block : Format.formatter -> LLVMAst.typ LLVMAst.block -> unit =
     pp_force_newline ppf () ;
     terminator ppf t;
     pp_close_box ppf ()
+
 and comment : Format.formatter -> char list -> unit =
   fun ppf s -> fprintf ppf "; %s" (of_str s)
 


### PR DESCRIPTION
This PR adds a pretty printer on the ocaml side outputting valid (up-to bug) Coq syntax of the internal representation of vellvm's ast.

This is notably convenient to convert llvm's test cases for its optimization to refinement proofs in our framework. 