### PR TITLE
Print the error message passed to raise as a side effect instead of including it in the failure event

### DIFF
--- a/src/coq/Semantics/LLVMEvents.v
+++ b/src/coq/Semantics/LLVMEvents.v
@@ -95,10 +95,14 @@ Set Contextual Implicit.
   Definition debug {E} `{DebugE -< E} (msg : string) : itree E unit :=
     trigger (Debug msg).
 
-  Definition FailureE := exceptE string.
+  Definition FailureE := exceptE unit.
+
+  (* This function can be replaced with print_string during extraction
+     to print the error messages of Throw and (indirectly) ThrowUB. *)
+  Definition print_msg (msg : string) : unit := tt.
 
   Definition raise {E} {A} `{FailureE -< E} (msg : string) : itree E A :=
-    v <- trigger (Throw msg);; match v: void with end.
+    v <- trigger (Throw (print_msg msg));; match v: void with end.
     
   Definition lift_err {A B} {E} `{FailureE -< E} (f : A -> itree E B) (m:err A) : itree E B :=
     match m with

--- a/src/ml/extracted/Extract.v
+++ b/src/ml/extracted/Extract.v
@@ -51,6 +51,15 @@ Extract Inlined Constant ascii_dec => "(=)".
 Extract Inductive string => "string" [ "str_nil" "str_cons" ].
 *)
 
+(* camlstring_of_coqstring is from Camlcoq *)
+Extract Constant print_msg => "let camlstring_of_coqstring (s: char list) =
+  let r = Bytes.create (List.length s) in
+  let rec fill pos = function
+  | [] -> r
+  | c :: s -> Bytes.set r pos c; fill (pos + 1) s
+  in Bytes.to_string (fill 0 s)
+in fun msg -> print_string (camlstring_of_coqstring msg ^ ""\n"")".
+
 (* OCaml pervasive types ---------------------------------------------------- *)
 (* Extract Inlined Constant LLVMAst.int => "int". *)
 (* Extract Inlined Constant LLVMAst.float => "float". *)

--- a/src/ml/libvellvm/interpreter.ml
+++ b/src/ml/libvellvm/interpreter.ml
@@ -92,8 +92,8 @@ let rec step (m : ('a coq_L5, memory_stack * ((local_env * lstack) * (global_env
       step (k (Obj.magic DV.UVALUE_None)))
 
   (* The failE effect is a failure *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 f), _) ->
-     Error (Camlcoq.camlstring_of_coqstring f)
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 _), _) ->
+     Error "Failure effect"
 
   (* The UndefinedBehaviourE effect is a failure *)
   (* | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 f)), _) -> *)


### PR DESCRIPTION
This introduces a `print_msg` function that is a no-op in Coq but extracted to an actual printing function in OCaml.
This allows to prove properties like `eutt eq (raise msg1) (raise msg2)`.