### PR TITLE
updated ocaml versioning requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ University of Pennsylvania as part of the DeepSpec project.
     - itree      ~~(installed via, e.g. opam install coq-itree)~~
       - Currently you should actually just use the submodule (lib/InteractionTrees): see the instructions for compilation below.
     - ceres      (installed via, e.g. opam install coq-ceres)
-- ocamlc : version 4.04    (probably works with 4.03 or later)
+- ocamlc : version 4.07 or above
   - OPAM packages: dune, menhir, [optional: llvm  (for llvm v. 3.8)]
 
 Compilation:


### PR DESCRIPTION
Building vellvm tests uses Stdlib, but Stdlib is only in OCaml versions 4.07.0 or above.  (See `src/ml/test.ml`) and ![OCaml release 4.07.0](https://ocaml.org/releases/4.07.0.html).