### PR TITLE
Memory testing performance: PR #223 on alloca performance

### DIFF
--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -397,18 +397,18 @@ Definition filter_sized_typs (typ_ctx: list (ident * typ)) (ctx : list (ident * 
     | (S sz') =>
         ctx <- get_ctx;;
         aliases <- get_typ_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
-        oneOf_LLVM
-        (typs_in_ctx ++[gen_sized_typ_0
-        ; ret TYPE_Pointer <*> gen_sized_typ_size sz'
+        let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) (filter_sized_typs aliases ctx) in
+       freq_LLVM
+        (typs_in_ctx ++[(1%nat, gen_sized_typ_0)
+        ; (1%nat, ret TYPE_Pointer <*> gen_sized_typ_size sz')
         (* TODO: Might want to restrict the size to something reasonable *)
-        ; ret TYPE_Array <*> lift_GenLLVM genN <*> gen_sized_typ_size sz'
-        ; ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_sized_typ_size 0
+        ; (1%nat, ret TYPE_Array <*> lift_GenLLVM genN <*> gen_sized_typ_size sz')
+        ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_sized_typ_size 0)
         (* TODO: I don't think functions are sized types? *)
         (* ; let n := Nat.div sz 2 in *)
         (*   ret TYPE_Function <*> gen_sized_typ_size n <*> listOf_LLVM (gen_sized_typ_size n) *)
-        ; ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')
-        ; ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')
+        ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+        ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
           ])
     end.
   Next Obligation.
@@ -424,17 +424,17 @@ Definition filter_sized_typs (typ_ctx: list (ident * typ)) (ctx : list (ident * 
     | (S sz') =>
         ctx <- get_ctx;;
         aliases <- get_typ_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
-      oneOf_LLVM
-        (typs_in_ctx ++ [ gen_sized_typ_0
+        let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) (filter_sized_typs aliases ctx) in
+      freq_LLVM
+        (typs_in_ctx ++ [(1%nat, gen_sized_typ_0)
         (* TODO: Might want to restrict the size to something reasonable *)
-        ; ret TYPE_Array <*> lift_GenLLVM genN <*> gen_sized_typ_size_ptrinctx sz'
-        ; ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_sized_typ_size_ptrinctx 0
+        ; (1%nat, ret TYPE_Array <*> lift_GenLLVM genN <*> gen_sized_typ_size_ptrinctx sz')
+        ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_sized_typ_size_ptrinctx 0)
         (* TODO: I don't think functions are sized types? *)
         (* ; let n := Nat.div sz 2 in *)
         (*   ret TYPE_Function <*> gen_sized_typ_size n <*> listOf_LLVM (gen_sized_typ_size n) *)
-        ; ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size_ptrinctx sz')
-        ; ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size_ptrinctx sz')])
+        ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size_ptrinctx sz'))
+        ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size_ptrinctx sz'))])
     end.
   Next Obligation.
   lia.
@@ -480,18 +480,18 @@ Definition filter_sized_typs (typ_ctx: list (ident * typ)) (ctx : list (ident * 
     | 0%nat => gen_typ_0
     | (S sz') =>
         ctx <- get_ctx;;
-        aliases <- get_typ_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
-        oneOf_LLVM
-          (typs_in_ctx ++ [ gen_typ_0 (* TODO: Not sure if I need to add it here *)
+        (* not filter sized types for this one *)
+        let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) ctx in
+        freq_LLVM
+          (typs_in_ctx ++ [ (1%nat, gen_typ_0) (* TODO: Not sure if I need to add it here *)
               (* Might want to restrict the size to something reasonable *)
               (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-            ; ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz'
-            ; ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0
+            ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
+            ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
             ; let n := Nat.div sz 2 in
-              ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n)
-            ; ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')
-            ; ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')
+              (1%nat, ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n))
+            ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+            ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
           ])
     end.
   Next Obligation.
@@ -539,17 +539,17 @@ Definition filter_sized_typs (typ_ctx: list (ident * typ)) (ctx : list (ident * 
     | (S sz') =>
         ctx <- get_ctx;;
         aliases <- get_typ_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
-        oneOf_LLVM        
-          (typs_in_ctx ++[ gen_typ_non_void_0
+        let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) (filter_sized_typs aliases ctx) in
+        freq_LLVM        
+          (typs_in_ctx ++[ (1%nat, gen_typ_non_void_0)
               (* Might want to restrict the size to something reasonable *)
               (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-            ; ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz'
-            ; ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0
+            ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
+            ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
             ; let n := Nat.div sz 2 in
-              ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n)
-            ; ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')
-            ; ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')
+              (1%nat, ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n))
+            ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+            ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
           ])
     end.
 
@@ -559,15 +559,15 @@ Definition filter_sized_typs (typ_ctx: list (ident * typ)) (ctx : list (ident * 
   | (S sz') =>
       ctx <- get_ctx;;
       aliases <- get_typ_ctx;;
-      let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
-      oneOf_LLVM                
-        (typs_in_ctx ++ [ gen_typ_non_void_0
+      let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) (filter_sized_typs aliases ctx) in
+      freq_LLVM                
+        (typs_in_ctx ++ [ (1%nat, gen_typ_non_void_0)
             (* Might want to restrict the size to something reasonable *)
             (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-          ; ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz'
-          ; ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0
-          ; ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')
-          ; ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')
+          ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
+          ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
+          ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+          ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
         ])
   end.
 

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -429,13 +429,13 @@ Definition filter_ptr_typs (ctx : list (ident * typ)) : list (ident * typ) :=
 
         ; ctx <- get_ctx;;
           let ptrs_in_ctx := filter_ptr_typs ctx in
-          if seq.nilp ptrs_in_ctx then '(_,typ) <- oneOf_LLVM (map ret ctx);; ret typ else '(_,typ) <- oneOf_LLVM (map ret ptrs_in_ctx);; ret typ
+          if seq.nilp ptrs_in_ctx then '(_,typ) <- oneOf_LLVM (map ret ctx);; ret typ else gen_sized_typ_size_ptrinctx sz' (* If not simply wait till the next size. This will prevent any failGen *)
         ])
     end.
   Next Obligation.
   lia.
   Defined.
-
+    
   Definition gen_sized_typ_ptrinctx : GenLLVM typ
     := sized_LLVM (fun sz => gen_sized_typ_size_ptrinctx sz).
   

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -464,9 +464,10 @@ Definition filter_ptr_vecptr_typ (ctx: list (ident * typ)) : list (ident * typ) 
     | (S sz') =>
         ctx <- get_ctx;;
         aliases <- get_typ_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) (filter_sized_typs aliases ctx) in
-       freq_LLVM
-        (typs_in_ctx ++[(1%nat, gen_sized_typ_0)
+        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
+        freq_LLVM
+        ([(min (List.length typs_in_ctx) 10, oneOf_LLVM typs_in_ctx)] ++
+         [(1%nat, gen_sized_typ_0)
         ; (1%nat, ret TYPE_Pointer <*> gen_sized_typ_size sz')
         (* TODO: Might want to restrict the size to something reasonable *)
         ; (1%nat, ret TYPE_Array <*> lift_GenLLVM genN <*> gen_sized_typ_size sz')
@@ -491,9 +492,10 @@ Definition filter_ptr_vecptr_typ (ctx: list (ident * typ)) : list (ident * typ) 
     | (S sz') =>
         ctx <- get_ctx;;
         aliases <- get_typ_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) (filter_sized_typs aliases ctx) in
-      freq_LLVM
-        (typs_in_ctx ++ [(1%nat, gen_sized_typ_0)
+        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
+        freq_LLVM
+        ([(min (List.length typs_in_ctx) 10, oneOf_LLVM typs_in_ctx)] ++
+        [(1%nat, gen_sized_typ_0)
         (* TODO: Might want to restrict the size to something reasonable *)
         ; (1%nat, ret TYPE_Array <*> lift_GenLLVM genN <*> gen_sized_typ_size_ptrinctx sz')
         ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_sized_typ_size_ptrinctx 0)
@@ -548,18 +550,19 @@ Definition filter_ptr_vecptr_typ (ctx: list (ident * typ)) : list (ident * typ) 
     | (S sz') =>
         ctx <- get_ctx;;
         (* not filter sized types for this one *)
-        let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) ctx in
+        let typs_in_ctx := map (fun '(_, typ) =>ret typ) ctx in
         freq_LLVM
-          (typs_in_ctx ++ [ (1%nat, gen_typ_0) (* TODO: Not sure if I need to add it here *)
-              (* Might want to restrict the size to something reasonable *)
-              (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-            ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
-            ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
-            ; let n := Nat.div sz 2 in
-              (1%nat, ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n))
-            ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-            ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-          ])
+        ([(min (List.length typs_in_ctx) 10, oneOf_LLVM typs_in_ctx)] ++
+        [ (1%nat, gen_typ_0) (* TODO: Not sure if I need to add it here *)
+        (* Might want to restrict the size to something reasonable *)
+        (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
+        ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
+        ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
+        ; let n := Nat.div sz 2 in
+        (1%nat, ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n))
+        ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+        ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+        ])
     end.
   Next Obligation.
     cbn.
@@ -605,17 +608,18 @@ Definition filter_ptr_vecptr_typ (ctx: list (ident * typ)) : list (ident * typ) 
     | 0%nat => gen_typ_non_void_0
     | (S sz') =>
         ctx <- get_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) (filter_non_void_typs ctx) in
-        freq_LLVM        
-          (typs_in_ctx ++[ (1%nat, gen_typ_non_void_0)
-              (* Might want to restrict the size to something reasonable *)
-              (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-            ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
-            ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
-            ; let n := Nat.div sz 2 in
-              (1%nat, ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n))
-            ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-            ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_non_void_typs ctx) in
+        freq_LLVM
+        ([(min (List.length typs_in_ctx) 10, oneOf_LLVM typs_in_ctx)] ++
+        [ (1%nat, gen_typ_non_void_0)
+        (* Might want to restrict the size to something reasonable *)
+        (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
+        ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
+        ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
+        ; let n := Nat.div sz 2 in
+        (1%nat, ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n))
+        ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+        ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
           ])
     end.
 
@@ -625,16 +629,17 @@ Definition filter_ptr_vecptr_typ (ctx: list (ident * typ)) : list (ident * typ) 
   | (S sz') =>
       ctx <- get_ctx;;
       aliases <- get_typ_ctx;;
-      let typs_in_ctx := map (fun '(_, typ) => (1%nat, ret typ)) (filter_sized_typs aliases ctx) in
-      freq_LLVM                
-        (typs_in_ctx ++ [ (1%nat, gen_typ_non_void_0)
-            (* Might want to restrict the size to something reasonable *)
-            (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-          ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
-          ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
-          ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-          ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-        ])
+      let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
+      freq_LLVM
+      ([(min (List.length typs_in_ctx) 10, oneOf_LLVM typs_in_ctx)] ++
+      [ (1%nat, gen_typ_non_void_0)
+      (* Might want to restrict the size to something reasonable *)
+      (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
+      ; (1%nat, ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
+      ; (1%nat, ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
+      ; (1%nat, ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+      ; (1%nat, ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
+      ])
   end.
 
   (* TODO: look up identifiers *)


### PR DESCRIPTION
Switched `gen_sized_typ` with a new function `gen_sized_typ_ptrinctx` that does a similar thing except has the possibility of generating a pointer only when there is a pointer in the ctx.