### PR TITLE
Added in insertValue insertElement and extractElement

### DIFF
--- a/src/coq/Handlers/Serialization.v
+++ b/src/coq/Handlers/Serialization.v
@@ -159,10 +159,10 @@ Module Type SerializationBase (LP : LLVMParams) (MP : MemoryParams LP).
         | UVALUE_ExtractElement vec_typ vec idx =>
             dvec <- concretize_uvalueM M undef_handler ERR_M lift_ue vec;;
             didx <- concretize_uvalueM M undef_handler ERR_M lift_ue idx;;
-            let elt_typ := match vec_typ with
-                           | DTYPE_Vector _ t => ret t
-                           | _ => lift_ue (raise_error "Invalid vector type for ExtractElement")
-                           end in 
+            elt_typ <- match vec_typ with
+                       | DTYPE_Vector _ t => ret t
+                       | _ => lift_ue _ (raise_error "Invalid vector type for ExtractElement")
+                       end;; 
             lift_ue dvalue (index_into_vec_dv elt_typ dvec didx)
         | UVALUE_InsertElement vec_typ vec elt idx =>
             dvec <- concretize_uvalueM M undef_handler ERR_M lift_ue vec;;

--- a/src/coq/Handlers/Serialization.v
+++ b/src/coq/Handlers/Serialization.v
@@ -151,29 +151,19 @@ Module Type SerializationBase (LP : LLVMParams) (MP : MemoryParams LP).
                   v <- insert_into_str str elt i;;
                   ret v
               | i :: tl =>
-                  v <- index_into_str_dv str i;;
-                  loop v tl
+                      v <- index_into_str_dv str i;;
+                      v2 <- loop v tl;;
+                      v3 <- insert_into_str str v2 i;;
+                      ret v3
               end in
             lift_ue dvalue (loop str idxs)
         | UVALUE_ExtractElement vec_typ vec idx =>
             dvec <- concretize_uvalueM M undef_handler ERR_M lift_ue vec;;
             didx <- concretize_uvalueM M undef_handler ERR_M lift_ue idx;;
