### PR TITLE
Simplification of the intrinsics

### DIFF
--- a/src/coq/Semantics/DynamicValues.v
+++ b/src/coq/Semantics/DynamicValues.v
@@ -666,7 +666,6 @@ Section DecidableEquality.
     | _, _ => false
     end.
 
-
   Lemma dvalue_eq_dec : forall (d1 d2:dvalue), {d1 = d2} + {d1 <> d2}.
     refine (fix f d1 d2 :=
     let lsteq_dec := list_eq_dec f in
@@ -724,6 +723,178 @@ Section DecidableEquality.
   Global Instance eq_dec_dvalue : RelDec (@eq dvalue) := RelDec_from_dec (@eq dvalue) (@dvalue_eq_dec).
   Global Instance eqv_dvalue : Eqv dvalue := (@eq dvalue).
   Hint Unfold eqv_dvalue : core.
+
+	Lemma dtyp_eq_dec : forall (t1 t2:dtyp), {t1 = t2} + {t1 <> t2}.
+    refine (fix f t1 t2 :=
+              let lsteq_dec := list_eq_dec f in
+              match t1, t2 with
+              | DTYPE_I n, DTYPE_I m => _
+              | DTYPE_Pointer, DTYPE_Pointer => _
+              | DTYPE_Void, DTYPE_Void => _
+              | DTYPE_Half, DTYPE_Half => _
+              | DTYPE_Float, DTYPE_Float => _
+              | DTYPE_Double, DTYPE_Double => _
+              | DTYPE_Fp128, DTYPE_Fp128 => _
+              | DTYPE_X86_fp80, DTYPE_X86_fp80 => _
+              | DTYPE_Ppc_fp128, DTYPE_Ppc_fp128 => _
+              | DTYPE_Metadata, DTYPE_Metadata => _
+              | DTYPE_X86_mmx, DTYPE_X86_mmx => _
+              | DTYPE_Array n t, DTYPE_Array m t' => _
+              | DTYPE_Struct l, DTYPE_Struct l' => _
+              | DTYPE_Packed_struct l, DTYPE_Packed_struct l' => _
+              | DTYPE_Opaque, DTYPE_Opaque => _
+              | DTYPE_Vector n t, DTYPE_Vector m t' => _
+              | _, _ => _
+              end); try (ltac:(dec_dvalue); fail).
+    - destruct (N.eq_dec n m).
+      * left; subst; reflexivity.
+      * right; intros H; inversion H. contradiction.
+    - destruct (N.eq_dec n m).
+      * destruct (f t t').
+      + left; subst; reflexivity.
+      + right; intros H; inversion H. contradiction.
+        * right; intros H; inversion H. contradiction.
+    - destruct (lsteq_dec l l').
+      * left; subst; reflexivity.
+      * right; intros H; inversion H. contradiction.
+    - destruct (lsteq_dec l l').
+      * left; subst; reflexivity.
+      * right; intros H; inversion H. contradiction.
+    - destruct (N.eq_dec n m).
+      * destruct (f t t').
+      + left; subst; reflexivity.
+      + right; intros H; inversion H. contradiction.
+        * right; intros H; inversion H. contradiction.
+  Qed.
+  Arguments dtyp_eq_dec: clear implicits.
+
+ Lemma ibinop_eq_dec : forall (op1 op2:ibinop), {op1 = op2} + {op1 <> op2}.
+    intros.
+    repeat decide equality.
+  Qed.
+
+  Lemma fbinop_eq_dec : forall (op1 op2:fbinop), {op1 = op2} + {op1 <> op2}.
+    intros.
+    repeat decide equality.
+  Qed.
+
+  Lemma icmp_eq_dec : forall (op1 op2:icmp), {op1 = op2} + {op1 <> op2}.
+    intros.
+    repeat decide equality.
+  Qed.
+
+  Lemma fcmp_eq_dec : forall (op1 op2:fcmp), {op1 = op2} + {op1 <> op2}.
+    intros.
+    repeat decide equality.
+  Qed.
+
+  Lemma fast_math_eq_dec : forall (op1 op2:fast_math), {op1 = op2} + {op1 <> op2}.
+    intros.
+    repeat decide equality.
+  Qed.
+
+  Lemma conversion_type_eq_dec : forall (op1 op2:conversion_type), {op1 = op2} + {op1 <> op2}.
+    intros.
+    repeat decide equality.
+  Qed.
+
+  Arguments ibinop_eq_dec: clear implicits.
+  Arguments fbinop_eq_dec: clear implicits.
+  Arguments icmp_eq_dec: clear implicits.
+  Arguments fcmp_eq_dec: clear implicits.
+  Arguments fast_math_eq_dec: clear implicits.
+  Arguments conversion_type_eq_dec: clear implicits.
+
+  Ltac __abs := right; intros H; inversion H; contradiction.
+  Ltac __eq := left; subst; reflexivity.
+
+  Lemma uvalue_eq_dec : forall (u1 u2:uvalue), {u1 = u2} + {u1 <> u2}.
+  Proof with (try (__eq || __abs)).
+    refine (fix f u1 u2 :=
+              let lsteq_dec := list_eq_dec f in
+              match u1, u2 with
+              | UVALUE_Addr a1, UVALUE_Addr a2 => _
+              | UVALUE_I1 x1, UVALUE_I1 x2 => _
+              | UVALUE_I8 x1, UVALUE_I8 x2 => _
+              | UVALUE_I32 x1, UVALUE_I32 x2 => _
+              | UVALUE_I64 x1, UVALUE_I64 x2 => _
+              | UVALUE_Double x1, UVALUE_Double x2 => _
+              | UVALUE_Float x1, UVALUE_Float x2 => _
+              | UVALUE_Undef t1, UVALUE_Undef t2 => _
+              | UVALUE_Poison, UVALUE_Poison => _
+              | UVALUE_None, UVALUE_None => _
+              | UVALUE_Struct f1, UVALUE_Struct f2 => _
+              | UVALUE_Packed_struct f1, UVALUE_Packed_struct f2 => _
+              | UVALUE_Array f1, UVALUE_Array f2 => _
+              | UVALUE_Vector f1, UVALUE_Vector f2 => _
+              | UVALUE_IBinop op uv1 uv2, UVALUE_IBinop op' uv1' uv2' => _
+              | UVALUE_ICmp op uv1 uv2, UVALUE_ICmp op' uv1' uv2' => _
+              | UVALUE_FBinop op fm uv1 uv2, UVALUE_FBinop op' fm' uv1' uv2' => _
+              | UVALUE_FCmp op uv1 uv2, UVALUE_FCmp op' uv1' uv2' => _
+              | UVALUE_Conversion ct u t, UVALUE_Conversion ct' u' t' => _
+              | UVALUE_GetElementPtr t u l, UVALUE_GetElementPtr t' u' l' => _
+              | UVALUE_ExtractElement u v, UVALUE_ExtractElement u' v' => _
+              | UVALUE_InsertElement u v t, UVALUE_InsertElement u' v' t' => _
+              | UVALUE_ShuffleVector u v t, UVALUE_ShuffleVector u' v' t' => _
+              | UVALUE_ExtractValue u l, UVALUE_ExtractValue u' l' => _
+              | UVALUE_InsertValue u v l, UVALUE_InsertValue u' v' l' => _
+              | UVALUE_Select u v t, UVALUE_Select u' v' t' => _
+              | _, _ => _
+              end); try (ltac:(dec_dvalue); fail).
+    - destruct (A.eq_dec a1 a2)...
+    - destruct (Int1.eq_dec x1 x2)...
+    - destruct (Int8.eq_dec x1 x2)...
+    - destruct (Int32.eq_dec x1 x2)...
+    - destruct (Int64.eq_dec x1 x2)...
+    - destruct (Float.eq_dec x1 x2)...
+    - destruct (Float32.eq_dec x1 x2)...
+    - destruct (dtyp_eq_dec t1 t2)...
+    - destruct (lsteq_dec f1 f2)...
+    - destruct (lsteq_dec f1 f2)...
+    - destruct (lsteq_dec f1 f2)...
+    - destruct (lsteq_dec f1 f2)...
+    - destruct (ibinop_eq_dec op op')...
+      destruct (f uv1 uv1')...
+      destruct (f uv2 uv2')...
+    - destruct (icmp_eq_dec op op')...
+      destruct (f uv1 uv1')...
+      destruct (f uv2 uv2')...
+    - destruct (fbinop_eq_dec op op')...
+      destruct (list_eq_dec fast_math_eq_dec fm fm')...
+      destruct (f uv1 uv1')...
+      destruct (f uv2 uv2')...
+    - destruct (fcmp_eq_dec op op')...
+      destruct (f uv1 uv1')...
+      destruct (f uv2 uv2')...
+    - destruct (conversion_type_eq_dec ct ct')...
+      destruct (f u u')...
+      destruct (dtyp_eq_dec t t')...
+    - destruct (dtyp_eq_dec t t')...
+      destruct (f u u')...
+      destruct (lsteq_dec l l')...
+    - destruct (f u u')...
+      destruct (f v v')...
+    - destruct (f u u')...
+      destruct (f v v')...
+      destruct (f t t')...
+    - destruct (f u u')...
+      destruct (f v v')...
+      destruct (f t t')...
+    - destruct (f u u')...
+      destruct (list_eq_dec Int.eq_dec l l')...
+    - destruct (f u u')...
+      destruct (f v v')...
+      destruct (list_eq_dec Int.eq_dec l l')...
+    - destruct (f u u')...
+      destruct (f v v')...
+      destruct (f t t')...
+  Qed.
+
+  Global Instance eq_dec_uvalue : RelDec (@eq uvalue) := RelDec_from_dec (@eq uvalue) (@uvalue_eq_dec).
+  Global Instance eqv_uvalue : Eqv uvalue := (@eq uvalue).
+  Hint Unfold eqv_uvalue : core.
+  Global Instance eq_dec_uvalue_correct: @RelDec.RelDec_Correct uvalue (@Logic.eq uvalue) _ := _.
+
 End DecidableEquality.
 
 (* TODO: include Undefined values in this way? i.e. Undef is really a predicate on values

--- a/src/coq/Semantics/TopLevel.v
+++ b/src/coq/Semantics/TopLevel.v
@@ -199,21 +199,20 @@ Definition denote_vellvm_main (mcfg : CFG.mcfg dtyp) : itree L0 uvalue :=
      Now that we know how to denote a whole llvm program, we can _interpret_
      the resulting [itree].
  *)
-Definition interpreter_user
+Definition interpreter_gen
            (ret_typ : dtyp)
            (entry : string)
            (args : list uvalue)
-           (user_intrinsics: intrinsic_definitions)
            (prog: list (toplevel_entity typ (block typ * list (block typ))))
   : itree L5 res_L4 :=
   let t := denote_vellvm ret_typ entry args (convert_types (mcfg_of_tle prog)) in
-  interp_to_L5_exec user_intrinsics t [] ([],[]) empty_memory_stack.
+  interp_to_L5_exec t [] ([],[]) empty_memory_stack.
 
 (**
      Finally, the reference interpreter assumes no user-defined intrinsics and starts 
      from "main" using bogus initial inputs.
  *)
-Definition interpreter := interpreter_user (DTYPE_I 32%N) "main" main_args [].
+Definition interpreter := interpreter_gen (DTYPE_I 32%N) "main" main_args.
 
 (**
      We now turn to the definition of our _model_ of vellvm's semantics. The
@@ -230,14 +229,13 @@ Definition model_user
            (ret_typ : dtyp)
            (entry : string)
            (args : list uvalue)
-           (user_intrinsics: IS.intrinsic_definitions)
            (prog: list (toplevel_entity typ (block typ * list (block typ))))
   : PropT L5 (memory_stack * (local_env * lstack * (global_env * uvalue))) :=
   let t := denote_vellvm ret_typ entry args (convert_types (mcfg_of_tle prog)) in
-  interp_to_L5 Logic.eq user_intrinsics t [] ([],[]) empty_memory_stack. 
+  interp_to_L5 Logic.eq t [] ([],[]) empty_memory_stack. 
 
 (**
      Finally, the official model assumes no user-defined intrinsics.
  *)
-Definition model := model_user (DTYPE_I 32%N) "main" main_args [].
+Definition model := model_user (DTYPE_I 32%N) "main" main_args.
 

--- a/src/coq/Theory/ExpLemmas.v
+++ b/src/coq/Theory/ExpLemmas.v
@@ -69,9 +69,9 @@ Section Translations.
   
 End Translations.
 
-Lemma denote_exp_GR :forall defs g l m id v τ,
+Lemma denote_exp_GR :forall g l m id v τ,
     Maps.lookup id g = Some v ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) (EXP_Ident (ID_Global id)))) g l m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) (EXP_Ident (ID_Global id)))) g l m
     ≈
     Ret (m,(l,(g,dvalue_to_uvalue v))).
 Proof.
@@ -88,9 +88,9 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma denote_exp_LR :forall defs g l m id v τ,
+Lemma denote_exp_LR :forall g l m id v τ,
     Maps.lookup id l = Some v ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) (EXP_Ident (ID_Local id)))) g l m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) (EXP_Ident (ID_Local id)))) g l m
     ≈
     Ret (m,(l,(g,v))).
 Proof.
@@ -121,8 +121,8 @@ Proof.
   cbn.  lia.
 Qed.
 
-Lemma denote_exp_i64 :forall defs t g l m,
-    interp_cfg_to_L3 defs
+Lemma denote_exp_i64 :forall t g l m,
+    interp_cfg_to_L3
                      (translate exp_E_to_instr_E
                                 (denote_exp (Some (DTYPE_I 64))
                                             (EXP_Integer (Integers.Int64.intval t))))
@@ -135,8 +135,8 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma denote_exp_i64_repr :forall defs t g l m,
-    interp_cfg_to_L3 defs
+Lemma denote_exp_i64_repr :forall t g l m,
+    interp_cfg_to_L3
                      (translate exp_E_to_instr_E
                                 (denote_exp (Some (DTYPE_I 64))
                                             (EXP_Integer t)))
@@ -149,8 +149,8 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma denote_exp_double :forall defs t g l m,
-    interp_cfg_to_L3 defs
+Lemma denote_exp_double :forall t g l m,
+    interp_cfg_to_L3
                      (translate exp_E_to_instr_E
                                 (denote_exp (Some DTYPE_Double)
                                             (EXP_Double t)))
@@ -164,19 +164,19 @@ Proof.
 Qed.
 
 Lemma denote_conversion_concrete :
-  forall (conv : conversion_type) τ1 τ2 e g ρ m x a av defs,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ1) e)) g ρ m
+  forall (conv : conversion_type) τ1 τ2 e g ρ m x a av,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ1) e)) g ρ m
     ≈
     Ret (m, (ρ, (g, a)))
     ->
     uvalue_to_dvalue a = inr av ->
     eval_conv conv τ1 av τ2  = ret x ->
-    interp_cfg_to_L3 defs
+    interp_cfg_to_L3
    (translate exp_E_to_instr_E
       (denote_exp None
          (OP_Conversion conv τ1 e τ2))) g ρ m ≈ Ret (m, (ρ, (g, (dvalue_to_uvalue x)))).
 Proof.
-  intros conv τ1 τ2 e g ρ m x a av defs A AV EVAL.
+  intros conv τ1 τ2 e g ρ m x a av A AV EVAL.
 
   cbn.
   rewrite translate_bind.
@@ -257,18 +257,18 @@ Proof.
 Qed.
 
 Lemma denote_ibinop_concrete :
-  forall (op : ibinop) τ e0 e1 g ρ m x a av b bv defs,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) e0)) g ρ m
+  forall (op : ibinop) τ e0 e1 g ρ m x a av b bv,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) e0)) g ρ m
     ≈
     Ret (m, (ρ, (g, a)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) e1)) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) e1)) g ρ m
     ≈
     Ret (m, (ρ, (g, b))) ->
     uvalue_to_dvalue a = inr av ->
     uvalue_to_dvalue b = inr bv ->
     eval_iop op av bv  = ret x ->
-    interp_cfg_to_L3 defs
+    interp_cfg_to_L3
     (translate exp_E_to_instr_E
       (denote_exp None
          (OP_IBinop op τ e0 e1))) g ρ m ≈ Ret (m, (ρ, (g, (dvalue_to_uvalue x)))).
@@ -305,19 +305,19 @@ Proof.
 Qed.
 
 Lemma denote_fbinop_concrete :
-  forall (op : fbinop) τ e0 e1 g ρ m x a av b bv defs params,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) e0)) g ρ m
+  forall (op : fbinop) τ e0 e1 g ρ m x a av b bv params,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) e0)) g ρ m
     ≈ 
     Ret (m, (ρ, (g, a)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) e1)) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) e1)) g ρ m
     ≈
     Ret (m, (ρ, (g, b)))
     ->
     uvalue_to_dvalue a = inr av ->
     uvalue_to_dvalue b = inr bv ->
     eval_fop op av bv  = ret x ->
-   interp_cfg_to_L3 defs
+   interp_cfg_to_L3
    (translate exp_E_to_instr_E
       (denote_exp None
          (OP_FBinop op params τ e0 e1))) g ρ m ≈ Ret (m, (ρ, (g, (dvalue_to_uvalue x)))).
@@ -354,19 +354,19 @@ Proof.
 Qed.
 
 Lemma denote_fcmp_concrete :
-  forall (op : fcmp) τ e0 e1 g ρ m x a av b bv defs,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) e0)) g ρ m
+  forall (op : fcmp) τ e0 e1 g ρ m x a av b bv,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) e0)) g ρ m
     ≈
     Ret (m, (ρ, (g, a)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) e1)) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) e1)) g ρ m
     ≈
     Ret (m, (ρ, (g, b)))
     ->
     uvalue_to_dvalue a = inr av ->
     uvalue_to_dvalue b = inr bv ->
     eval_fcmp op av bv  = ret x ->
