### PR TITLE
support for c string literals

### DIFF
--- a/src/coq/Semantics/Denotation.v
+++ b/src/coq/Semantics/Denotation.v
@@ -455,8 +455,10 @@ Module Denotation(A:MemoryAddress.ADDRESS)(LLVMEvents:LLVM_INTERACTIONS(A)).
           | Some t => lift_err ret (fmap dvalue_to_uvalue (dv_zero_initializer t))
           end
 
-        | EXP_Cstring s => raise "EXP_Cstring not yet implemented"
-
+        | EXP_Cstring es => 
+          vs <- map_monad eval_texp es ;;
+          ret (UVALUE_Array vs)
+          
         | EXP_Undef =>
           match top with
           | None   => raise "denote_exp given untyped EXP_Undef"

--- a/src/coq/Syntax/AstLib.v
+++ b/src/coq/Syntax/AstLib.v
@@ -379,7 +379,7 @@ Section ExpInd.
   Hypothesis IH_Bool    : forall (b:bool), P ((EXP_Bool b)).
   Hypothesis IH_Null    : P ((EXP_Null)).
   Hypothesis IH_Zero_initializer : P ((EXP_Zero_initializer)).
-  Hypothesis IH_Cstring : forall (s:string), P ((EXP_Cstring s)).
+  Hypothesis IH_Cstring : forall (elts: list (T * (exp T))), (forall p, In p elts -> P (snd p)) -> P ((EXP_Cstring elts)).
   Hypothesis IH_Undef   : P ((EXP_Undef)).
   Hypothesis IH_Struct  : forall (fields: list (T * (exp T))), (forall p, In p fields -> P (snd p)) -> P ((EXP_Struct fields)).
   Hypothesis IH_Packed_struct : forall (fields: list (T * (exp T))), (forall p, In p fields -> P (snd p)) -> P ((EXP_Packed_struct fields)).
@@ -414,6 +414,11 @@ Section ExpInd.
     - apply IH_Null.
     - apply IH_Zero_initializer.
     - apply IH_Cstring.