-            let elt_typ := match dvec with
-                           | DVALUE_Vector elts => match elts with
-                                                  | [] => DTYPE_Void
-                                                  | hd::tl => match hd with
-                                                            | DVALUE_I1 _ => DTYPE_I 1
-                                                            | DVALUE_I8 _ => DTYPE_I 8
-                                                            | DVALUE_I32 _ => DTYPE_I 32
-                                                            | DVALUE_I64 _ => DTYPE_I 64
-                                                            | DVALUE_IPTR _ => DTYPE_Pointer
-                                                            | DVALUE_Float _ => DTYPE_Float
-                                                            | DVALUE_Double _ => DTYPE_Double
-                                                            | _ => DTYPE_Void (* Won't reach here *)
-                                                            end
-                                                  end
-                           | _ => DTYPE_Void (* Won't reach here*)
-                           end in
+            let elt_typ := match vec_typ with
+                           | DTYPE_Vector _ t => t
+                           | _ => DTYPE_Void (* Won't reach here *)
+                           end in 
             lift_ue dvalue (index_into_vec_dv elt_typ dvec didx)
         | UVALUE_InsertElement vec_typ vec elt idx =>
             dvec <- concretize_uvalueM M undef_handler ERR_M lift_ue vec;;
@@ -924,29 +914,19 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) : SerializationBase LP 
                   v <- insert_into_str str elt i;;
                   ret v
               | i :: tl =>
-                  v <- index_into_str_dv str i;;
-                  loop v tl
+                      v <- index_into_str_dv str i;;
+                      v2 <- loop v tl;;
+                      v3 <- insert_into_str str v2 i;;
+                      ret v3
               end in
             lift_ue (loop str idxs)
         | UVALUE_ExtractElement vec_typ vec idx =>
             dvec <- concretize_uvalueM vec;;
             didx <- concretize_uvalueM idx;;
-            let elt_typ := match dvec with
-                           | DVALUE_Vector elts => match elts with
-                                                  | [] => DTYPE_Void
-                                                  | hd::tl => match hd with
-                                                            | DVALUE_I1 _ => DTYPE_I 1
-                                                            | DVALUE_I8 _ => DTYPE_I 8
-                                                            | DVALUE_I32 _ => DTYPE_I 32
-                                                            | DVALUE_I64 _ => DTYPE_I 64
-                                                            | DVALUE_IPTR _ => DTYPE_Pointer
-                                                            | DVALUE_Float _ => DTYPE_Float
-                                                            | DVALUE_Double _ => DTYPE_Double
-                                                            | _ => DTYPE_Void (* Won't reach here *)
-                                                            end
-                                                  end
-                           | _ => DTYPE_Void (* Won't reach here*)
-                           end in
+            let elt_typ := match vec_typ with
+                           | DTYPE_Vector _ t => t
+                           | _ => DTYPE_Void (* Won't reach here *)
+                           end in 
             lift_ue (index_into_vec_dv elt_typ dvec didx)
         | UVALUE_InsertElement vec_typ vec elt idx =>
             dvec <- concretize_uvalueM vec;;
@@ -1104,44 +1084,34 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) : SerializationBase LP 
                 (* TODO: maybe this is just an error? ExtractByte should be guarded by ConcatBytes? *)
                 lift_ue (raise_error "Attempting to concretize UVALUE_ExtractByte, should not happen.")
             | UVALUE_InsertValue t uv elt idxs =>
-            str <- concretize_uvalueM uv;;
-            elt <- concretize_uvalueM elt;;
-            let fix loop str idxs : ERR_M dvalue :=
-              match idxs with
-            | [] => ret str (* What to do? Do we print out some error *)
-            | i :: nil =>
-                  v <- insert_into_str str elt i;;
-                  ret v
-            | i :: tl =>
-                  v <- index_into_str_dv str i;;
-                  loop v tl
-              end in
-            lift_ue (loop str idxs)
-        | UVALUE_ExtractElement vec_typ vec idx =>
-            dvec <- concretize_uvalueM vec;;
-            didx <- concretize_uvalueM idx;;
-            let elt_typ := match dvec with
-                           | DVALUE_Vector elts => match elts with
-                                                  | [] => DTYPE_Void
-                                                  | hd::tl => match hd with
-                                                            | DVALUE_I1 _ => DTYPE_I 1
-                                                            | DVALUE_I8 _ => DTYPE_I 8
-                                                            | DVALUE_I32 _ => DTYPE_I 32
-                                                            | DVALUE_I64 _ => DTYPE_I 64
-                                                            | DVALUE_IPTR _ => DTYPE_Pointer
-                                                            | DVALUE_Float _ => DTYPE_Float
-                                                            | DVALUE_Double _ => DTYPE_Double
-                                                            | _ => DTYPE_Void (* Won't reach here *)
-                                                            end
-                                                  end
-                           | _ => DTYPE_Void (* Won't reach here*)
-                           end in
-            lift_ue (index_into_vec_dv elt_typ dvec didx)
-        | UVALUE_InsertElement vec_typ vec elt idx =>
-            dvec <- concretize_uvalueM vec;;
-            didx <- concretize_uvalueM idx;;
-            delt <- concretize_uvalueM elt;;
-            lift_ue (insert_into_vec_dv vec_typ dvec delt didx)
+                str <- concretize_uvalueM uv;;
+                elt <- concretize_uvalueM elt;;
+                let fix loop str idxs : ERR_M dvalue :=
+                  match idxs with
+                  | [] => ret str (* What to do? Do we print out some error *)
+                  | i :: nil =>
+                      v <- insert_into_str str elt i;;
+                      ret v
+                  | i :: tl =>
+                      v <- index_into_str_dv str i;;
+                      v2 <- loop v tl;;
+                      v3 <- insert_into_str str v2 i;;
+                      ret v3
+                  end in
+                lift_ue (loop str idxs)
+            | UVALUE_ExtractElement vec_typ vec idx =>
+                dvec <- concretize_uvalueM vec;;
+                didx <- concretize_uvalueM idx;;
+                let elt_typ := match vec_typ with
+                               | DTYPE_Vector _ t => t
+                               | _ => DTYPE_Void (* Won't reach here *)
+                               end in 
+                lift_ue (index_into_vec_dv elt_typ dvec didx)
+            | UVALUE_InsertElement vec_typ vec elt idx =>
+                dvec <- concretize_uvalueM vec;;
+                didx <- concretize_uvalueM idx;;
+                delt <- concretize_uvalueM elt;;
+                lift_ue (insert_into_vec_dv vec_typ dvec delt didx)
             | _ => lift_ue (raise_error ("concretize_uvalueM: Attempting to convert a partially non-reduced uvalue to dvalue. Should not happen: " ++ uvalue_constructor_string u))
 
             end.

--- a/tests/memory/insertAndExtractElement.ll
+++ b/tests/memory/insertAndExtractElement.ll
@@ -41,3 +41,7 @@ define i64 @insertAndRemove(i64 %location, i64 %val, i64 %removeLoc) {
 ; ASSERT EQ: i64 10 = call i64 @insertAndRemove(i64 3, i64 2, i64 1)
 ; ASSERT EQ: i64 15 = call i64 @insertAndRemove(i64 3, i64 2, i64 2)
 ; ASSERT EQ: i64 2 = call i64 @insertAndRemove(i64 3, i64 2, i64 3)
+
+
+
+

--- a/tests/memory/insertAndExtractValue.ll
+++ b/tests/memory/insertAndExtractValue.ll
@@ -2,16 +2,43 @@ define i32  @testExtractX() {
   %agg1 = insertvalue {i32, float} undef, i32 1, 0            
   %agg2 = insertvalue {i32, float} %agg1, float 10.0, 1
   %val = extractvalue {i32, float} %agg2, 0
-  ret i32 %agg2
+  ret i32 %val
 }
 
 define float @testExtractY() {
   %agg1 = insertvalue {i32, float} undef, i32 1, 0            
   %agg2 = insertvalue {i32, float} %agg1, float 20.0, 1
   %val = extractvalue {i32, float} %agg2, 1
-  ret float %agg2
+  ret float %val
 }
+
+define i32 @testValuesChange() {
+  %agg1 = add [4 x i32] [i32 10, i32 20, i32 30, i32 40], zeroinitializer          
+  %agg2 = insertvalue [4 x i32] %agg1, i32 100, 1
+  %val = extractvalue [4 x i32] %agg2, 1
+  ret i32 %val
+}
+
+define i32 @testChangeDifferentLocation() {
+  %agg1 = add [4 x i32] [i32 10, i32 20, i32 30, i32 40], zeroinitializer          
+  %agg2 = insertvalue [4 x i32] %agg1, i32 100, 1
+  %val = extractvalue [4 x i32] %agg2, 3
+  ret i32 %val
+}
+
+define i32 @testSingletonArray() {
+  %agg1 = add [1 x i32] [i32 4], zeroinitializer
+  %agg2 = insertvalue [1 x i32] %agg1, i32 60, 0
+  %val = extractvalue [1 x i32] %agg2, 0
+  ret i32 %val
+  }
 
 ; ASSERT EQ: i32 1 = call i32 @testExtractX()
 
 ; ASSERT EQ: float 20.0 = call float @testExtractY()
+
+; ASSERT EQ: i32 100 = call i32 @testValuesChange()
+
+; ASSERT EQ: i32 40 = call i32 @testChangeDifferentLocation()
+
+; ASSERT EQ: i32 60 = call i32 @testSingletonArray() 


### PR DESCRIPTION
We added in functionality for these three functions in all three concretize_uvalue spots. Some of the test cases that I wrote for insert and extract value pass, but not all. None of the tests pass for insert and extract element, and I'm not yet sure if that's based on the test cases themselves or the code in Serialization.v