-    interp_cfg_to_L3 defs
+    interp_cfg_to_L3
     (translate exp_E_to_instr_E
       (denote_exp None
          (OP_FCmp op τ e0 e1))) g ρ m ≈ Ret (m, (ρ, (g, (dvalue_to_uvalue x)))).
@@ -399,19 +399,19 @@ Proof.
 Qed.
 
 Lemma denote_icmp_concrete :
-  forall (op : icmp) τ e0 e1 g ρ m x a av b bv defs,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) e0)) g ρ m
+  forall (op : icmp) τ e0 e1 g ρ m x a av b bv,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) e0)) g ρ m
     ≈
     Ret (m, (ρ, (g, a)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τ) e1)) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τ) e1)) g ρ m
     ≈
     Ret (m, (ρ, (g, b)))
     ->
     uvalue_to_dvalue a = inr av ->
     uvalue_to_dvalue b = inr bv ->
     eval_icmp op av bv  = ret x ->
-    interp_cfg_to_L3 defs
+    interp_cfg_to_L3
     (translate exp_E_to_instr_E
       (denote_exp None
          (OP_ICmp op τ e0 e1))) g ρ m ≈ Ret (m, (ρ, (g, (dvalue_to_uvalue x)))).
@@ -452,8 +452,8 @@ Definition pure {E R} (t : global_env -> local_env -> memory_stack -> itree E (m
 Require Import String.
 Opaque append.
 
-Lemma failure_is_pure : forall R s defs,
-    pure (R := R) (interp_cfg_to_L3 defs (translate exp_E_to_instr_E (raise s))).
+Lemma failure_is_pure : forall R s,
+    pure (R := R) (interp_cfg_to_L3 (translate exp_E_to_instr_E (raise s))).
 Proof.
   unfold pure, has_post, raise, Exception.throw; intros.
   rewrite translate_vis.
@@ -469,8 +469,8 @@ Proof.
   apply eutt_eq_bind; intros (_ & ? & ? & []).
 Qed.
 
-Lemma UB_is_pure : forall R s defs,
-    pure (R := R) (interp_cfg_to_L3 defs (translate exp_E_to_instr_E (raiseUB s))).
+Lemma UB_is_pure : forall R s,
+    pure (R := R) (interp_cfg_to_L3 (translate exp_E_to_instr_E (raiseUB s))).
 Proof.
   unfold pure, has_post, raiseUB; intros.
   rewrite translate_vis.
@@ -522,10 +522,10 @@ Proof.
     rewrite interp_state_ret; reflexivity.
 Qed.
 
-Lemma interp_cfg_to_L3_map_monad {A B} defs g l m (xs : list A) (ts : A -> itree _ B) : 
-  interp_cfg_to_L3 defs (map_monad ts xs) g l m ≈
+Lemma interp_cfg_to_L3_map_monad {A B} g l m (xs : list A) (ts : A -> itree _ B) : 
+  interp_cfg_to_L3 (map_monad ts xs) g l m ≈
                    map_monad (m := Monads.stateT _ (Monads.stateT _ (Monads.stateT _ (itree _))))
-                   (fun a => interp_cfg_to_L3 defs (ts a)) xs g l m.
+                   (fun a => interp_cfg_to_L3 (ts a)) xs g l m.
 Proof.
   intros; revert g l m; induction xs as [| a xs IH]; simpl; intros.
   - rewrite interp_cfg_to_L3_ret; reflexivity.
@@ -572,7 +572,7 @@ Qed.
 (*     intros [s' ?] [] [EQ ?]; inv EQ; cbn; apply eutt_Ret; auto.  *)
 (* Qed. *)
 
-Lemma expr_are_pure : forall defs o e, pure (interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp o e))).
+Lemma expr_are_pure : forall o e, pure (interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp o e))).
 Proof.
   intros; unfold pure, has_post.
   induction e; simpl; intros.

--- a/src/coq/Theory/InstrLemmas.v
+++ b/src/coq/Theory/InstrLemmas.v
@@ -33,12 +33,12 @@ Open Scope itree_scope.
 
 (* TODO: Move this *)
 Lemma interp_cfg_to_L3_concretize_or_pick_concrete :
-  forall (uv : uvalue) (dv : dvalue) P defs g ρ m,
+  forall (uv : uvalue) (dv : dvalue) P g ρ m,
     is_concrete uv ->
     uvalue_to_dvalue uv = inr dv ->
-    interp_cfg_to_L3 defs (concretize_or_pick uv P) g ρ m ≈ Ret (m, (ρ, (g, dv))).
+    interp_cfg_to_L3 (concretize_or_pick uv P) g ρ m ≈ Ret (m, (ρ, (g, dv))).
 Proof.
-  intros uv dv P defs g ρ m CONC CONV.
+  intros uv dv P g ρ m CONC CONV.
   unfold concretize_or_pick.
   rewrite CONC.
   cbn.
@@ -125,11 +125,11 @@ Qed.
 
 (* TODO: Move this *)
 Lemma interp_cfg_to_L3_concretize_or_pick_concrete_exists :
-  forall (uv : uvalue) P defs g ρ m,
+  forall (uv : uvalue) P g ρ m,
     is_concrete uv ->
