### PR TITLE
Memory testing gen solved aggregate and vector element bug

### DIFF
--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -962,12 +962,6 @@ Definition genType: G (typ) :=
   (* TODO: should make it much more likely to pick an identifier for
            better test cases *)
 
-  Fixpoint gen_exp_size_wo_ctx (sz: nat) (t : typ) {struct t} : GenLLVM (exp typ) :=
-    match sz with
-    | 0%nat => ret (EXP_Null)
-    | S z => ret (EXP_Null)
-    end.
-
   Fixpoint gen_exp_size (sz : nat) (t : typ) {struct t} : GenLLVM (exp typ) :=
     match sz with
     | 0%nat =>


### PR DESCRIPTION
Edit to both let vector to have size greater than 0 and generate expression such that the element of aggregate types and vector type to not have local identifier