### PR TITLE
Moving the potential failure in conversion from tle to mcfg down to the parser?

### DIFF
--- a/src/coq/TopLevelRefinements.v
+++ b/src/coq/TopLevelRefinements.v
@@ -386,30 +386,30 @@ Theorem interpreter_sound: forall p, model p (interpreter p).
 Proof.
   intros p.
   unfold model, model_user, lift_sem_to_mcfg.
-  flatten_goal.
-  2:{
-    unfold interpreter, interpreter_user.
-    rewrite Heq.
-    admit.
-  }
-  unfold interpreter, interpreter_user; rewrite Heq.
-  unfold interp_vellvm_model_user, interp_vellvm_exec_user.
-  match goal with |- model_UB _ (interp_UB ?t) => exists t end.
-  split.
-  2:{
+  (* flatten_goal. *)
+  (* 2:{ *)
+  (*   unfold interpreter, interpreter_user. *)
+  (*   rewrite Heq. *)
+  (*   admit. *)
+  (* } *)
+  (* unfold interpreter, interpreter_user; rewrite Heq. *)
+  (* unfold interp_vellvm_model_user, interp_vellvm_exec_user. *)
+  (* match goal with |- model_UB _ (interp_UB ?t) => exists t end. *)
+  (* split. *)
+  (* 2:{ *)
 
-    fold_L3.
-    apply interp_prop_correct_exec.
-    intros.
-    subst.
-    destruct e as [|e]; cbn; [reflexivity|].
-    destruct e; cbn; [constructor | reflexivity].
-  }
-  fold_L3.
-  apply interp_prop_correct_exec.
-  intros.
-  destruct e as [|e]; cbn; [reflexivity|].
-  destruct e; cbn; [|reflexivity].
+  (*   fold_L3. *)
+  (*   apply interp_prop_correct_exec. *)
+  (*   intros. *)
+  (*   subst. *)
+  (*   destruct e as [|e]; cbn; [reflexivity|]. *)
+  (*   destruct e; cbn; [constructor | reflexivity]. *)
+  (* } *)
+  (* fold_L3. *)
+  (* apply interp_prop_correct_exec. *)
+  (* intros. *)
+  (* destruct e as [|e]; cbn; [reflexivity|]. *)
+  (* destruct e; cbn; [|reflexivity]. *)
 
   (* Remains to prove refinement of pick handlers.
      Currently ~untrue due to the predicate

--- a/src/coq/Transformations/Transform.v
+++ b/src/coq/Transformations/Transform.v
@@ -38,10 +38,11 @@ Definition mangle_instr (i:instr_id * instr T) : (instr_id * instr T) :=
 Definition mangle_block (blk:block T) : block T :=
   blk.
 
-Definition mangle_blocks (blks:list (block T)) : list (block T) :=
-  List.map mangle_block blks.
+Definition mangle_blocks (blks: block T * list (block T)) : block T * list (block T) :=
+  let '(entry, body) := blks in 
+  (mangle_block entry, List.map mangle_block body).
 
-Definition mangle_definition (d:definition T (list (block T))) : definition T (list (block T)) :=
+Definition mangle_definition (d:definition T (block T * list (block T))) : definition T (block T * list (block T)) :=
   mk_definition _
   (df_prototype d)
   (df_args d)
@@ -49,13 +50,13 @@ Definition mangle_definition (d:definition T (list (block T))) : definition T (l
 .
 
 
-Definition mangle_toplevel_entity (tle : toplevel_entity T (list (block T))) : toplevel_entity T (list (block T)) :=
+Definition mangle_toplevel_entity (tle : toplevel_entity T (block T * list (block T))) : toplevel_entity T (block T * list (block T)) :=
   match tle with
   | TLE_Definition d => TLE_Definition (mangle_definition d)
   | _ => tle
   end.
 
-Definition transform (prog: list (toplevel_entity T (list (block T)))) : list (toplevel_entity T (list (block T))) :=
+Definition transform (prog: list (toplevel_entity T (block T * list (block T)))) : list (toplevel_entity T (block T * list (block T))) :=
   List.map mangle_toplevel_entity prog.
 
 End WithT.

--- a/src/ml/ast_printer.ml
+++ b/src/ml/ast_printer.ml
@@ -539,14 +539,14 @@ and texp ppf (t, v) = fprintf ppf "(%a, %a)" typ t exp v
 
 and tident ppf (t, v) = fprintf ppf "(%a, %a)" typ t ident v
 
-and toplevel_entities : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entities -> unit =
+and toplevel_entities : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entities -> unit =
   fun ppf entries ->
     pp_print_string ppf "[";
     pp_print_list ~pp_sep:(fun ppf () -> pp_sc_space ppf (); pp_force_newline ppf ()) toplevel_entity ppf entries;
     pp_print_string ppf "].";
     pp_print_flush ppf ();
 
-and toplevel_entity : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity -> unit =
+and toplevel_entity : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity -> unit =
   fun ppf ->
   function
   | TLE_Comment msg            -> fprintf ppf "TLE_Comment %s" (of_str msg)
@@ -783,7 +783,7 @@ and declaration : Format.formatter -> (LLVMAst.typ LLVMAst.declaration) -> unit 
 
     pp_close_box ppf ();
 
-and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.definition -> unit =
+and definition : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block list))) LLVMAst.definition -> unit =
   fun ppf ->
   fun { df_prototype = df
       ; df_args = args
@@ -808,8 +808,10 @@ and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block l
     pp_print_string ppf "  df_instrs := [";
     pp_open_box ppf 0;
     pp_force_newline ppf ();
+    block ppf (fst ins); 
+    pp_force_newline ppf ();
     pp_print_list ~pp_sep:(fun ppf () -> pp_print_string ppf ";"; pp_force_newline ppf ())
-      block ppf ins ;
+      block ppf (snd ins) ;
     pp_print_string ppf "]";
     pp_force_newline ppf ();
 
@@ -859,7 +861,7 @@ and block : Format.formatter -> LLVMAst.typ LLVMAst.block -> unit =
 
     pp_print_string ppf "|}";
 
-and modul : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.modul -> unit =
+and modul : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block list))) LLVMAst.modul -> unit =
   fun ppf m ->
 
   pp_option ppf (fun ppf x -> fprintf ppf "; ModuleID = '%s'" (of_str x)) m.m_name ;