-    exists dv, uvalue_to_dvalue uv = inr dv /\ interp_cfg_to_L3 defs (concretize_or_pick uv P) g ρ m ≈ Ret (m, (ρ, (g, dv))).
+    exists dv, uvalue_to_dvalue uv = inr dv /\ interp_cfg_to_L3 (concretize_or_pick uv P) g ρ m ≈ Ret (m, (ρ, (g, dv))).
 Proof.
-  intros uv P defs g ρ m CONC.
+  intros uv P g ρ m CONC.
   pose proof is_concrete_uvalue_to_dvalue uv CONC as (dv & CONV).
   exists dv.
   split; auto.
@@ -138,10 +138,10 @@ Qed.
 
 (* TODO: Move this *)
 Lemma interp_cfg_to_L3_pick :
-  forall uv P defs g ρ m,
-    interp_cfg_to_L3 defs (trigger (pick uv P)) g ρ m ≈ ITree.bind (trigger (pick uv P)) (fun dv => Ret (m, (ρ, (g, dv)))).
+  forall uv P g ρ m,
+    interp_cfg_to_L3 (trigger (pick uv P)) g ρ m ≈ ITree.bind (trigger (pick uv P)) (fun dv => Ret (m, (ρ, (g, dv)))).
 Proof.
-  intros uv P defs g ρ m.
+  intros uv P g ρ m.
   unfold interp_cfg_to_L3.
 
   rewrite interp_intrinsics_trigger.
@@ -177,11 +177,11 @@ Qed.
 
 (* TODO; Move this *)
 Lemma interp_cfg_to_L3_concretize_or_pick_not_concrete :
-  forall (uv : uvalue) (dv : dvalue) P defs g ρ m,
+  forall (uv : uvalue) (dv : dvalue) P g ρ m,
     is_concrete uv = false ->
-    interp_cfg_to_L3 defs (concretize_or_pick uv P) g ρ m ≈ ITree.bind (trigger (pick uv P)) (fun dv => Ret (m, (ρ, (g, dv)))).
+    interp_cfg_to_L3 (concretize_or_pick uv P) g ρ m ≈ ITree.bind (trigger (pick uv P)) (fun dv => Ret (m, (ρ, (g, dv)))).
 Proof.
-  intros uv dv P defs g ρ m NCONC.
+  intros uv dv P g ρ m NCONC.
   unfold concretize_or_pick.
   rewrite NCONC.
   rewrite interp_cfg_to_L3_pick.
@@ -191,12 +191,12 @@ Qed.
 (** Lemmas about denote_instr *)
 
 Lemma denote_instr_load :
-  forall (i : raw_id) volatile τ τp ptr align defs g ρ ρ' m a uv,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τp) ptr)) g ρ m ≈ Ret (m, (ρ', (g, UVALUE_Addr a))) ->
+  forall (i : raw_id) volatile τ τp ptr align g ρ ρ' m a uv,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τp) ptr)) g ρ m ≈ Ret (m, (ρ', (g, UVALUE_Addr a))) ->
     read m a τ = inr uv ->
-    interp_cfg_to_L3 defs (denote_instr (IId i, INSTR_Load volatile τ (τp, ptr) align)) g ρ m ≈ Ret (m, (Maps.add i uv ρ', (g, tt))).
+    interp_cfg_to_L3 (denote_instr (IId i, INSTR_Load volatile τ (τp, ptr) align)) g ρ m ≈ Ret (m, (Maps.add i uv ρ', (g, tt))).
 Proof.
-  intros i volatile τ τp ptr align defs g ρ ρ' m a uv EXP READ.
+  intros i volatile τ τp ptr align g ρ ρ' m a uv EXP READ.
   cbn.
   rewrite interp_cfg_to_L3_bind.
   rewrite EXP.
@@ -213,14 +213,14 @@ Proof.
 Qed.
 
 Lemma denote_instr_store :
-  forall (i : int) volatile τv val τp ptr align defs uv dv a g ρ ρ' ρ'' m m',
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τv) val)) g ρ m ≈ Ret (m, (ρ', (g, uv))) ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τp) ptr)) g ρ' m ≈ Ret (m, (ρ'', (g, UVALUE_Addr a))) ->
+  forall (i : int) volatile τv val τp ptr align uv dv a g ρ ρ' ρ'' m m',
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τv) val)) g ρ m ≈ Ret (m, (ρ', (g, uv))) ->
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τp) ptr)) g ρ' m ≈ Ret (m, (ρ'', (g, UVALUE_Addr a))) ->
     uvalue_to_dvalue uv = inr dv ->
     write m a dv = inr m' ->
-    interp_cfg_to_L3 defs (denote_instr (IVoid i, INSTR_Store volatile (τv, val) (τp, ptr) align)) g ρ m ≈ Ret (m', (ρ'', (g, tt))).
+    interp_cfg_to_L3 (denote_instr (IVoid i, INSTR_Store volatile (τv, val) (τp, ptr) align)) g ρ m ≈ Ret (m', (ρ'', (g, tt))).
 Proof.
-  intros i volatile τv val τp ptr align defs uv dv a g ρ ρ' ρ'' m m' EXP PTR CONV_UV WRITE.
+  intros i volatile τv val τp ptr align uv dv a g ρ ρ' ρ'' m m' EXP PTR CONV_UV WRITE.
   cbn.
   rewrite interp_cfg_to_L3_bind.
   rewrite EXP.
@@ -248,31 +248,31 @@ Proof.
 Qed.
 
 Lemma denote_instr_store_exists :
-  forall (i : int) volatile τv val τp ptr align defs uv dv a g ρ ρ' ρ'' m,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τv) val)) g ρ m ≈ Ret (m, (ρ', (g, uv))) ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some τp) ptr)) g ρ' m ≈ Ret (m, (ρ'', (g, UVALUE_Addr a))) ->
+  forall (i : int) volatile τv val τp ptr align uv dv a g ρ ρ' ρ'' m,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τv) val)) g ρ m ≈ Ret (m, (ρ', (g, uv))) ->
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some τp) ptr)) g ρ' m ≈ Ret (m, (ρ'', (g, UVALUE_Addr a))) ->
     uvalue_to_dvalue uv = inr dv ->
     dvalue_has_dtyp dv τv ->
     dtyp_fits m a τv ->
     exists m',
-      write m a dv = inr m' /\ interp_cfg_to_L3 defs (denote_instr (IVoid i, INSTR_Store volatile (τv, val) (τp, ptr) align)) g ρ m ≈ Ret (m', (ρ'', (g, tt))).
+      write m a dv = inr m' /\ interp_cfg_to_L3 (denote_instr (IVoid i, INSTR_Store volatile (τv, val) (τp, ptr) align)) g ρ m ≈ Ret (m', (ρ'', (g, tt))).
 Proof.
-  intros i volatile τv val τp ptr align defs uv dv a g ρ ρ' ρ'' m EXP PTR CONV_UV TYP FITS.
+  intros i volatile τv val τp ptr align uv dv a g ρ ρ' ρ'' m EXP PTR CONV_UV TYP FITS.
   apply write_succeeds with (v:=dv) in FITS as [m2 WRITE]; auto.
   exists m2. split; auto.
   eapply denote_instr_store; eauto.
 Qed.
 
 Lemma denote_instr_alloca_exists :
-  forall (m : memory_stack) (τ : dtyp) g ρ i align nb defs,
+  forall (m : memory_stack) (τ : dtyp) g ρ i align nb,
     non_void τ ->
     exists m' a,
       allocate m τ = inr (m', a) /\
-      interp_cfg_to_L3 defs (denote_instr (IId i, INSTR_Alloca τ nb align)) g ρ m ≈ Ret (m', (Maps.add i (UVALUE_Addr a) ρ, (g, tt))).
+      interp_cfg_to_L3 (denote_instr (IId i, INSTR_Alloca τ nb align)) g ρ m ≈ Ret (m', (Maps.add i (UVALUE_Addr a) ρ, (g, tt))).
 Proof.
-  intros m τ g ρ i align nb defs NV.
+  intros m τ g ρ i align nb NV.
 
-  pose proof interp_cfg_to_L3_alloca defs m τ g ρ NV as (m' & a & ALLOC & TRIGGER).
+  pose proof interp_cfg_to_L3_alloca m τ g ρ NV as (m' & a & ALLOC & TRIGGER).
   exists m'. exists a. split; auto.
 
   cbn. rewrite interp_cfg_to_L3_bind.
@@ -283,19 +283,19 @@ Proof.
 Qed.
 
 Lemma denote_instr_comment :
-  forall i str g ρ m defs,
-    interp_cfg_to_L3 defs (denote_instr (i, INSTR_Comment str)) g ρ m ≈ Ret (m, (ρ, (g, tt))).
+  forall i str g ρ m,
+    interp_cfg_to_L3 (denote_instr (i, INSTR_Comment str)) g ρ m ≈ Ret (m, (ρ, (g, tt))).
 Proof.
-  intros i str g ρ m defs.
+  intros i str g ρ m.
   destruct i; cbn; rewrite interp_cfg_to_L3_ret; reflexivity.
 Qed.
 
 Lemma denote_instr_op :
-  forall (i : raw_id) (op : exp dtyp) defs uv g ρ ρ' m,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp None op)) g ρ m ≈ Ret (m, (ρ', (g, uv))) ->
-    interp_cfg_to_L3 defs (denote_instr (IId i, INSTR_Op op)) g ρ m ≈ Ret (m, (Maps.add i uv ρ', (g, tt))).
+  forall (i : raw_id) (op : exp dtyp) uv g ρ ρ' m,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp None op)) g ρ m ≈ Ret (m, (ρ', (g, uv))) ->
+    interp_cfg_to_L3 (denote_instr (IId i, INSTR_Op op)) g ρ m ≈ Ret (m, (Maps.add i uv ρ', (g, tt))).
 Proof.
-  intros i op defs uv g ρ ρ' m OP.
+  intros i op uv g ρ ρ' m OP.
   cbn.
   unfold denote_op.
   rewrite interp_cfg_to_L3_bind.
@@ -314,12 +314,12 @@ Qed.
 
 
 Lemma denote_instr_gep_array :
-  forall i size τ defs e_ix ix ptr a val g ρ m,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some DTYPE_Pointer) ptr)) g ρ m
+  forall i size τ e_ix ix ptr a val g ρ m,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some DTYPE_Pointer) ptr)) g ρ m
     ≈
     Ret (m, (ρ, (g, UVALUE_Addr a)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 64)) e_ix)) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 64)) e_ix)) g ρ m
     ≈
     Ret (m, (ρ, (g, UVALUE_I64 (repr (Z.of_nat ix)))))
     ->
@@ -327,13 +327,13 @@ Lemma denote_instr_gep_array :
     ->
     exists ptr_res,
       read m ptr_res τ = inr val /\
-      interp_cfg_to_L3 defs (denote_instr (IId i, INSTR_Op (OP_GetElementPtr (DTYPE_Array size τ) (DTYPE_Pointer, ptr) [(DTYPE_I 64, EXP_Integer 0%Z); (DTYPE_I 64, e_ix)]))) g ρ m
+      interp_cfg_to_L3 (denote_instr (IId i, INSTR_Op (OP_GetElementPtr (DTYPE_Array size τ) (DTYPE_Pointer, ptr) [(DTYPE_I 64, EXP_Integer 0%Z); (DTYPE_I 64, e_ix)]))) g ρ m
       ≈
       Ret (m, (Maps.add i (UVALUE_Addr ptr_res) ρ, (g, tt))).
 Proof.
