### PR TITLE
gen_exp_size better integer

### DIFF
--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -472,45 +472,45 @@ Section GenerationState.
 End GenerationState.
 
 Section TypGenerators.
-    (*filter all the (ident, typ) in ctx such that typ is a ptr*)
-Definition filter_ptr_typs (ctx : list (ident * typ)) : list (ident * typ) :=
-  filter (fun '(_, t) => match t with
+  (*filter all the (ident, typ) in ctx such that typ is a ptr*)
+  Definition filter_ptr_typs (ctx : list (ident * typ)) : list (ident * typ) :=
+    filter (fun '(_, t) => match t with
                         | TYPE_Pointer _ => true
                         | _ => false
-                     end) ctx.
+                        end) ctx.
 
   Definition filter_sized_typs (typ_ctx: list (ident * typ)) (ctx : list (ident * typ)) : list (ident * typ) :=
     filter (fun '(_, t) => is_sized_type typ_ctx t) ctx.
 
-Definition filter_non_void_typs (ctx : list (ident * typ)) : list (ident * typ) :=
-  filter (fun '(_, t) => match t with
-                      | TYPE_Void => false
-                      | _ => true
-                      end) ctx.
+  Definition filter_non_void_typs (ctx : list (ident * typ)) : list (ident * typ) :=
+    filter (fun '(_, t) => match t with
+                        | TYPE_Void => false
+                        | _ => true
+                        end) ctx.
 
-Definition filter_agg_typs (ctx: list (ident * typ)) : list (ident * typ) :=
-  filter (fun '(_, t) =>
-            match t with
-            | TYPE_Array sz _ => N.ltb 0 sz
-            | TYPE_Struct l
-            | TYPE_Packed_struct l => negb (seq.nilp l)
-            | _ => false
-            end ) ctx.
+  Definition filter_agg_typs (ctx: list (ident * typ)) : list (ident * typ) :=
+    filter (fun '(_, t) =>
+              match t with
+              | TYPE_Array sz _ => N.ltb 0 sz
+              | TYPE_Struct l
+              | TYPE_Packed_struct l => negb (seq.nilp l)
+              | _ => false
+              end ) ctx.
 
-Definition filter_vec_typs (ctx: list (ident * typ)) : list (ident * typ) :=
-  filter (fun '(_, t) =>
-            match t with
-            | TYPE_Vector _ _ => true
-            | _ => false
-            end) ctx.
+  Definition filter_vec_typs (ctx: list (ident * typ)) : list (ident * typ) :=
+    filter (fun '(_, t) =>
+              match t with
+              | TYPE_Vector _ _ => true
+              | _ => false
+              end) ctx.
 
-Definition filter_ptr_vecptr_typs (ctx: list (ident * typ)) : list (ident * typ) :=
-  filter (fun '(_, t) =>
-            match t with
-            | TYPE_Pointer _ => true
-            | TYPE_Vector _ (TYPE_Pointer _) => true
-            | _ => false
-            end) ctx.
+  Definition filter_ptr_vecptr_typs (ctx: list (ident * typ)) : list (ident * typ) :=
+    filter (fun '(_, t) =>
+              match t with
+              | TYPE_Pointer _ => true
+              | TYPE_Vector _ (TYPE_Pointer _) => true
+              | _ => false
+              end) ctx.
 
   (* TODO: These currently don't generate pointer types either. *)
 
@@ -1127,16 +1127,16 @@ Section ExpGenerators.
                               paths)))
            fields (0%Z, DList_empty : DList (typ * DList Z))).
 
-(* The method is mainly used by extractvalue and insertvalue,
+  (* The method is mainly used by extractvalue and insertvalue,
    which requires at least one index for getting inside the aggregate type.
    There is a possibility for us to get nil path. The filter below will get rid of that possibility.
    Given that the nilpath will definitely be at the beginning of a list of options, we can essentially get the tail. *)
-Definition get_index_paths_agg (t_from: typ) : list (typ * list (Z)) :=
-  tl (DList_paths_to_list_paths (get_index_paths_agg_aux t_from DList_empty)).
+  Definition get_index_paths_agg (t_from: typ) : list (typ * list (Z)) :=
+    tl (DList_paths_to_list_paths (get_index_paths_agg_aux t_from DList_empty)).
 
-Definition get_ctx_ptrs  : GenLLVM (list (ident * typ)) :=
-  ctx <- get_ctx;;
-  ret (filter_ptr_typs ctx).
+  Definition get_ctx_ptrs  : GenLLVM (list (ident * typ)) :=
+    ctx <- get_ctx;;
+    ret (filter_ptr_typs ctx).
 
 (* Index path without getting into vector *)
   Fixpoint get_index_paths_insertvalue_aux (t_from : typ) (pre_path : DList Z) (ctx : list (ident * typ)) {struct t_from}: bool * DList (typ * DList (Z)) :=

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -1405,7 +1405,12 @@ Definition genType: G (typ) :=
           end in
       let fix gen_size_0 (t: typ) :=
           match t with
-          | TYPE_I n                  => ret EXP_Integer <*> lift (arbitrary : G Z) (* lift (x <- (arbitrary : G nat);; ret (Z.of_nat x)) (* TODO: should the integer be forced to be in bounds? *) *)
+          | TYPE_I n                  =>
+              let size := BinIntDef.Z.of_N (N.min (2 ^ n) (2 ^ 30 - 1)) in
+              z <- lift (choose (0, size - 1));;
+              ret (EXP_Integer (z))
+          (* lift (x <- (arbitrary : G nat);; ret (Z.of_nat x))
+           (* TODO: should the integer be forced to be in bounds? *) *)
           | TYPE_IPTR => ret EXP_Integer <*> lift (arbitrary : G Z)
           | TYPE_Pointer subtyp       => lift failGen
           (* Only pointer type expressions might be conversions? Maybe GEP? *)

--- a/src/coq/Semantics/DynamicValues.v
+++ b/src/coq/Semantics/DynamicValues.v
@@ -1699,6 +1699,13 @@ Module DVALUE(A:Vellvm.Semantics.MemoryAddress.ADDRESS)(IP:Vellvm.Semantics.Memo
     | _      => false
     end.
 
+  Definition iop_is_signed (iop : ibinop) : bool :=
+    match iop with
+    | SDiv _ => true
+    | SRem   => true
+    | _      => false
+    end.
+
   Definition iop_is_shift (iop : ibinop) : bool :=
     match iop with
     | Shl _ _ => true


### PR DESCRIPTION
Generate integer that are the minimum of its size and (2^30 - 1). The reason we have 2^30 - 1 and not the regular 2^64 - 1 is because in `QuickChick/src/ExtractionQC.v.cppo`, given our version is below 4.13.0, the ocaml random integer function QC is calling is `Random.int`, which allows a range of [0,2^30), instead of `Random.full_int`, which allows a random integer beyond the range.

Another thing that we can probably decide is whether we want to generate negative integer. Currently we only generate positive integer. The PR so far will make sure integers are in bound. Don't know how this will affect some of the tests tho so maybe need further guidance on this.