### PR TITLE
do not git update itress

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -49,8 +49,10 @@ coq: $(VOFILES)
 
 coqinterp: $(COQFILESINTERP:%=coq/%.vo)
 
-itrees:
+update-trees:
 	git submodule update -- $(ITREEDIR)
+
+itrees:
 	make -C $(ITREEDIR)
 
 .PHONY: extracted itrees 


### PR DESCRIPTION
automatic submodule update prevents from working with older checked out version on vellvm. 
it updates itrees automatically during build and new version of itrees might be incompatible with checked out version of  vellcm.