-  intros i size τ defs e_ix ix ptr a val g ρ m PTR IX GET.
+  intros i size τ e_ix ix ptr a val g ρ m PTR IX GET.
 
-  pose proof interp_cfg_to_L3_GEP_array defs τ a size g ρ m val ix GET as (ptr_res & EQ & READ).
+  pose proof interp_cfg_to_L3_GEP_array τ a size g ρ m val ix GET as (ptr_res & EQ & READ).
   exists ptr_res. split; auto.
 
   cbn.
@@ -385,12 +385,12 @@ Proof.
 Qed.
 
 Lemma denote_instr_gep_array' :
-  forall i size τ defs e_ix ix ptr a val g ρ m,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some DTYPE_Pointer) ptr)) g ρ m
+  forall i size τ e_ix ix ptr a val g ρ m,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some DTYPE_Pointer) ptr)) g ρ m
     ≈
     Ret (m, (ρ, (g, UVALUE_Addr a)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 64)) e_ix)) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 64)) e_ix)) g ρ m
     ≈
     Ret (m, (ρ, (g, UVALUE_I64 (repr (Z.of_nat ix)))))
     ->
@@ -399,13 +399,13 @@ Lemma denote_instr_gep_array' :
     exists ptr_res,
       read m ptr_res τ = inr val /\
       handle_gep_addr (DTYPE_Array size τ) a [DVALUE_I64 (repr 0); DVALUE_I64 (repr (Z.of_nat ix))] = inr ptr_res /\
-      interp_cfg_to_L3 defs (denote_instr (IId i, INSTR_Op (OP_GetElementPtr (DTYPE_Array size τ) (DTYPE_Pointer, ptr) [(DTYPE_I 64, EXP_Integer 0%Z); (DTYPE_I 64, e_ix)]))) g ρ m
+      interp_cfg_to_L3 (denote_instr (IId i, INSTR_Op (OP_GetElementPtr (DTYPE_Array size τ) (DTYPE_Pointer, ptr) [(DTYPE_I 64, EXP_Integer 0%Z); (DTYPE_I 64, e_ix)]))) g ρ m
       ≈
       Ret (m, (Maps.add i (UVALUE_Addr ptr_res) ρ, (g, tt))).
 Proof.
-  intros i size τ defs e_ix ix ptr a val g ρ m PTR IX GET.
+  intros i size τ e_ix ix ptr a val g ρ m PTR IX GET.
 
-  pose proof interp_cfg_to_L3_GEP_array' defs τ a size g ρ m val ix GET as (ptr_res & EQ & GEP & READ).
+  pose proof interp_cfg_to_L3_GEP_array' τ a size g ρ m val ix GET as (ptr_res & EQ & GEP & READ).
   exists ptr_res.
   split; auto.
   split; auto.
@@ -461,23 +461,23 @@ Qed.
 
 
 Lemma denote_instr_gep_array_no_read_addr :
-  forall i size τ defs e_ix ix ptr a g ρ m ptr_res,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some DTYPE_Pointer) ptr)) g ρ m
+  forall i size τ e_ix ix ptr a g ρ m ptr_res,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some DTYPE_Pointer) ptr)) g ρ m
     ≈
     Ret (m, (ρ, (g, UVALUE_Addr a)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 64)) e_ix)) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 64)) e_ix)) g ρ m
     ≈
     Ret (m, (ρ, (g, UVALUE_I64 (repr (Z.of_nat ix)))))
     ->
     dtyp_fits m a (DTYPE_Array size τ) ->
     handle_gep_addr (DTYPE_Array size τ) a [DVALUE_I64 (Int64.repr 0); DVALUE_I64 (Int64.repr (Z.of_nat ix))] = inr ptr_res ->
-    interp_cfg_to_L3 defs (denote_instr (IId i, INSTR_Op (OP_GetElementPtr (DTYPE_Array size τ) (DTYPE_Pointer, ptr) [(DTYPE_I 64, EXP_Integer 0%Z); (DTYPE_I 64, e_ix)]))) g ρ m
+    interp_cfg_to_L3 (denote_instr (IId i, INSTR_Op (OP_GetElementPtr (DTYPE_Array size τ) (DTYPE_Pointer, ptr) [(DTYPE_I 64, EXP_Integer 0%Z); (DTYPE_I 64, e_ix)]))) g ρ m
       ≈
       Ret (m, (Maps.add i (UVALUE_Addr ptr_res) ρ, (g, tt))).
 Proof.
   intros * PTR IX FITS HGEP.
-  pose proof @interp_cfg_to_L3_GEP_array_no_read_addr defs τ a size g ρ m ix ptr_res FITS.
+  pose proof @interp_cfg_to_L3_GEP_array_no_read_addr τ a size g ρ m ix ptr_res FITS.
 
   cbn.
   rewrite translate_bind.
@@ -528,25 +528,25 @@ Proof.
 Qed.
 
 Lemma denote_instr_gep_array_no_read :
-  forall i size τ defs e_ix ix ptr a g ρ m,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some DTYPE_Pointer) ptr)) g ρ m
+  forall i size τ e_ix ix ptr a g ρ m,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some DTYPE_Pointer) ptr)) g ρ m
     ≈
     Ret (m, (ρ, (g, UVALUE_Addr a)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 64)) e_ix)) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 64)) e_ix)) g ρ m
     ≈
     Ret (m, (ρ, (g, UVALUE_I64 (repr (Z.of_nat ix)))))
     ->
     dtyp_fits m a (DTYPE_Array size τ) ->
     exists ptr_res,
       handle_gep_addr (DTYPE_Array size τ) a [DVALUE_I64 (repr 0); DVALUE_I64 (repr (Z.of_nat ix))] = inr ptr_res /\
-      interp_cfg_to_L3 defs (denote_instr (IId i, INSTR_Op (OP_GetElementPtr (DTYPE_Array size τ) (DTYPE_Pointer, ptr) [(DTYPE_I 64, EXP_Integer 0%Z); (DTYPE_I 64, e_ix)]))) g ρ m
+      interp_cfg_to_L3 (denote_instr (IId i, INSTR_Op (OP_GetElementPtr (DTYPE_Array size τ) (DTYPE_Pointer, ptr) [(DTYPE_I 64, EXP_Integer 0%Z); (DTYPE_I 64, e_ix)]))) g ρ m
       ≈
       Ret (m, (Maps.add i (UVALUE_Addr ptr_res) ρ, (g, tt))).
 Proof.
-  intros i size τ defs e_ix ix ptr a g ρ m PTR IX FITS.
+  intros i size τ e_ix ix ptr a g ρ m PTR IX FITS.
 
-  pose proof interp_cfg_to_L3_GEP_array_no_read defs τ a size g ρ m ix FITS as (ptr_res & EQ & GEP).
+  pose proof interp_cfg_to_L3_GEP_array_no_read τ a size g ρ m ix FITS as (ptr_res & EQ & GEP).
   exists ptr_res.
   split; auto.
 
@@ -599,22 +599,22 @@ Proof.
 Qed.
 
 Lemma denote_instr_intrinsic :
-  forall i τ defs fn in_n sem_f args arg_vs conc_args res g ρ m,
+  forall i τ fn in_n sem_f args arg_vs conc_args res g ρ m,
     @intrinsic_exp dtyp (EXP_Ident (ID_Global (Name fn))) = Some in_n
     ->
-    assoc in_n (defs_assoc defs) = Some sem_f
+    assoc in_n (defs_assoc) = Some sem_f
     ->
