### PR TITLE
Fix spelling typos

### DIFF
--- a/src/coq/LLVMAst.v
+++ b/src/coq/LLVMAst.v
@@ -136,7 +136,7 @@ Inductive ident : Set :=
 | ID_Local  (id:raw_id)   (* %id *)
 .
 
-(* auxilliary definitions for when we know which case we're in already *)
+(* auxiliary definitions for when we know which case we're in already *)
 Definition local_id  := raw_id.
 Definition global_id := raw_id.
 Definition block_id := raw_id.

--- a/src/coq/LLVMEvents.v
+++ b/src/coq/LLVMEvents.v
@@ -40,7 +40,7 @@ From Vellvm Require Import
    effectful computations.
    This file defined the interface provided to the interaction trees, that is the set of
    events that a LLVM program can trigger.
-   These events are then concretely interpreted as a succesion of handler, as defined in the
+   These events are then concretely interpreted as a succession of handler, as defined in the
    _Handlers_ folder.
    The possible events are:
    * Function calls [CallE]

--- a/src/coq/ParserHelper.v
+++ b/src/coq/ParserHelper.v
@@ -799,7 +799,7 @@ Section Correctness.
           apply set_digits_m_eq in Heqo1. assumption.
           unfold FLX.Prec_gt_0; lia.
           assumption.
-    - (* unsuccesful normalization - impossible to normalize? *)
+    - (* unsuccessful normalization - impossible to normalize? *)
       intros xf H.
       apply Bool.not_true_is_false.
       intros V.

--- a/src/ml/libvellvm/interpreter.ml
+++ b/src/ml/libvellvm/interpreter.ml
@@ -15,7 +15,7 @@
 open Format
 open ITreeDefinition
 
-(* TODO: probaly should be part of ADDRESS module interface*)
+(* TODO: probably should be part of ADDRESS module interface*)
 let pp_addr : Format.formatter -> Memory.A.addr -> unit
   = fun ppf _ -> fprintf ppf "UVALUE_Addr(?)"
 


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.