--- a/src/ml/driver.ml
+++ b/src/ml/driver.ml
@@ -14,8 +14,8 @@ let of_str = Camlcoq.camlstring_of_coqstring
 
 let interpret = ref false
 
-let transform (prog : (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity list)
-  : (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.toplevel_entity list =
+let transform (prog : (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity list)
+  : (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block list))) LLVMAst.toplevel_entity list =
   Transform.transform prog
 
 let print_banner s =

--- a/src/ml/libvellvm/interpreter.ml
+++ b/src/ml/libvellvm/interpreter.ml
@@ -93,5 +93,5 @@ let rec step (m : ('a TopLevel.IO.coq_L5, TopLevel.TopLevelEnv.memory * ((TopLev
        *   step (k (Obj.magic (DV.DVALUE_I64 DynamicValues.Int64.zero))) *)
 
 
-let interpret (prog:(LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity list) : (DV.uvalue, string) result =
+let interpret (prog:(LLVMAst.typ, (LLVMAst.typ LLVMAst.block * (LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity list) : (DV.uvalue, string) result =
   step (TopLevel.TopLevelEnv.interpreter prog)

--- a/src/ml/libvellvm/interpreter.mli
+++ b/src/ml/libvellvm/interpreter.mli
@@ -5,7 +5,7 @@ val pp_addr : Format.formatter -> Memory.A.addr -> unit
 
 val pp_uvalue : Format.formatter -> DV.uvalue -> unit
 
-val interpret: ((LLVMAst.typ, (LLVMAst.typ LLVMAst.block) list) LLVMAst.toplevel_entity) list -> (DV.uvalue, string) result
+val interpret: ((LLVMAst.typ, LLVMAst.typ LLVMAst.block * (LLVMAst.typ LLVMAst.block) list) LLVMAst.toplevel_entity) list -> (DV.uvalue, string) result
 
 (* SAZ: do we need to expose the step function in this way?  Its type is very complicated *)
 (* val step : ((Obj.t Std.failureE, Obj.t debugE, 'b) Sum.sum1, DV.dvalue) coq_LLVM -> (TopLevel.IO.DV.dvalue, string) result *)

--- a/src/ml/libvellvm/llvm_printer.ml
+++ b/src/ml/libvellvm/llvm_printer.ml
@@ -588,11 +588,11 @@ and texp ppf (t, v) = fprintf ppf "%a %a" typ t exp v
 
 and tident ppf (t, v) = fprintf ppf "%a %a" typ t ident v
 
-and toplevel_entities : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entities -> unit =
+and toplevel_entities : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entities -> unit =
   fun ppf entries ->
   pp_print_list ~pp_sep:pp_force_newline toplevel_entity ppf entries
 
-and toplevel_entity : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity -> unit =
+and toplevel_entity : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity -> unit =
   fun ppf ->
   function
   | TLE_Comment msg            -> fprintf ppf "; %s" (of_str msg)
@@ -693,7 +693,7 @@ and declaration : Format.formatter -> (LLVMAst.typ LLVMAst.declaration) -> unit 
     (match dc_gc with
        Some x -> fprintf ppf "gc \"%s\" " (of_str x) | _ -> ())
 
-and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.definition -> unit =
+and definition : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block list))) LLVMAst.definition -> unit =
   fun ppf ->
   fun ({ df_prototype =
            { dc_name = i
@@ -752,7 +752,9 @@ and definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block l
        Some x -> fprintf ppf "gc \"%s\" " (of_str x) | _ -> ()) ;
     pp_print_char ppf '{' ;
     pp_force_newline ppf () ;
-    pp_print_list ~pp_sep:pp_force_newline block ppf df.df_instrs ;
+    block ppf (fst df.df_instrs);
+    pp_force_newline ppf () ;
+    pp_print_list ~pp_sep:pp_force_newline block ppf (snd df.df_instrs) ;
     pp_force_newline ppf () ;
     pp_print_char ppf '}' ;
 
@@ -781,7 +783,7 @@ and block : Format.formatter -> LLVMAst.typ LLVMAst.block -> unit =
 and comment : Format.formatter -> char list -> unit =
   fun ppf s -> fprintf ppf "; %s" (of_str s)
 
-and modul : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block list))) LLVMAst.modul -> unit =
+and modul : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block list))) LLVMAst.modul -> unit =
   fun ppf m ->
 
   pp_option ppf (fun ppf x -> fprintf ppf "; ModuleID = '%s'" (of_str x)) m.m_name ;

--- a/src/ml/libvellvm/llvm_printer.mli
+++ b/src/ml/libvellvm/llvm_printer.mli
@@ -20,11 +20,11 @@ val exp : Format.formatter -> LLVMAst.typ LLVMAst.exp -> unit
 val texp : Format.formatter -> LLVMAst.typ LLVMAst.texp -> unit
 val tident : Format.formatter -> LLVMAst.typ LLVMAst.tident -> unit
 val toplevel_entities :
-  Format.formatter -> (LLVMAst.typ , ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entities -> unit
-val toplevel_entity : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity -> unit
+  Format.formatter -> (LLVMAst.typ , (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entities -> unit
+val toplevel_entity : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entity -> unit
 val metadata : Format.formatter -> LLVMAst.typ LLVMAst.metadata -> unit
 val global : Format.formatter -> LLVMAst.typ LLVMAst.global -> unit
 val declaration : Format.formatter -> LLVMAst.typ LLVMAst.declaration -> unit
-val definition : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.definition -> unit
+val definition : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.definition -> unit
 val block : Format.formatter -> (LLVMAst.typ LLVMAst.block) -> unit
-val modul : Format.formatter -> (LLVMAst.typ, ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.modul -> unit
+val modul : Format.formatter -> (LLVMAst.typ, (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.modul -> unit


### PR DESCRIPTION
@Zdancewic This does not address at all the interesting semantics questions that we were discussing this afternoon, but do you thing that such a change would be sensible? 

This patch is partial, it needs some OCaml code. But basically it is simply enforcing the parser to output pairs of a block and a list of block, the former being the initial block of the cfg, so that on the Coq side the conversion between toplevel entities and mcfg can be total.

The change is cosmetic, but would allow for cleaner lemmas to manipulate the toplevel semantics I think.