-    interp_cfg_to_L3 defs (map_monad (fun '(t, op) => translate exp_E_to_instr_E (denote_exp (Some t) op)) args) g ρ m
+    interp_cfg_to_L3 (map_monad (fun '(t, op) => translate exp_E_to_instr_E (denote_exp (Some t) op)) args) g ρ m
     ≈
     Ret (m, (ρ, (g, arg_vs))) 
     ->
-    interp_cfg_to_L3 defs (map_monad (fun uv : uvalue => pickUnique uv) arg_vs) g ρ m
+    interp_cfg_to_L3 (map_monad (fun uv : uvalue => pickUnique uv) arg_vs) g ρ m
     ≈
     Ret (m, (ρ, (g, conc_args)))
     ->
     sem_f conc_args = inr res
     ->
-    (interp_cfg_to_L3 defs
+    (interp_cfg_to_L3
        (denote_instr
           (IId i,
            INSTR_Call (τ, EXP_Ident (ID_Global (Name fn))) args)) g ρ m)
@@ -645,12 +645,12 @@ Proof.
 Qed.
 
 Lemma denote_term_br_l :
-  forall (e : exp dtyp) defs b1 b2 g ρ ρ' m,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 1)) e)) g ρ m
+  forall (e : exp dtyp) b1 b2 g ρ ρ' m,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 1)) e)) g ρ m
     ≈
     Ret (m, (ρ', (g, UVALUE_I1 one)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_terminator (TERM_Br (DTYPE_I 1%N, e) b1 b2))) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_terminator (TERM_Br (DTYPE_I 1%N, e) b1 b2))) g ρ m
     ≈
     Ret (m, (ρ', (g, inl b1))).
 Proof.
@@ -666,12 +666,12 @@ Proof.
 Qed.
 
 Lemma denote_term_br_r :
-  forall (e : exp dtyp) defs b1 b2 g ρ ρ' m,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 1)) e)) g ρ m
+  forall (e : exp dtyp) b1 b2 g ρ ρ' m,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp (Some (DTYPE_I 1)) e)) g ρ m
     ≈
     Ret (m, (ρ', (g, UVALUE_I1 zero)))
     ->
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_terminator (TERM_Br (DTYPE_I 1%N, e) b1 b2))) g ρ m
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_terminator (TERM_Br (DTYPE_I 1%N, e) b1 b2))) g ρ m
     ≈
     Ret (m, (ρ', (g, inl b2))).
 Proof.
@@ -687,12 +687,12 @@ Proof.
 Qed.
 
 Lemma denote_term_br_1 :
-  forall defs b g ρ m,
-    interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_terminator (TERM_Br_1 b))) g ρ m
+  forall b g ρ m,
+    interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_terminator (TERM_Br_1 b))) g ρ m
     ≈
     Ret (m, (ρ, (g, inl b))).
 Proof.
-  intros defs b g ρ m.
+  intros b g ρ m.
   cbn.
   rewrite translate_ret,interp_cfg_to_L3_ret.
   reflexivity.
@@ -728,20 +728,20 @@ interp_cfg_to_L3_intrinsic:
   forall (defs : Intrinsics.intrinsic_definitions) (m : memory_stack) (τ : dtyp)
     (g : global_env) (l : local_env) (fn : String.string) (args : list dvalue)
     (df : Intrinsics.semantic_function) (res : dvalue),
-  assoc Strings.String.string_dec fn (defs_assoc defs) = Some df ->
+  assoc Strings.String.string_dec fn (defs_assoc) = Some df ->
   df args = inr res ->
-  Monad.eqm (interp_cfg_to_L3 defs (trigger (Intrinsic τ fn args)) g l m) (ret (m, (l, (g, res))))
+  Monad.eqm (interp_cfg_to_L3 (trigger (Intrinsic τ fn args)) g l m) (ret (m, (l, (g, res))))
 
 *)
 
 (* Lemma denote_instr_call : *)
-(*   forall defs i τf f args uf uvs g ρ ρ' m t, *)
+(*   forall i τf f args uf uvs g ρ ρ' m t, *)
 (*     map_monad (fun '(t, op) => translate exp_E_to_instr_E (denote_exp (Some t) op)) args ≈ Ret uvs -> *)
-(*     interp_cfg_to_L3 defs (translate exp_E_to_instr_E (denote_exp None f)) g ρ m ≈ Ret (m, (ρ', (g, uf))) -> *)
+(*     interp_cfg_to_L3 (translate exp_E_to_instr_E (denote_exp None f)) g ρ m ≈ Ret (m, (ρ', (g, uf))) -> *)
 (*     intrinsic_exp f = None -> *)
-(*     interp_cfg_to_L3 defs (denote_instr (IId i, INSTR_Call (τf, f) args)) g ρ m ≈ t. (* interp_cfg_to_L3 defs (ITree.bind (trigger (LLVMEvents.Call τf uf uvs)) (fun x => trigger (LocalWrite i x)) g ρ' m). *) *)
+(*     interp_cfg_to_L3 (denote_instr (IId i, INSTR_Call (τf, f) args)) g ρ m ≈ t. (* interp_cfg_to_L3 (ITree.bind (trigger (LLVMEvents.Call τf uf uvs)) (fun x => trigger (LocalWrite i x)) g ρ' m). *) *)
 (* Proof. *)
-(*   intros defs i τf f args uf uvs g ρ ρ' m t MAP FEXP INT. *)
+(*   intros i τf f args uf uvs g ρ ρ' m t MAP FEXP INT. *)
 (*   cbn. *)
 (*   rewrite MAP. rewrite bind_ret_l. *)
 (*   rewrite INT. rewrite bind_bind. *)
@@ -753,7 +753,7 @@ interp_cfg_to_L3_intrinsic:
 (*   rewrite interp_cfg_to_L3_LW. *)
 (*   rewrite <- bind_trigger. *)
 
-(*   interp_cfg_to_L3 defs *)
+(*   interp_cfg_to_L3 *)
 (*     (ITree.bind (trigger (LLVMEvents.Call τf uf uvs)) *)
 (*        (fun returned_value : uvalue => trigger (LocalWrite i returned_value))) g ρ' m ≈ t *)
 

--- a/src/coq/Theory/InterpreterCFG.v
+++ b/src/coq/Theory/InterpreterCFG.v
@@ -34,34 +34,34 @@ Section InterpreterCFG.
    NOTE: Can we avoid this duplication w.r.t. [interp_to_Li]?
    *)
 
-  Definition interp_cfg_to_L1 {R} user_intrinsics (t: itree instr_E R) (g: global_env) :=
-    let L0_trace       := interp_intrinsics user_intrinsics t in
+  Definition interp_cfg_to_L1 {R} (t: itree instr_E R) (g: global_env) :=
+    let L0_trace       := interp_intrinsics t in
     let L1_trace       := interp_global L0_trace g in
     L1_trace.
 
-  Definition interp_cfg_to_L2 {R} user_intrinsics (t: itree instr_E R) (g: global_env) (l: local_env) :=
-    let L0_trace       := interp_intrinsics user_intrinsics t in
+  Definition interp_cfg_to_L2 {R} (t: itree instr_E R) (g: global_env) (l: local_env) :=
+    let L0_trace       := interp_intrinsics t in
     let L1_trace       := interp_global L0_trace g in
     let L2_trace       := interp_local L1_trace l in
     L2_trace.
 
-  Definition interp_cfg_to_L3 {R} user_intrinsics (t: itree instr_E R) (g: global_env) (l: local_env) (m: memory_stack) :=
-    let L0_trace       := interp_intrinsics user_intrinsics t in
+  Definition interp_cfg_to_L3 {R} (t: itree instr_E R) (g: global_env) (l: local_env) (m: memory_stack) :=
+    let L0_trace       := interp_intrinsics t in
     let L1_trace       := interp_global L0_trace g in
     let L2_trace       := interp_local L1_trace l in
     let L3_trace       := interp_memory L2_trace m in
     L3_trace.
 
-  Definition interp_cfg_to_L4 {R} RR user_intrinsics (t: itree instr_E R) (g: global_env) (l: local_env) (m: memory_stack) :=
-    let L0_trace       := interp_intrinsics user_intrinsics t in
+  Definition interp_cfg_to_L4 {R} RR (t: itree instr_E R) (g: global_env) (l: local_env) (m: memory_stack) :=
+    let L0_trace       := interp_intrinsics t in
     let L1_trace       := interp_global L0_trace g in
     let L2_trace       := interp_local L1_trace l in
     let L3_trace       := interp_memory L2_trace m in
     let L4_trace       := model_undef RR L3_trace in
     L4_trace.
 
-  Definition interp_cfg_to_L5 {R} RR user_intrinsics (t: itree instr_E R) (g: global_env) (l: local_env) (m: memory_stack) :=
-    let L0_trace       := interp_intrinsics user_intrinsics t in
+  Definition interp_cfg_to_L5 {R} RR (t: itree instr_E R) (g: global_env) (l: local_env) (m: memory_stack) :=
+    let L0_trace       := interp_intrinsics t in
     let L1_trace       := interp_global L0_trace g in
     let L2_trace       := interp_local L1_trace l in
     let L3_trace       := interp_memory L2_trace m in
@@ -69,9 +69,9 @@ Section InterpreterCFG.
     model_UB RR L4_trace.
 
   Lemma interp_cfg_to_L1_bind :
-    forall ui {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g, 
-      interp_cfg_to_L1 ui (ITree.bind t k) g ≈
-                       (ITree.bind (interp_cfg_to_L1 ui t g) (fun '(g',x) => interp_cfg_to_L1 ui (k x) g')).
+    forall {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g, 
+      interp_cfg_to_L1 (ITree.bind t k) g ≈
+                       (ITree.bind (interp_cfg_to_L1 t g) (fun '(g',x) => interp_cfg_to_L1 (k x) g')).
   Proof.
     intros.
     unfold interp_cfg_to_L1.
@@ -79,16 +79,16 @@ Section InterpreterCFG.
     apply eutt_eq_bind; intros (? & ?); reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L1_ret : forall ui (R : Type) g (x : R), interp_cfg_to_L1 ui (Ret x) g ≈ Ret (g,x).
+  Lemma interp_cfg_to_L1_ret : forall (R : Type) g (x : R), interp_cfg_to_L1 (Ret x) g ≈ Ret (g,x).
   Proof.
     intros; unfold interp_cfg_to_L1.
     rewrite interp_intrinsics_ret, interp_global_ret; reflexivity.
   Qed.
 
   Lemma interp_cfg_to_L2_bind :
-    forall ui {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g l,
-      interp_cfg_to_L2 ui (ITree.bind t k) g l ≈
-                       (ITree.bind (interp_cfg_to_L2 ui t g l) (fun '(g',(l',x)) => interp_cfg_to_L2 ui (k x) l' g')).
+    forall {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g l,
+      interp_cfg_to_L2 (ITree.bind t k) g l ≈
+                       (ITree.bind (interp_cfg_to_L2 t g l) (fun '(g',(l',x)) => interp_cfg_to_L2 (k x) l' g')).
   Proof.
     intros.
     unfold interp_cfg_to_L2.
@@ -96,16 +96,16 @@ Section InterpreterCFG.
     apply eutt_eq_bind; intros (? & ? & ?); reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L2_ret : forall ui (R : Type) g l (x : R), interp_cfg_to_L2 ui (Ret x) g l ≈ Ret (l, (g, x)).
+  Lemma interp_cfg_to_L2_ret : forall (R : Type) g l (x : R), interp_cfg_to_L2 (Ret x) g l ≈ Ret (l, (g, x)).
   Proof.
     intros; unfold interp_cfg_to_L2.
     rewrite interp_intrinsics_ret, interp_global_ret, interp_local_ret; reflexivity.
   Qed.
 
   Lemma interp_cfg_to_L3_bind :
-    forall ui {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g l m,
-      interp_cfg_to_L3 ui (ITree.bind t k) g l m ≈
-                       (ITree.bind (interp_cfg_to_L3 ui t g l m) (fun '(m',(l',(g',x))) => interp_cfg_to_L3 ui (k x) g' l' m')).
+    forall {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g l m,
+      interp_cfg_to_L3 (ITree.bind t k) g l m ≈
+                       (ITree.bind (interp_cfg_to_L3 t g l m) (fun '(m',(l',(g',x))) => interp_cfg_to_L3 (k x) g' l' m')).
   Proof.
     intros.
     unfold interp_cfg_to_L3.
@@ -113,14 +113,14 @@ Section InterpreterCFG.
     apply eutt_eq_bind; intros (? & ? & ? & ?); reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_ret : forall ui (R : Type) g l m (x : R), interp_cfg_to_L3 ui (Ret x) g l m ≈ Ret (m, (l, (g,x))).
+  Lemma interp_cfg_to_L3_ret : forall (R : Type) g l m (x : R), interp_cfg_to_L3 (Ret x) g l m ≈ Ret (m, (l, (g,x))).
   Proof.
     intros; unfold interp_cfg_to_L3.
     rewrite interp_intrinsics_ret, interp_global_ret, interp_local_ret, interp_memory_ret; reflexivity.
   Qed.
 
-  Global Instance eutt_interp_cfg_to_L1 (defs: intrinsic_definitions) {T}:
-    Proper (eutt Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_cfg_to_L1 T defs).
+  Global Instance eutt_interp_cfg_to_L1 {T}:
+    Proper (eutt Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_cfg_to_L1 T).
   Proof.
     repeat intro.
     unfold interp_cfg_to_L1.
@@ -128,8 +128,8 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Global Instance eutt_interp_cfg_to_L2 (defs: intrinsic_definitions) {T}:
-    Proper (eutt Logic.eq ==> Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_cfg_to_L2 T defs).
+  Global Instance eutt_interp_cfg_to_L2 {T}:
+    Proper (eutt Logic.eq ==> Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_cfg_to_L2 T).
   Proof.
     repeat intro.
     unfold interp_cfg_to_L2.
@@ -137,8 +137,8 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Global Instance eutt_interp_cfg_to_L3 (defs: intrinsic_definitions) {T}:
-    Proper (eutt Logic.eq ==> Logic.eq ==> Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_cfg_to_L3 T defs).
+  Global Instance eutt_interp_cfg_to_L3 {T}:
+    Proper (eutt Logic.eq ==> Logic.eq ==> Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_cfg_to_L3 T).
   Proof.
     repeat intro.
     unfold interp_cfg_to_L3.
@@ -146,12 +146,11 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  (* NOTEYZ: This can probably be refined to [eqit eq] instead of [eutt eq], but I don't think it matters to us *)
-  Lemma interp_cfg_to_L3_vis (defs: IS.intrinsic_definitions):
+  Lemma interp_cfg_to_L3_vis :
     forall T R (e : instr_E T) (k : T -> itree instr_E R) g l m,
-      interp_cfg_to_L3 defs (Vis e k) g l m ≈ 
-                       ITree.bind (interp_cfg_to_L3 defs (trigger e) g l m)
-                       (fun '(m, (l, (g, x)))=> interp_cfg_to_L3 defs (k x) g l m).
+      interp_cfg_to_L3 (Vis e k) g l m ≈ 
+                       ITree.bind (interp_cfg_to_L3 (trigger e) g l m)
+                       (fun '(m, (l, (g, x)))=> interp_cfg_to_L3 (k x) g l m).
   Proof.
     intros.
     unfold interp_cfg_to_L3.
@@ -162,18 +161,15 @@ Section InterpreterCFG.
     rewrite Eq.bind_bind.
     apply eutt_eq_bind.
     intros (? & ? & ? & ?).
-    do 2 match goal with
-      |- context[interp ?x ?t] => replace (interp x t) with (interp_intrinsics defs t) by reflexivity
-    end. 
     rewrite interp_intrinsics_ret, interp_global_ret, interp_local_ret, interp_memory_ret, bind_ret_l.
     reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_bind_trigger (defs: IS.intrinsic_definitions):
+  Lemma interp_cfg_to_L3_bind_trigger :
     forall T R (e : instr_E T) (k : T -> itree instr_E R) g l m,
-      interp_cfg_to_L3 defs (ITree.bind (trigger e) k) g l m ≈ 
-                       ITree.bind (interp_cfg_to_L3 defs (trigger e) g l m)
-                       (fun '(m, (l, (g, x)))=> interp_cfg_to_L3 defs (k x) g l m).
+      interp_cfg_to_L3 (ITree.bind (trigger e) k) g l m ≈ 
+                       ITree.bind (interp_cfg_to_L3 (trigger e) g l m)
+                       (fun '(m, (l, (g, x)))=> interp_cfg_to_L3 (k x) g l m).
   Proof.
     intros.
     rewrite bind_trigger.
@@ -181,9 +177,9 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_GR : forall defs id g l m v,
+  Lemma interp_cfg_to_L3_GR : forall id g l m v,
       Maps.lookup id g = Some v ->
-      interp_cfg_to_L3 defs (trigger (GlobalRead id)) g l m ≈ Ret (m,(l,(g,v))).
+      interp_cfg_to_L3 (trigger (GlobalRead id)) g l m ≈ Ret (m,(l,(g,v))).
   Proof.
     intros * LU.
     unfold interp_cfg_to_L3.
@@ -196,9 +192,9 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_LR : forall defs id g l m v,
+  Lemma interp_cfg_to_L3_LR : forall id g l m v,
       Maps.lookup id l = Some v ->
-      interp_cfg_to_L3 defs (trigger (LocalRead id)) g l m ≈ Ret (m,(l,(g,v))).
+      interp_cfg_to_L3 (trigger (LocalRead id)) g l m ≈ Ret (m,(l,(g,v))).
   Proof.
     intros * LU.
     unfold interp_cfg_to_L3.
@@ -213,8 +209,8 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_LW : forall defs id g l m v,
-      interp_cfg_to_L3 defs (trigger (LocalWrite id v)) g l m ≈ Ret (m,(Maps.add id v l, (g,tt))).
+  Lemma interp_cfg_to_L3_LW : forall id g l m v,
+      interp_cfg_to_L3 (trigger (LocalWrite id v)) g l m ≈ Ret (m,(Maps.add id v l, (g,tt))).
   Proof.
     intros.
     unfold interp_cfg_to_L3.
@@ -226,8 +222,8 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_GW : forall defs id g l m v,
-      interp_cfg_to_L3 defs (trigger (GlobalWrite id v)) g l m ≈ Ret (m,(l,(Maps.add id v g,tt))).
+  Lemma interp_cfg_to_L3_GW : forall id g l m v,
+      interp_cfg_to_L3 (trigger (GlobalWrite id v)) g l m ≈ Ret (m,(l,(Maps.add id v g,tt))).
   Proof.
     intros.
     unfold interp_cfg_to_L3.
@@ -238,9 +234,9 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_Load : forall defs t a g l m val,
+  Lemma interp_cfg_to_L3_Load : forall t a g l m val,
       read m a t = inr val ->
-      interp_cfg_to_L3 defs (trigger (Load t (DVALUE_Addr a))) g l m ≈ Ret (m,(l,(g,val))).
+      interp_cfg_to_L3 (trigger (Load t (DVALUE_Addr a))) g l m ≈ Ret (m,(l,(g,val))).
   Proof.
     intros * READ.
     unfold interp_cfg_to_L3.
@@ -259,11 +255,11 @@ Section InterpreterCFG.
   Qed.
 
   Lemma interp_cfg_to_L3_store :
-    forall (m m' : memory_stack) (t : dtyp) (val : dvalue) (a : addr) g l defs,
+    forall (m m' : memory_stack) (t : dtyp) (val : dvalue) (a : addr) g l,
       write m a val = inr m' ->
-      interp_cfg_to_L3 defs (trigger (Store (DVALUE_Addr a) val)) g l m ≈ Ret (m',(l,(g,tt))).
+      interp_cfg_to_L3 (trigger (Store (DVALUE_Addr a) val)) g l m ≈ Ret (m',(l,(g,tt))).
   Proof.
-    intros m m' t val a g l defs WRITE.
+    intros m m' t val a g l WRITE.
     unfold interp_cfg_to_L3.
     rewrite interp_intrinsics_trigger.
     cbn.
@@ -282,11 +278,11 @@ Section InterpreterCFG.
 
   Arguments allocate : simpl never.
   Lemma interp_cfg_to_L3_alloca :
-    forall (defs : intrinsic_definitions) (m : memory_stack) (t : dtyp) (g : global_env) l,
+    forall (m : memory_stack) (t : dtyp) (g : global_env) l,
       non_void t ->
       exists m' a',
         allocate m t = inr (m', a') /\
-        interp_cfg_to_L3 defs (trigger (Alloca t)) g l m ≈ Ret (m', (l, (g, DVALUE_Addr a'))).
+        interp_cfg_to_L3 (trigger (Alloca t)) g l m ≈ Ret (m', (l, (g, DVALUE_Addr a'))).
   Proof.
     intros * NV.
     unfold interp_cfg_to_L3.
@@ -314,16 +310,22 @@ Section InterpreterCFG.
     auto.
   Qed.
 
-  Lemma interp_cfg_to_L3_intrinsic :
-    forall (defs : intrinsic_definitions) (m : memory_stack) (τ : dtyp) (g : global_env) l fn args df res,
-      assoc fn (defs_assoc defs) = Some df ->
-      df args = inr res ->
-      interp_cfg_to_L3 defs (trigger (Intrinsic τ fn args)) g l m ≈ Ret (m, (l, (g, res))).
-  Proof.
-    intros defs m τ g l fn args df res LUP RES.
-    unfold interp_cfg_to_L3.
+  (* Because [defs_assoc] is applied to a concrete list, [cbn] reduces it, and proceeds to destroy the string notations, creating a mess.
+     There's probably a better fix that this to it.
+   *)
+  Arguments defs_assoc: simpl never.
 
-    rewrite interp_intrinsics_trigger; cbn.
+  Lemma interp_cfg_to_L3_intrinsic :
+    forall (m : memory_stack) (τ : dtyp) (g : global_env) l fn args df res,
+      assoc fn defs_assoc = Some df ->
+      df args = inr res ->
+      interp_cfg_to_L3 (trigger (Intrinsic τ fn args)) g l m ≈ Ret (m, (l, (g, res))).
+  Proof.
+    intros m τ g l fn args df res LUP RES.
+    unfold interp_cfg_to_L3.
+    rewrite interp_intrinsics_trigger.
+    cbn.
+    
     rewrite LUP; cbn.
     rewrite RES.
 
@@ -334,10 +336,10 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_GEP_array' : forall defs t a size g l m val i,
+  Lemma interp_cfg_to_L3_GEP_array' : forall t a size g l m val i,
       get_array_cell m a i t = inr val ->
       exists ptr,
-        interp_cfg_to_L3 defs (trigger (GEP
+        interp_cfg_to_L3 (trigger (GEP
                                   (DTYPE_Array size t)
                                   (DVALUE_Addr a)
                                   [DVALUE_I64 (Integers.Int64.repr 0); DVALUE_I64 (Integers.Int64.repr (Z.of_nat i))])) g l m
@@ -345,7 +347,7 @@ Section InterpreterCFG.
         handle_gep_addr (DTYPE_Array size t) a [DVALUE_I64 (repr 0); DVALUE_I64 (repr (Z.of_nat i))] = inr ptr /\
         read m ptr t = inr val.
   Proof.
-    intros defs t a size g l m val i GET.
+    intros t a size g l m val i GET.
     epose proof @interp_memory_GEP_array' _ (PickE +' UBE +' DebugE +' FailureE) _ _ _ t _ size _ _ _ GET as [ptr [INTERP READ]].
     exists ptr.
     split; auto.
@@ -371,10 +373,10 @@ Section InterpreterCFG.
   Qed.
 
 
-  Lemma interp_cfg_to_L3_GEP_array_no_read_addr : forall defs t a size g l m i ptr,
+  Lemma interp_cfg_to_L3_GEP_array_no_read_addr : forall t a size g l m i ptr,
       dtyp_fits m a (DTYPE_Array size t) ->
       handle_gep_addr (DTYPE_Array size t) a [DVALUE_I64 (repr 0); DVALUE_I64 (repr (Z.of_nat i))] = inr ptr ->
-        interp_cfg_to_L3 defs (trigger (GEP
+        interp_cfg_to_L3 (trigger (GEP
                                   (DTYPE_Array size t)
                                   (DVALUE_Addr a)
                                   [DVALUE_I64 (Integers.Int64.repr 0); DVALUE_I64 (Integers.Int64.repr (Z.of_nat i))])) g l m
@@ -404,17 +406,17 @@ Section InterpreterCFG.
     reflexivity.
   Qed.
 
-  Lemma interp_cfg_to_L3_GEP_array_no_read : forall defs t a size g l m i,
+  Lemma interp_cfg_to_L3_GEP_array_no_read : forall t a size g l m i,
       dtyp_fits m a (DTYPE_Array size t) ->
       exists ptr,
-        interp_cfg_to_L3 defs (trigger (GEP
+        interp_cfg_to_L3 (trigger (GEP
                                   (DTYPE_Array size t)
                                   (DVALUE_Addr a)
                                   [DVALUE_I64 (Integers.Int64.repr 0); DVALUE_I64 (Integers.Int64.repr (Z.of_nat i))])) g l m
                       ≈ Ret (m, (l, (g, DVALUE_Addr ptr))) /\
         handle_gep_addr (DTYPE_Array size t) a [DVALUE_I64 (repr 0); DVALUE_I64 (repr (Z.of_nat i))] = inr ptr.
   Proof.
-    intros defs t a size g l m i FITS.
+    intros t a size g l m i FITS.
     epose proof @interp_memory_GEP_array_no_read _ (PickE +' UBE +' DebugE +' FailureE) _ _ _ t _ size _ _ FITS as [ptr [INTERP GEP]].
     exists ptr.
     split; auto.
@@ -440,17 +442,17 @@ Section InterpreterCFG.
     auto.
   Qed.
 
-  Lemma interp_cfg_to_L3_GEP_array : forall defs t a size g l m val i,
+  Lemma interp_cfg_to_L3_GEP_array : forall t a size g l m val i,
       get_array_cell m a i t = inr val ->
       exists ptr,
-        interp_cfg_to_L3 defs (trigger (GEP
+        interp_cfg_to_L3 (trigger (GEP
                                   (DTYPE_Array size t)
                                   (DVALUE_Addr a)
                                   [DVALUE_I64 (Integers.Int64.repr 0); DVALUE_I64 (Integers.Int64.repr (Z.of_nat i))])) g l m
                       ≈ Ret (m, (l, (g, DVALUE_Addr ptr))) /\
         read m ptr t = inr val.
   Proof.
-    intros defs t a size g l m val i GET.
+    intros t a size g l m val i GET.
     epose proof @interp_memory_GEP_array _ (PickE +' UBE +' DebugE +' FailureE) _ _ _ t _ size _ _ _ GET as [ptr [INTERP READ]].
     exists ptr.
     split; auto.
@@ -474,35 +476,5 @@ Section InterpreterCFG.
     rewrite interp_memory_ret.
     reflexivity.
   Qed.
-
-  (**
-     YZ : Should be obsolete. Keeping it around for a bit
-   *)
-  (*
-  Lemma interp_cfg_to_L3_LM : forall defs t a size offset g l m v bytes concrete_id,
-      get_logical_block m a = Some (LBlock size bytes concrete_id) ->
-      deserialize_sbytes (lookup_all_index offset (sizeof_dtyp t) bytes SUndef) t = v ->
-      interp_cfg_to_L3 defs (trigger (Load t (DVALUE_Addr (a, offset)))) g l m ≈ Ret (m,(l,(g,v))).
-  Proof.
-    intros * LUL EQ.
-    unfold interp_cfg_to_L3.
-    rewrite interp_intrinsics_trigger.
-    cbn.
-    unfold Intrinsics.F_trigger.
-    rewrite interp_global_trigger.
-    cbn.
-    rewrite interp_local_bind, interp_local_trigger.
-    cbn; rewrite bind_bind.
-    rewrite interp_memory_bind, interp_memory_trigger.
-    cbn.
-    destruct m as [mem memstack]. cbn.
-    cbn in LUL. unfold read.
-    cbn; rewrite LUL.
-    rewrite 2 bind_ret_l, interp_local_ret, interp_memory_ret.
-    unfold read_in_mem_block.
-    rewrite EQ.
-    reflexivity.
-  Qed.
-   *)
 
 End InterpreterCFG.

--- a/src/coq/Theory/InterpreterMCFG.v
+++ b/src/coq/Theory/InterpreterMCFG.v
@@ -25,34 +25,34 @@ Section InterpreterMCFG.
    This gives us a _vertical_ notion of compositionality.
    *)
 
-  Definition interp_to_L1 {R} user_intrinsics (t: itree L0 R) g :=
-    let uvalue_trace       := interp_intrinsics user_intrinsics t in
+  Definition interp_to_L1 {R} (t: itree L0 R) g :=
+    let uvalue_trace       := interp_intrinsics t in
     let L1_trace           := interp_global uvalue_trace g in
     L1_trace.
 
-  Definition interp_to_L2 {R} user_intrinsics (t: itree L0 R) g l :=
-    let uvalue_trace   := interp_intrinsics user_intrinsics t in
+  Definition interp_to_L2 {R} (t: itree L0 R) g l :=
+    let uvalue_trace   := interp_intrinsics t in
     let L1_trace       := interp_global uvalue_trace g in
     let L2_trace       := interp_local_stack (handle_local (v:=uvalue)) L1_trace l in
     L2_trace.
 
-  Definition interp_to_L3 {R} user_intrinsics (t: itree L0 R) g l m :=
-    let uvalue_trace   := interp_intrinsics user_intrinsics t in
+  Definition interp_to_L3 {R} (t: itree L0 R) g l m :=
+    let uvalue_trace   := interp_intrinsics t in
     let L1_trace       := interp_global uvalue_trace g in
     let L2_trace       := interp_local_stack (handle_local (v:=uvalue)) L1_trace l in
     let L3_trace       := interp_memory L2_trace m in
     L3_trace.
 
-  Definition interp_to_L4 {R} RR user_intrinsics (t: itree L0 R) g l m :=
-    let uvalue_trace   := interp_intrinsics user_intrinsics t in
+  Definition interp_to_L4 {R} RR (t: itree L0 R) g l m :=
+    let uvalue_trace   := interp_intrinsics t in
     let L1_trace       := interp_global uvalue_trace g in
     let L2_trace       := interp_local_stack (handle_local (v:=uvalue)) L1_trace l in
     let L3_trace       := interp_memory L2_trace m in
     let L4_trace       := model_undef RR L3_trace in
     L4_trace.
 
-  Definition interp_to_L5 {R} RR user_intrinsics (t: itree L0 R) g l m :=
-    let uvalue_trace   := interp_intrinsics user_intrinsics t in
+  Definition interp_to_L5 {R} RR (t: itree L0 R) g l m :=
+    let uvalue_trace   := interp_intrinsics t in
     let L1_trace       := interp_global uvalue_trace g in
     let L2_trace       := interp_local_stack (handle_local (v:=uvalue)) L1_trace l in
     let L3_trace       := interp_memory L2_trace m in
@@ -60,16 +60,16 @@ Section InterpreterMCFG.
     model_UB RR L4_trace.
 
   (* The interpreter stray away from the model starting from the fourth layer: we pick an arbitrary valid path of execution *)
-  Definition interp_to_L4_exec {R} user_intrinsics (t: itree L0 R) g l m :=
-    let uvalue_trace   := interp_intrinsics user_intrinsics t in
+  Definition interp_to_L4_exec {R} (t: itree L0 R) g l m :=
+    let uvalue_trace   := interp_intrinsics t in
     let L1_trace       := interp_global uvalue_trace g in
     let L2_trace       := interp_local_stack (handle_local (v:=uvalue)) L1_trace l in
     let L3_trace       := interp_memory L2_trace m in
     let L4_trace       := exec_undef L3_trace in
     L4_trace.
 
-  Definition interp_to_L5_exec {R} user_intrinsics (t: itree L0 R) g l m :=
-    let uvalue_trace   := interp_intrinsics user_intrinsics t in
+  Definition interp_to_L5_exec {R} (t: itree L0 R) g l m :=
+    let uvalue_trace   := interp_intrinsics t in
     let L1_trace       := interp_global uvalue_trace g in
     let L2_trace       := interp_local_stack (handle_local (v:=uvalue)) L1_trace l in
     let L3_trace       := interp_memory L2_trace m in
@@ -79,9 +79,9 @@ Section InterpreterMCFG.
   Section Structural_Lemmas.
 
     Lemma interp_to_L1_bind :
-      forall ui {R S} (t: itree L0 R) (k: R -> itree L0 S) g, 
-        interp_to_L1 ui (ITree.bind t k) g ≈
-                     (ITree.bind (interp_to_L1 ui t g) (fun '(g',x) => interp_to_L1 ui (k x) g')).
+      forall {R S} (t: itree L0 R) (k: R -> itree L0 S) g, 
+        interp_to_L1 (ITree.bind t k) g ≈
+                     (ITree.bind (interp_to_L1 t g) (fun '(g',x) => interp_to_L1 (k x) g')).
     Proof.
       intros.
       unfold interp_to_L1.
@@ -89,16 +89,16 @@ Section InterpreterMCFG.
       apply eutt_eq_bind; intros (? & ?); reflexivity.
     Qed.
 
-    Lemma interp_to_L1_ret : forall ui (R : Type) g (x : R), interp_to_L1 ui (Ret x) g ≈ Ret (g,x).
+    Lemma interp_to_L1_ret : forall (R : Type) g (x : R), interp_to_L1 (Ret x) g ≈ Ret (g,x).
     Proof.
       intros; unfold interp_to_L1.
       rewrite interp_intrinsics_ret, interp_global_ret; reflexivity.
     Qed.
 
     Lemma interp_to_L2_bind :
-      forall ui {R S} (t: itree L0 R) (k: R -> itree L0 S) g l,
-        interp_to_L2 ui (ITree.bind t k) g l ≈
-                     (ITree.bind (interp_to_L2 ui t g l) (fun '(g',(l',x)) => interp_to_L2 ui (k x) l' g')).
+      forall {R S} (t: itree L0 R) (k: R -> itree L0 S) g l,
+        interp_to_L2 (ITree.bind t k) g l ≈
+                     (ITree.bind (interp_to_L2 t g l) (fun '(g',(l',x)) => interp_to_L2 (k x) l' g')).
     Proof.
       intros.
       unfold interp_to_L2.
@@ -106,16 +106,16 @@ Section InterpreterMCFG.
       apply eutt_eq_bind; intros (? & ? & ?); reflexivity.
     Qed.
 
-    Lemma interp_to_L2_ret : forall ui (R : Type) g l (x : R), interp_to_L2 ui (Ret x) g l ≈ Ret (l, (g, x)).
+    Lemma interp_to_L2_ret : forall (R : Type) g l (x : R), interp_to_L2 (Ret x) g l ≈ Ret (l, (g, x)).
     Proof.
       intros; unfold interp_to_L2.
       rewrite interp_intrinsics_ret, interp_global_ret, interp_local_stack_ret; reflexivity.
     Qed.
 
     Lemma interp_to_L3_bind :
-      forall ui {R S} (t: itree L0 R) (k: R -> itree L0 S) g l m,
-        interp_to_L3 ui (ITree.bind t k) g l m ≈
-                     (ITree.bind (interp_to_L3 ui t g l m) (fun '(m',(l',(g',x))) => interp_to_L3 ui (k x) g' l' m')).
+      forall {R S} (t: itree L0 R) (k: R -> itree L0 S) g l m,
+        interp_to_L3 (ITree.bind t k) g l m ≈
+                     (ITree.bind (interp_to_L3 t g l m) (fun '(m',(l',(g',x))) => interp_to_L3 (k x) g' l' m')).
     Proof.
       intros.
       unfold interp_to_L3.
@@ -123,14 +123,14 @@ Section InterpreterMCFG.
       apply eutt_eq_bind; intros (? & ? & ? & ?); reflexivity.
     Qed.
 
-    Lemma interp_to_L3_ret : forall ui (R : Type) g l m (x : R), interp_to_L3 ui (Ret x) g l m ≈ Ret (m, (l, (g,x))).
+    Lemma interp_to_L3_ret : forall (R : Type) g l m (x : R), interp_to_L3 (Ret x) g l m ≈ Ret (m, (l, (g,x))).
     Proof.
       intros; unfold interp_to_L3.
       rewrite interp_intrinsics_ret, interp_global_ret, interp_local_stack_ret, interp_memory_ret; reflexivity.
     Qed.
 
-    Global Instance eutt_interp_to_L1 (defs: intrinsic_definitions) {T}:
-      Proper (eutt Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_to_L1 T defs).
+    Global Instance eutt_interp_to_L1 {T}:
+      Proper (eutt Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_to_L1 T).
     Proof.
       repeat intro.
       unfold interp_to_L1.
@@ -138,8 +138,8 @@ Section InterpreterMCFG.
       reflexivity.
     Qed.
 
-    Global Instance eutt_interp_to_L2 (defs: intrinsic_definitions) {T}:
-      Proper (eutt Logic.eq ==> Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_to_L2 T defs).
+    Global Instance eutt_interp_to_L2 {T}:
+      Proper (eutt Logic.eq ==> Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_to_L2 T).
     Proof.
       repeat intro.
       unfold interp_to_L2.
@@ -147,8 +147,8 @@ Section InterpreterMCFG.
       reflexivity.
     Qed.
 
-    Global Instance eutt_interp_to_L3 (defs: intrinsic_definitions) {T}:
-      Proper (eutt Logic.eq ==> Logic.eq ==> Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_to_L3 T defs).
+    Global Instance eutt_interp_to_L3 {T}:
+      Proper (eutt Logic.eq ==> Logic.eq ==> Logic.eq ==> Logic.eq ==> eutt Logic.eq) (@interp_to_L3 T).
     Proof.
       repeat intro.
       unfold interp_to_L3.
@@ -157,11 +157,11 @@ Section InterpreterMCFG.
     Qed.
 
     (* NOTEYZ: This can probably be refined to [eqit eq] instead of [eutt eq], but I don't think it matters to us *)
-    Lemma interp_to_L3_vis (defs: IS.intrinsic_definitions):
+    Lemma interp_to_L3_vis: 
       forall T R (e : L0 T) (k : T -> itree L0 R) g l m,
-        interp_to_L3 defs (Vis e k) g l m ≈ 
-                     ITree.bind (interp_to_L3 defs (trigger e) g l m)
-                     (fun '(m, (l, (g, x)))=> interp_to_L3 defs (k x) g l m).
+        interp_to_L3 (Vis e k) g l m ≈ 
+                     ITree.bind (interp_to_L3 (trigger e) g l m)
+                     (fun '(m, (l, (g, x)))=> interp_to_L3 (k x) g l m).
     Proof.
       intros.
       unfold interp_to_L3.
@@ -172,18 +172,15 @@ Section InterpreterMCFG.
       rewrite Eq.bind_bind.
       apply eutt_eq_bind.
       intros (? & ? & ? & ?).
-      do 2 match goal with
-             |- context[interp ?x ?t] => replace (interp x t) with (interp_intrinsics defs t) by reflexivity
-           end. 
       rewrite interp_intrinsics_ret, interp_global_ret, interp_local_stack_ret, interp_memory_ret, bind_ret_l.
       reflexivity.
     Qed.
 
-    Lemma interp_to_L3_bind_trigger (defs: IS.intrinsic_definitions):
+    Lemma interp_to_L3_bind_trigger :
       forall T R (e : L0 T) (k : T -> itree L0 R) g l m,
-        interp_to_L3 defs (ITree.bind (trigger e) k) g l m ≈ 
-                     ITree.bind (interp_to_L3 defs (trigger e) g l m)
-                     (fun '(m, (l, (g, x)))=> interp_to_L3 defs (k x) g l m).
+        interp_to_L3 (ITree.bind (trigger e) k) g l m ≈ 
+                     ITree.bind (interp_to_L3 (trigger e) g l m)
+                     (fun '(m, (l, (g, x)))=> interp_to_L3 (k x) g l m).
     Proof.
       intros.
       rewrite bind_trigger.
@@ -191,8 +188,8 @@ Section InterpreterMCFG.
       reflexivity.
     Qed.
 
-    Lemma interp_to_L3_GW : forall defs id g l m v,
-        interp_to_L3 defs (trigger (GlobalWrite id v)) g l m ≈ ret (m,(l,(Maps.add id v g,tt))).
+    Lemma interp_to_L3_GW : forall id g l m v,
+        interp_to_L3 (trigger (GlobalWrite id v)) g l m ≈ ret (m,(l,(Maps.add id v g,tt))).
     Proof.
       intros.
       unfold interp_to_L3.
@@ -204,10 +201,10 @@ Section InterpreterMCFG.
       reflexivity.
     Qed.
 
-    Lemma interp_cfg_to_L3_LM : forall defs t a size offset g l m v bytes concrete_id,
+    Lemma interp_cfg_to_L3_LM : forall t a size offset g l m v bytes concrete_id,
         get_logical_block m a = Some (LBlock size bytes concrete_id) ->
         deserialize_sbytes (lookup_all_index offset (sizeof_dtyp t) bytes SUndef) t = v ->
-        interp_to_L3 defs (trigger (Load t (DVALUE_Addr (a, offset)))) g l m ≈ Ret (m,(l,(g,v))).
+        interp_to_L3 (trigger (Load t (DVALUE_Addr (a, offset)))) g l m ≈ Ret (m,(l,(g,v))).
     Proof.
       intros * LUL EQ.
       unfold interp_to_L3.
@@ -235,11 +232,11 @@ Section InterpreterMCFG.
     Qed.
 
     Lemma interp_to_L3_alloca :
-      forall (defs : intrinsic_definitions) (m : memory_stack) (t : dtyp) (g : global_env) l,
+      forall (m : memory_stack) (t : dtyp) (g : global_env) l,
         non_void t ->
         exists m' a',
           allocate m t = inr (m', a') /\
-          interp_to_L3 defs (trigger (Alloca t)) g l m ≈ ret (m', (l, (g, DVALUE_Addr a'))).
+          interp_to_L3 (trigger (Alloca t)) g l m ≈ ret (m', (l, (g, DVALUE_Addr a'))).
     Proof.
       intros * NV.
       unfold interp_to_L3.
@@ -275,17 +272,17 @@ End InterpreterMCFG.
 
 Ltac fold_L1 :=
   match goal with
-    |- context[interp_global (interp_intrinsics ?ui ?p) ?g] =>
-    replace (interp_global (interp_intrinsics ui p) g) with
-    (interp_to_L1 ui p g) by reflexivity
+    |- context[interp_global (interp_intrinsics ?p) ?g] =>
+    replace (interp_global (interp_intrinsics p) g) with
+    (interp_to_L1 p g) by reflexivity
   end.
 
 Ltac fold_L2 :=
   match goal with
     |- context[interp_local_stack ?h
-                                 (interp_global (interp_intrinsics ?ui ?p) ?g) ?l] =>
-    replace (interp_local_stack h (interp_global (interp_intrinsics ui p) g) l) with
-    (interp_to_L2 ui p g l) by reflexivity
+                                 (interp_global (interp_intrinsics ?p) ?g) ?l] =>
+    replace (interp_local_stack h (interp_global (interp_intrinsics p) g) l) with
+    (interp_to_L2 p g l) by reflexivity
   end.
 
 Ltac fold_L3 :=
@@ -293,9 +290,9 @@ Ltac fold_L3 :=
     |- context[
           interp_memory
             (interp_local_stack ?h
-                                (interp_global (interp_intrinsics ?ui ?p) ?g) ?l) ?m] =>
-    replace (interp_memory (interp_local_stack h (interp_global (interp_intrinsics ui p) g) l) m) with
-    (interp_to_L3 ui p g l m) by reflexivity
+                                (interp_global (interp_intrinsics ?p) ?g) ?l) ?m] =>
+    replace (interp_memory (interp_local_stack h (interp_global (interp_intrinsics p) g) l) m) with
+    (interp_to_L3 p g l m) by reflexivity
   end.
 
 Ltac fold_L4 :=
@@ -304,14 +301,14 @@ Ltac fold_L4 :=
           model_undef ?RR
             (interp_memory
                (interp_local_stack ?h
-                                   (interp_global (interp_intrinsics ?ui ?p) ?g) ?l) ?m)] =>
-    replace (model_undef ?RR (interp_memory (interp_local_stack h (interp_global (interp_intrinsics ui p) g) l) m)) with
-    (interp_to_L4 RR ui p g l m) by reflexivity
+                                   (interp_global (interp_intrinsics ?p) ?g) ?l) ?m)] =>
+    replace (model_undef ?RR (interp_memory (interp_local_stack h (interp_global (interp_intrinsics p) g) l) m)) with
+    (interp_to_L4 RR p g l m) by reflexivity
   end.
 
 Ltac fold_L5 :=
   match goal with
-    |- context[model_UB ?RR (model_undef (Logic.eq) (interp_memory (interp_local_stack ?h (interp_global (interp_intrinsics ?ui ?p) ?g) ?l) ?m))] =>
-    replace (model_UB ?RR (model_undef (Logic.eq) (interp_memory (interp_local_stack h (interp_global (interp_intrinsics ui p) g) l) m))) with
-    (interp_to_L5 RR ui p g l m) by reflexivity
+    |- context[model_UB ?RR (model_undef (Logic.eq) (interp_memory (interp_local_stack ?h (interp_global (interp_intrinsics ?p) ?g) ?l) ?m))] =>
+    replace (model_UB ?RR (model_undef (Logic.eq) (interp_memory (interp_local_stack h (interp_global (interp_intrinsics p) g) l) m))) with
+    (interp_to_L5 RR p g l m) by reflexivity
   end.

--- a/src/coq/Utils/NoEvent.v
+++ b/src/coq/Utils/NoEvent.v
@@ -932,9 +932,9 @@ Admitted.
 Variable remove_pick_ub : itree (ExternalCallE +' PickE +' UBE +' DebugE +' FailureE) ~> itree (ExternalCallE +' DebugE +' FailureE).
 Variable deterministic_vellvm : forall R, itree L0 R -> Prop.
 (* Definition deterministic_vellvm *)
-Lemma deterministc_llvm_is_singleton : forall defs R RR t g sl mem,
+Lemma deterministc_llvm_is_singleton : forall R RR t g sl mem,
     deterministic_vellvm t ->
-    is_singleton (interp_to_L5 (R := R) RR defs t g sl mem) (remove_pick_ub (interp_to_L3 (R := R) defs t g sl mem)).
+    is_singleton (interp_to_L5 (R := R) RR t g sl mem) (remove_pick_ub (interp_to_L3 (R := R) t g sl mem)).
 
   (*
     Then the same statement on llvm syntax by applying it with (t := denote_llvm p)

--- a/src/ml/main.ml
+++ b/src/ml/main.ml
@@ -36,7 +36,7 @@ let make_test ll_ast t : string * assertion  =
       in
       Printf.sprintf "%s = %s(%s)" expected_str entry args_str
     in
-    let result () = Interpreter.step (TopLevel.interpreter_user dtyp (Camlcoq.coqstring_of_camlstring entry) args [] ll_ast) 
+    let result () = Interpreter.step (TopLevel.interpreter_gen dtyp (Camlcoq.coqstring_of_camlstring entry) args ll_ast) 
     in
     str, (Assert.assert_eqf result (Ok expected))
   | Assertion.POISONTest (dtyp, entry, args) ->
@@ -53,14 +53,14 @@ let make_test ll_ast t : string * assertion  =
       Printf.sprintf "%s = %s(%s)" expected_str entry args_str
      in
 
-     let result () = Interpreter.step(TopLevel.interpreter_user dtyp (Camlcoq.coqstring_of_camlstring entry) args [] ll_ast)
+     let result () = Interpreter.step(TopLevel.interpreter_gen dtyp (Camlcoq.coqstring_of_camlstring entry) args ll_ast)
      in 
      str, (Assert.assert_eqf result (Ok expected))
          
   | Assertion.SRCTGTTest (expected_rett, generated_args) ->
      let (_t_args, v_args) = List.split generated_args in
-     let res_src () = Interpreter.step(TopLevel.interpreter_user expected_rett (Camlcoq.coqstring_of_camlstring "src") v_args [] ll_ast) in
-     let res_tgt () = Interpreter.step(TopLevel.interpreter_user expected_rett (Camlcoq.coqstring_of_camlstring "tgt") v_args [] ll_ast) in
+     let res_src () = Interpreter.step(TopLevel.interpreter_gen expected_rett (Camlcoq.coqstring_of_camlstring "src") v_args ll_ast) in
+     let res_tgt () = Interpreter.step(TopLevel.interpreter_gen expected_rett (Camlcoq.coqstring_of_camlstring "tgt") v_args ll_ast) in
      let str =
        let src_str =
          match res_src () with


### PR DESCRIPTION
The semantics currently takes as parameter a field `user_intrinsics` that I believe is only crust from iterations on the design.

The initial intention was as follow:
- VIR provides a set of standard intrinsics whose names are collected in `defined_intrinsics`
- users can define their own intrinsics whose name are collected in `user_intrinsics`
- the top-level semantics takes `user_intrinsics` as argument.

However:
- these user intrinsics cannot be linked outside of the development, it needs to be recompiled anyway
- we have never used these user intrinsics
- it shows: there were a minor bug relating to them
- they are annoying as everything everywhere needs to be quantified by this useless parameter of `user_intrinsics`.

So I just removed completely this useless parameter in this branch.

Before merging I wanted to double check that we agree on this direction?