### PR TITLE
Document that coq quickcheck library is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Our current test-suite of LLVM programs for which we compare our semantics again
     * ceres      (installed via, e.g. `opam install coq-ceres`)
     * mathcomp   (installed via, e.g. `opam install coq-mathcomp-ssreflect`)
     * simple-io  (installed via, e.g. `opam install coq-simple-io`)
+    * quickcheck (installed via, e.g. `opam install coq-quickchick`)
 
   - Additional opam packages: 
     * ocamlbuild (installed via, e.g. `opam install ocamlbuild`)

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ COQLIBDIR = ../lib
 MLDIR = ml
 EXTRACTDIR = ml/extracted
 
-OPAMPKGS=coq coq-ext-lib coq-paco coq-ceres coq-flocq coq-mathcomp-ssreflect coq-simple-io coq-itree cppo dune menhir qcheck ocamlbuild
+OPAMPKGS=coq coq-ext-lib coq-paco coq-ceres coq-flocq coq-mathcomp-ssreflect coq-simple-io coq-itree cppo dune menhir qcheck ocamlbuild coq-quickchick
 
 QUICKCHICKDIR=../lib/QuickChick
 FLOCQQUICKCHICKDIR=../lib/flocq-quickchick


### PR DESCRIPTION
Mentions in the README and in the makefile that [coq-quickcheck](https://github.com/QuickChick/QuickChick) is required now as well to build the package.