+      { revert elts.
+        fix IHelts 1. intros [|u elts']. intros. inversion H.
+        intros u' [<-|Hin]. apply IH. eapply IHelts. apply Hin.
+      }
+      
     - apply IH_Undef.
     - apply IH_Struct.
       { revert fields.
@@ -573,7 +578,6 @@ Section hiding_notation.
       | EXP_Bool b => to_sexp b
       | EXP_Null => Atom "null"
       | EXP_Zero_initializer => Atom "zero initializer"
-      | EXP_Cstring s => Atom s
       | EXP_Undef => Atom "undef"
       | OP_IBinop iop t v1 v2 =>
         [to_sexp iop ; to_sexp t

--- a/src/coq/Syntax/LLVMAst.v
+++ b/src/coq/Syntax/LLVMAst.v
@@ -251,7 +251,11 @@ Inductive exp : Set :=
 | EXP_Bool    (b:bool)
 | EXP_Null
 | EXP_Zero_initializer
-| EXP_Cstring         (s:string)
+| EXP_Cstring         (elts: list (T * exp))
+                      (* parsing guarantees that the elts of a Cstring will be of the form
+                         ((TYPE_I 8), Exp_Integer <byte>)
+                      *)
+
 | EXP_Undef
 | EXP_Struct          (fields: list (T * exp))
 | EXP_Packed_struct   (fields: list (T * exp))

--- a/src/coq/Syntax/Traversal.v
+++ b/src/coq/Syntax/Traversal.v
@@ -101,8 +101,9 @@ Section Endo.
         | EXP_Bool    _
         | EXP_Null
         | EXP_Zero_initializer
-        | EXP_Cstring _
         | EXP_Undef => e
+        | EXP_Cstring elts =>
+          EXP_Cstring (List.map (fun '(t,e) => (endo t, f_exp e)) elts)          
         | EXP_Struct fields =>
           EXP_Struct (List.map (fun '(t,e) => (endo t, f_exp e)) fields)
         | EXP_Packed_struct fields =>
@@ -450,7 +451,7 @@ Section Fmap.
         | EXP_Bool    b                      => EXP_Bool    b
         | EXP_Null                           => EXP_Null
         | EXP_Zero_initializer               => EXP_Zero_initializer
-        | EXP_Cstring s                      => EXP_Cstring s
+        | EXP_Cstring elts                   => EXP_Cstring (fmap ftexp elts)
         | EXP_Undef                          => EXP_Undef
         | EXP_Struct fields                  => EXP_Struct (fmap ftexp fields)
         | EXP_Packed_struct fields           => EXP_Packed_struct (fmap ftexp fields)

--- a/src/coq/Theory/ExpLemmas.v
+++ b/src/coq/Theory/ExpLemmas.v
@@ -645,7 +645,7 @@ Proof.
   - destruct o; cbn; [| apply failure_is_pure].
     apply failure_is_pure.
 
-  - apply failure_is_pure.
+  - admit.
 
   - destruct o; cbn; [| apply failure_is_pure].
     rewrite translate_ret, interp_cfg_to_L3_ret; apply eutt_Ret; intuition.

--- a/src/ml/ast_printer.ml
+++ b/src/ml/ast_printer.ml
@@ -243,7 +243,9 @@ and exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
 
     | EXP_Zero_initializer  -> pp_print_string ppf "EXP_Zero_initializer"
 
-    | EXP_Cstring s -> fprintf ppf "(EXP_Cstring \"%s\")" (of_str s)
+    | EXP_Cstring tvl         ->
+      fprintf ppf "(EXP_Cstring [%a])"
+        (pp_print_list ~pp_sep:pp_sc_space (pp_print_prod typ exp)) tvl
 
     | OP_IBinop (op, t, v1, v2) ->
       fprintf ppf "(OP_IBinop %a %a %a %a)"

--- a/src/ml/libvellvm/llvm_parser.mly
+++ b/src/ml/libvellvm/llvm_parser.mly
@@ -27,27 +27,7 @@
 
 open LLVMAst
 open ParserHelper
-
-let str = Camlcoq.coqstring_of_camlstring
-let coq_of_int = Camlcoq.Z.of_sint
-let n_of_z z = Camlcoq.N.of_int64 (Camlcoq.Z.to_int64 z)
-
-let coqfloat_of_string d = Floats.Float.of_bits(Camlcoq.coqint_of_camlint64(Int64.bits_of_float (float_of_string d)))
-let coqfloat32_of_string d = Floats.Float32.of_bits(Camlcoq.coqint_of_camlint(Int32.bits_of_float (float_of_string d)))
-
-let rec string_of_positive =
-  let open BinNums in
-  function 
-    | Coq_xI p -> string_of_positive p ^ "1"
-    | Coq_xO p -> string_of_positive p ^ "0"
-    | Coq_xH -> "1"
-
-let string_of_Z =
-  let open BinNums in
-  function
-    | Z0 -> "0"
-    | Zpos v -> string_of_positive v
-    | Zneg v -> "-" ^ (string_of_positive v)
+open ParseUtil
 
 (* normalize_float_size : 
    - LLVM floating point literals need different interpretations depending
@@ -698,7 +678,9 @@ expr_val:
   | LSQUARE l=separated_list(csep, tconst) RSQUARE    { fun _ -> EXP_Array l          }
   | LT l=separated_list(csep, tconst) GT              { fun _ -> EXP_Vector l         }
   | i=ident                                           { fun _ -> EXP_Ident i          }
-  | KW_C cstr=STRING                                  { fun _ -> EXP_Cstring (str cstr) }
+  | KW_C cstr=STRING                                  { fun _ -> EXP_Cstring (
+								     cstring_bytes_to_LLVM_i8_array
+								     (unescape (str cstr))) }
 
 exp:
   | eo=expr_op { fun _ -> eo }

--- a/src/ml/libvellvm/llvm_printer.ml
+++ b/src/ml/libvellvm/llvm_printer.ml
@@ -3,11 +3,8 @@
 (*  ------------------------------------------------------------------------- *)
 
 open Format
-
-let of_str = Camlcoq.camlstring_of_coqstring
-let to_int = Camlcoq.Z.to_int
-let n_to_int = Camlcoq.N.to_int
-let float_of_coqfloat = Camlcoq.camlfloat_of_coqfloat
+open LLVMAst
+open ParseUtil
 
 (* TODO: Use pp_option everywhere instead of inlined matching *)
 let pp_option ppf f o =
@@ -21,8 +18,6 @@ let rec pp_print_list ?(pp_sep = Format.pp_print_cut) pp_v ppf = function
 | v :: vs ->
     pp_v ppf v; if vs <> [] then (pp_sep ppf ();
                                   pp_print_list ~pp_sep pp_v ppf vs)
-
-open LLVMAst
 
 let get_function_type dc_type =
   match dc_type with
@@ -286,7 +281,7 @@ and exp : Format.formatter -> (LLVMAst.typ LLVMAst.exp) -> unit =
                                        (pp_print_list ~pp_sep:pp_comma_space texp) tvl
   | EXP_Zero_initializer  -> pp_print_string ppf "zeroinitializer"
 
-  | EXP_Cstring s -> fprintf ppf "c\"%s\"" (of_str s)
+  | EXP_Cstring s -> fprintf ppf "c\"%s\"" (of_str (escape (llvm_i8_array_to_cstring_bytes s)))
 
   | OP_IBinop (op, t, v1, v2) ->
      fprintf ppf "%a (%a %a, %a %a)"

--- a/src/ml/libvellvm/parseUtil.ml
+++ b/src/ml/libvellvm/parseUtil.ml
@@ -1,0 +1,154 @@
+let str = Camlcoq.coqstring_of_camlstring
+let of_str = Camlcoq.camlstring_of_coqstring
+
+
+let coq_of_int = Camlcoq.Z.of_sint
+let to_int = Camlcoq.Z.to_int
+let n_to_int = Camlcoq.N.to_int
+
+let n_of_z z = Camlcoq.N.of_int64 (Camlcoq.Z.to_int64 z)
+
+
+let byte_to_i8 (b:char) =
+  (LLVMAst.TYPE_I (n_of_z (coq_of_int 8)), LLVMAst.EXP_Integer (coq_of_int (int_of_char b)))
+
+let i8_to_byte (typ, exp) =
+  begin match (typ, exp) with
+  | LLVMAst.TYPE_I sz, LLVMAst.EXP_Integer z ->
+     if (n_to_int sz) <> 8 then failwith "i8_to_byte failed with non-byte type annotation"
+     else Char.chr (to_int z)
+  | _ -> failwith "i8_to_byte failed with incorrect type/value"
+  end
+
+
+(* Dealing with C escape sequences: 
+    escape   : bytes -> bytes
+    unescape : bytes -> bytes
+
+*)
+
+(* 
+   c :: tail
+ *)
+
+let octal_digit (c : char) : int option  =
+  let c = Char.code c in
+  if c < 48 || c > 55
+  then None
+  else Some (c - 48)
+
+let hex_digit (c : char) : int option  =
+  let c = Char.code c in
+  if 48 <= c && c <= 57 then Some (c - 48)            (* 0 .. 9 *)
+  else if 65 <= c && c <= 70 then Some (c - 65 + 10)  (* A .. F *)
+  else if 97 <= c && c <= 102 then Some (c - 97 + 10) (* a .. f *)
+  else None
+
+
+(* 
+   SAZ: Despite their name, the so called "c string" literals in LLVM IR
+   really don't have anything to do with C strings.  They don't use any of
+   the same syntactic conventions for escape characters.
+
+   In LLVM the only form of escaped characters are \\ (slash) or
+   \hh where h is a hex number.
+ *)
+
+
+(* Parses a sequence of characters following a \ to see if it is a legal LLVM IR
+   escape sequence (excluding the leading \). 
+   returns 
+      None if the sequence isn't legal
+      Some (c, rest), where c is the decoded byte and rest is the remainder of the list.
+*)
+let interpret_escaped str : (char * char list) option =
+  begin match str with
+  | [] ->
+     None
+
+  | '\\' :: rest ->
+     (* found second \, so it is valid *)
+     Some ('\\', rest)
+     
+  | c1 :: c2 :: rest ->
+     begin match (hex_digit c1, hex_digit c2) with
+     | Some d1, Some d2  ->
+        Some (Char.chr (16 * d1 + d2), rest)
+     | _ ->
+        None
+     end
+
+  | _ ->
+     None
+  end
+
+let unescape (str : char list) : char list =
+  let rec go str acc =
+    begin match str with
+    | [] ->
+       List.rev acc 
+
+    | '\\' :: esc ->
+       begin match interpret_escaped esc with
+       | None -> go esc ('\\'::acc)
+       | Some (c, rest) -> go rest (c::acc)
+       end
+          
+    | x :: rest ->
+       go rest (x::acc)
+    end
+  in
+  go str []
+
+let int_to_hex_digit (h : int) : char =
+  if h < 10
+  then Char.chr (h+48)
+  else Char.chr (h-10 + 65)
+
+let to_hex_digits (c : char) : char * char =
+  let u = (Char.code c) / 16 in
+  let l = (Char.code c) mod 16 in
+  (int_to_hex_digit u, int_to_hex_digit l)
+
+(* Characters that _must_ be escaped inside of strings are the "unprintable" characters:
+   (Char.code c) < 32 || (Char.code c) >= 127
+ *)
+let escape_char (c:char) : char list =
+  if (Char.code c) < 32 || (Char.code c) >= 127 then
+    let (u,l) = to_hex_digits c in [u;l]
+  else [c]
+
+let escape (str : char list) : char list =
+  List.concat_map escape_char str
+
+let cstring_bytes_to_LLVM_i8_array bytes =
+  List.map byte_to_i8 bytes
+
+let llvm_i8_array_to_cstring_bytes arr =
+  List.map i8_to_byte arr
+
+
+let coqfloat_of_string d =
+  Floats.Float.of_bits(Camlcoq.coqint_of_camlint64(Int64.bits_of_float (float_of_string d)))
+
+let coqfloat32_of_string d =
+  Floats.Float32.of_bits(Camlcoq.coqint_of_camlint(Int32.bits_of_float (float_of_string d)))
+
+let rec string_of_positive =
+  let open BinNums in
+  function 
+    | Coq_xI p -> string_of_positive p ^ "1"
+    | Coq_xO p -> string_of_positive p ^ "0"
+    | Coq_xH -> "1"
+
+let string_of_Z =
+  let open BinNums in
+  function
+    | Z0 -> "0"
+    | Zpos v -> string_of_positive v
+    | Zneg v -> "-" ^ (string_of_positive v)
+
+
+let float_of_coqfloat = Camlcoq.camlfloat_of_coqfloat
+
+

--- a/tests/string/string1.ll
+++ b/tests/string/string1.ll
@@ -1,0 +1,26 @@
+@str = global [14 x i8] c"Hello World!\0A\00"
+
+@arr = global [14 x i8] [i8 72, i8 101, i8 108, i8 108, i8 111, i8 32,  i8 87,  i8 111, i8 114, i8 108, i8 100, i8 33,  i8 10,  i8 0]
+
+
+define i8 @index(i32 %x) {
+  %addr = getelementptr [14 x i8], [14 x i8]* @str, i32 0, i32 %x
+  %char = load i8, i8* %addr
+  ret i8 %char
+}
+
+; ASSERT EQ: i8 72  = call i8 @index(i32 0)
+; ASSERT EQ: i8 101 = call i8 @index(i32 1)
+; ASSERT EQ: i8 108 = call i8 @index(i32 2)
+; ASSERT EQ: i8 108 = call i8 @index(i32 3)
+; ASSERT EQ: i8 111 = call i8 @index(i32 4)
+; ASSERT EQ: i8 32  = call i8 @index(i32 5)
+; ASSERT EQ: i8 87  = call i8 @index(i32 6)
+; ASSERT EQ: i8 111 = call i8 @index(i32 7)
+; ASSERT EQ: i8 114 = call i8 @index(i32 8)
+; ASSERT EQ: i8 108 = call i8 @index(i32 9)
+; ASSERT EQ: i8 100 = call i8 @index(i32 10)
+; ASSERT EQ: i8 33  = call i8 @index(i32 11)
+; ASSERT EQ: i8 10  = call i8 @index(i32 12)
+; ASSERT EQ: i8 0   = call i8 @index(i32 13)
+

--- a/tests/string/string2.ll
+++ b/tests/string/string2.ll
@@ -1,0 +1,15 @@
+@str = global [7 x i8] c"\n\03\XY\17"
+
+define i8 @index(i32 %x) {
+  %addr = getelementptr [7 x i8], [7 x i8]* @str, i32 0, i32 %x
+  %char = load i8, i8* %addr
+  ret i8 %char
+}
+
+; ASSERT EQ: i8 92  = call i8 @index(i32 0)
+; ASSERT EQ: i8 110 = call i8 @index(i32 1)
+; ASSERT EQ: i8 3   = call i8 @index(i32 2)
+; ASSERT EQ: i8 92  = call i8 @index(i32 3)
+; ASSERT EQ: i8 88  = call i8 @index(i32 4)
+; ASSERT EQ: i8 89  = call i8 @index(i32 5)
+; ASSERT EQ: i8 23  = call i8 @index(i32 6)

--- a/tests/string/string3.ll
+++ b/tests/string/string3.ll
@@ -1,0 +1,9 @@
+@str = global [1 x i8] c"\22"
+
+define i8 @index(i32 %x) {
+  %addr = getelementptr [1 x i8], [1 x i8]* @str, i32 0, i32 %x
+  %char = load i8, i8* %addr
+  ret i8 %char
+}
+
+; ASSERT EQ: i8 34  = call i8 @index(i32 0)

--- a/tests/string/string4.ll
+++ b/tests/string/string4.ll
@@ -1,0 +1,9 @@
+@str = global [1 x i8] c"\\"
+
+define i8 @index(i32 %x) {
+  %addr = getelementptr [1 x i8], [1 x i8]* @str, i32 0, i32 %x
+  %char = load i8, i8* %addr
+  ret i8 %char
+}
+
+; ASSERT EQ: i8 92  = call i8 @index(i32 0)

--- a/tests/string/string5.ll
+++ b/tests/string/string5.ll
@@ -1,0 +1,11 @@
+@str = global [3 x i8] c"\1X"
+
+define i8 @index(i32 %x) {
+  %addr = getelementptr [3 x i8], [3 x i8]* @str, i32 0, i32 %x
+  %char = load i8, i8* %addr
+  ret i8 %char
+}
+
+; ASSERT EQ: i8 92  = call i8 @index(i32 0)
+; ASSERT EQ: i8 49  = call i8 @index(i32 1)
+; ASSERT EQ: i8 88  = call i8 @index(i32 2)

--- a/tests/string/string6.ll
+++ b/tests/string/string6.ll
@@ -1,0 +1,11 @@
+@str = global [3 x i8] c"\\11"
+
+define i8 @index(i32 %x) {
+  %addr = getelementptr [3 x i8], [3 x i8]* @str, i32 0, i32 %x
+  %char = load i8, i8* %addr
+  ret i8 %char
+}
+
+; ASSERT EQ: i8 92  = call i8 @index(i32 0)
+; ASSERT EQ: i8 49  = call i8 @index(i32 1)
+; ASSERT EQ: i8 49  = call i8 @index(i32 2)


### PR DESCRIPTION
Added support for LLVM IR's c string literals.  They are translated to/from i8 arrays during parsing/pretty printing. 

Submitting as a pull request to avoid any unintentional interference with HELIX.