### PR TITLE
Open cfg

### DIFF
--- a/src/coq/Denotation.v
+++ b/src/coq/Denotation.v
@@ -873,7 +873,67 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
 
        *)
 
-      Definition denote_bks (bks: list _): block_id -> itree instr_E (block_id + uvalue) :=
+      Definition interface: Type := list block_id.
+      Definition open_cfg: Type  := list (block dtyp).
+      Definition dom: open_cfg -> interface := List.map blk_id.
+      Definition lbl_from_terminator {T} (t: terminator T): interface :=
+        match t with
+        | TERM_Br _ id1 id2 => [id1;id2]
+        | TERM_Br_1 id => [id]
+        | _ => []
+        end.
+      Definition codom (ocfg: open_cfg): interface :=
+        List.fold_left (fun acc block => app (lbl_from_terminator (snd (blk_term block))) acc) ocfg [].
+      Definition inb {A: Type} {eqa} {H: RelDec.RelDec eqa} (xs: list A) (x: A): bool :=
+        existsb (fun y => RelDec.rel_dec x y) xs.
+      Definition collect_blocks (ocfg: open_cfg) (i: interface): open_cfg :=
+        List.filter (fun block => inb i (blk_id block)) ocfg.
+
+      (* Question: we denote phi-nodes of blocks we are about to jump to after the denotation of a given block.
+         If I jump to a block in B, and hence do not re-entry, should I denote the phis?
+       *)
+      Definition denote_open_bks (bks: open_cfg) (A B: list block_id): block_id -> itree instr_E (block_id + uvalue) :=
+        loop (C := ktree _)
+             (fun (bid: block_id + block_id) =>
+                match bid with
+                | inl bid
+                | inr bid =>
+                  (* We only consider bks described in A as valid entry point *)
+                  match find_block DynamicTypes.dtyp (collect_blocks bks A) bid with
+                  | None => ret (inr (inl bid)) (* Should this be a failure instead? *)
+                  | Some block =>
+                    (* We denote the block considered *)
+                    bd <- denote_block block;;
+                    match bd with
+                    | inr dv => ret (inr (inr dv)) (* On value we return *)
+                    | inl bid_target =>
+                      (* On jumps, we return if in B, try to loop otherwise *)
+                      if inb B bid_target
+                      then ret (inr (inl bid))
+                      else
+                        (* Otherwise, we find the block, evaluate its phi and loop back *)
+                        match find_block DynamicTypes.dtyp bks bid_target with
+                        | None => ret (inr (inl bid_target))
+                        | Some block_target =>
+                          (* And set the phi-nodes of the new destination, if any *)
+                          dvs <- Util.map_monad
+                                  (fun x => translate exp_E_to_instr_E (denote_phi bid x))
+                                  (blk_phis block_target) ;;
+                          Util.map_monad (fun '(id,dv) => trigger (LocalWrite id dv)) dvs;;
+                          ret (inl bid_target)
+                        end
+                    end
+                  end
+                end).
+
+      Definition denote_cfg' (f: cfg dtyp): itree instr_E uvalue :=
+        r <- denote_open_bks (blks _ f) [init _ f] [] (init _ f) ;;
+        match r with
+        | inl bid => raise ("Can't find block in denote_cfg " ++ to_string bid)
+        | inr uv  => ret uv
+        end.
+
+      Definition denote_bks (bks: open_cfg) (A B: list block_id): block_id -> itree instr_E (block_id + uvalue) :=
         loop (C := ktree _)
              (fun (bid : block_id + block_id) =>
                 match bid with

--- a/src/coq/FinLabels.v
+++ b/src/coq/FinLabels.v
@@ -1,0 +1,177 @@
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Basics.Category
+     Basics.CategorySub.
+
+From Vellvm Require Import
+     Util
+     LLVMAst
+     AstLib.
+
+From Coq Require Import
+     Arith
+     List.
+Import ListNotations.
+
+(*
+  In order to specify at the type level the interface an open control flow graph exposes,
+  we need to work over a type of finite [block_id].
+  This in term will allow us to work over the subcategory of [ktrees] when denoting such
+  open control flow graphs, allowing us in term to define sound combinators.
+  In contrast with the [asm] language from the [itree] tutorial, we work with non-canonical names.
+ *)
+
+Definition fin (l : list block_id) : Type := { x : (block_id * nat) | nth_error l (snd x) = Some (fst x) }.
+
+(* Definition fin_single (bid: block_id) : fin [bid] := exist _ bid (or_introl (eq_refl)). *)
+
+Lemma fin_nil {A} : fin [] -> A.
+Proof.
+  intros [[] ?].
+  rewrite nth_error_nil in e.
+  inversion e.
+Qed.
+
+(* [fin nil] is isomorphic to the empty set, it's the initial object of the subcategory *)
+Instance FinInitial {E} : Initial (sub (ktree E) fin) [] := fun _ => fin_nil.
+
+Program Definition split_fin_sum (a b : list block_id)
+  : fin (a ++ b) -> (fin a) + (fin b) :=
+  fun x =>
+    match lt_dec (snd (proj1_sig x)) (length a) with
+    | left Pf => inl (exist _ (proj1_sig x) _)
+    | right Pf => inr (exist _ (fst (proj1_sig x),(snd (proj1_sig x) - length a)) _)
+    end.
+Next Obligation.
+  destruct x as [[] ?]; cbn in *; rewrite nth_error_app1 in e; auto.
+Defined.
+Next Obligation.
+  destruct x as [[] ?]; cbn in *; rewrite nth_error_app2 in e; auto with arith.
+  generalize Pf; intros H; apply not_lt in H; auto.
+Defined.
+
+(* Might want this to compute *)
+Lemma nth_error_mono_l: forall {A} (l l': list A) n x,
+    nth_error l n = Some x ->
+    nth_error (l ++ l') n = Some x.
+Proof.
+  induction l as [| a l IH]; cbn; intros l' n x H.
+  - rewrite nth_error_nil in H; inversion H.
+  - destruct n as [| n]; cbn in *; auto.
+Defined.
+
+Lemma nth_error_mono_r: forall {A} (l l': list A) n x,
+    nth_error l' n = Some x ->
+    nth_error (l ++ l') (length l + n) = Some x.
+Proof.
+  induction l as [| a l IH]; cbn; intros l' n x H; auto.
+Defined.
+
+Definition L (a b: list block_id): fin a -> fin (a ++ b) :=
+  fun x =>
+    match x with
+    | exist (x,n) pf => exist _ (x,n) (nth_error_mono_l _ _ _ _ pf)
+    end.
+
+Definition R (a b: list block_id): fin b -> fin (a ++ b).
+  intros [[] ?].
+  refine (exist _ (b0, length a + n) _).
+  apply nth_error_mono_r; assumption.
+Defined.
+
+Definition merge_fin_sum (a b: list block_id) : fin a + fin b -> fin (a ++ b) :=
+  fun v =>
+    match v with
+    | inl v => L a b v
+    | inr v => R a b v
+    end.
+
+Lemma nth_error_unique: forall {A: Type}
+                          (eqdec: forall x y : A, {x = y} + {x <> y})
+                          n (l: list A) x
+                          (wit1 wit2: nth_error l n = Some x),
+    wit1 = wit2.
+Proof.
+  induction n as [| n IH]; cbn; intros.
+  - destruct l; cbn in *.
+    inv wit1.
+    inversion wit1.
+    subst.
+    apply Eqdep_dec.UIP_dec.
+    decide equality.
+  - destruct l; [inversion wit1 |].
+    apply IH.
+Qed.
+
+Lemma unique_fin : forall n (i j : fin n),
+    proj1_sig i = proj1_sig j -> i = j.
+Proof.
+  intros ? [] [] w. simpl in w; destruct w. f_equal.
+  apply nth_error_unique.
+  apply RawIDOrd.eq_dec.
+Qed.
+
+Require Import Lia.
+
+Lemma merge_split:
+  forall (a b: list block_id) (x : fin (a ++ b)),
+    merge_fin_sum a b (split_fin_sum a b x) = x.
+Proof.
+  intros a b [[] Pf]. unfold split_fin_sum; simpl.
+  destruct (lt_dec n (length a)) eqn:EQ.
+  - cbn; apply unique_fin; reflexivity.
+  - cbn; apply unique_fin.
+    cbn; generalize n0; intros ineq; apply not_lt in ineq.
+    f_equal.
+    lia.
+Qed.
+
+Lemma split_merge:
+  forall (a b : list block_id) (x : fin a + fin b), split_fin_sum a b (merge_fin_sum a b x) = x.
+Proof.
+  intros a b [[] | []]; unfold split_fin_sum; destruct x as [bk k]; cbn in *.
+  - destruct lt_dec; cbn.
+    f_equal; apply unique_fin; simpl; reflexivity.
+    exfalso; cbn in *; apply nth_error_in in e; lia.
+  - destruct lt_dec; cbn.
+    exfalso; cbn in *; apply nth_error_in in e; lia.
+    f_equal; apply unique_fin; simpl.
+    f_equal; lia.
+Qed.
+
+Instance ToBifunctor_ktree_fin {E} : ToBifunctor (ktree E) fin sum (@app _) :=
+  fun n m y => Ret (split_fin_sum n m y).
+
+Instance FromBifunctor_ktree_fin {E} : FromBifunctor (ktree E) fin sum (@app _) :=
+  fun n m y => Ret (merge_fin_sum n m y).
+
+Instance IsoBif_ktree_fin {E}
+  : forall a b, Iso (ktree E) (a := fin (app a b)) to_bif from_bif.
+Proof.
+  unfold to_bif, ToBifunctor_ktree_fin, from_bif, FromBifunctor_ktree_fin.
+  constructor; intros x.
+  - unfold cat, Cat_sub, Cat_Kleisli. cbn. rewrite bind_ret_l.
+    apply eqit_Ret, merge_split.
+  - unfold cat, Cat_sub, Cat_Kleisli. cbn. rewrite bind_ret_l.
+    apply eqit_Ret, split_merge.
+Qed.
+
+Instance ToBifunctor_Fun_fin : ToBifunctor Fun fin sum (@app _) :=
+  fun n m y => split_fin_sum n m y.
+
+Instance FromBifunctor_Fun_fin : FromBifunctor Fun fin sum (@app _) :=
+  fun n m y => merge_fin_sum n m y.
+
+Instance IsoBif_Fun_fin
+  : forall a b, Iso Fun (a := fin (app a b)) to_bif from_bif.
+Proof.
+  constructor; intros x.
+  - apply merge_split.
+  - apply split_merge.
+Qed.
+
+Instance InitialObject_ktree_fin {E} : InitialObject (sub (ktree E) fin) [].
+Proof.
+  intros n f x; apply fin_nil; auto.
+Qed.


### PR DESCRIPTION
This ongoing PR attempts to address #125. 

It currently introduces  a data-type of open-cfg that explicitly carries an input and output interface that controls in particular when the denotation should re-entry the loop and when it should return the computed label.

In contrast to the [asm] language from the itree tutorial, the returned type of the denotation is less precise: it is not explicit that it can only return a label that belongs to the output interface. This will have to be compensated with invariants.

Symmetrically, the denotation can be called on any label. It is slightly unclear whether it should fail or behave as the identity over labels that are not in the input interface. It might not matter.

It is at the moment slightly unclear what should be done with respect to phi-nodes: the current scheme denoting the future ones at the end of the body of the loop is invalid.

The next steps are to figure out which combinators over [open_cfg] we want and prove them correct.