### PR TITLE
Generate functions mentioned in Issue #209

### DIFF
--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -598,6 +598,7 @@ Section TypGenerators.
     | 0%nat => gen_sized_typ_0
     | (S sz') =>
         ctx <- get_ctx;;
+        let ctx := filter_non_fun_typs ctx in (* Don't need function in this generator *)
         aliases <- get_typ_ctx;;
         let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
         freq_LLVM
@@ -1001,6 +1002,13 @@ Section ExpGenerators.
        | TYPE_Identified id => false
        end.
 
+  (* This needs to use normalized_typ_eq, instead of dtyp_eq because of pointer types...
+     dtyps only tell you that a type is a pointer, the other type
+     information about the pointers is erased.
+   *)
+  Definition filter_type (ty : typ) (ctx : list (ident * typ)) : list (ident * typ)
+    := filter (fun '(i, t) => normalized_typ_eq (normalize_type ctx ty) (normalize_type ctx t)) ctx.
+  
   Variant contains_flag :=
   | soft
   | hard.
@@ -1072,15 +1080,17 @@ Section ExpGenerators.
             end
         | _ => fold_left (fun acc x => acc || contains_typ x t flag) fields false
         end
-    | _ => false
+    | TYPE_Function ret_t args =>
+        match t with
+        | TYPE_Function ret_t args =>
+            match flag with
+            | soft => true
+            | hard => normalized_typ_eq t_from t
+            end
+        | _ => false
+        end
+    | _ => false 
     end.
-
-  (* This needs to use normalized_typ_eq, instead of dtyp_eq because of pointer types...
-     dtyps only tell you that a type is a pointer, the other type
-     information about the pointers is erased.
-   *)
-  Definition filter_type (ty : typ) (ctx : list (ident * typ)) : list (ident * typ)
-    := filter (fun '(i, t) => normalized_typ_eq (normalize_type ctx ty) (normalize_type ctx t)) ctx.
 
   (* Can't use choose for these functions because it gets extracted to
      ocaml's Random.State.int function which has small bounds. *)
@@ -1465,6 +1475,12 @@ Definition gen_inttoptr : GenLLVM (typ * instr typ) :=
     end;;
   ret (new_tptr, INSTR_Op (OP_Conversion Inttoptr typ_from_cast (EXP_Ident id) new_tptr)).
 
+Definition get_ret_params_from_tfun (tfun: typ) :=
+  match tfun with
+  | TYPE_Function ret_t args => (ret_t, args)
+  | _ => (TYPE_Void, []) (* Won't reach here... Hopefully *)
+  end.
+
 Definition genTypHelper (n: nat): G (typ) :=
   run_GenLLVM (gen_typ_non_void_size n).
 
@@ -1618,7 +1634,7 @@ Definition genType: G (typ) :=
        | _ => lift failGen
       end.
 
-  Definition gen_exp (t : typ) : GenLLVM (exp typ)
+ Definition gen_exp (t : typ) : GenLLVM (exp typ)
     := sized_LLVM (fun sz => gen_exp_size sz t).
 
 Definition gen_insertvalue (typ_in_ctx: ident * typ): GenLLVM (typ * instr typ) :=
@@ -1629,6 +1645,18 @@ Definition gen_insertvalue (typ_in_ctx: ident * typ): GenLLVM (typ * instr typ) 
   ex <- hide_ctx (gen_exp_size 0 tsub);;
   (* Generate all of the type*)
   ret (tagg, INSTR_Op (OP_InsertValue (tagg, EXP_Ident id) (tsub, ex) path_for_insertvalue)).
+
+Definition gen_call : GenLLVM (typ * instr typ) :=
+  ctx <- get_ctx;;
+  let fun_in_ctx := filter (fun '(_, t) => contains_typ t (TYPE_Function TYPE_Void []) soft) ctx in
+  '(id, tfun) <- oneOf_LLVM (map ret fun_in_ctx);;
+  let '(ret_t, args) := get_ret_params_from_tfun tfun in
+  args_exp <- map_monad
+               (fun (arg_typ:typ) =>
+                  arg_exp <- gen_exp_size 0 arg_typ;;
+                  ret (arg_typ, arg_exp))
+               args;;
+  ret (ret_t, INSTR_Call (tfun, EXP_Ident id) []).
 
   Definition gen_texp : GenLLVM (texp typ)
     := t <- gen_typ;;

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -1996,7 +1996,7 @@ Section InstrGenerators.
        | Raw _ => false
        end.
   (* Don't want to generate CFGs, actually. Want to generated TLEs *)
-  
+
   Definition gen_definition (name : global_id) (ret_t : typ) (args : list (typ)) : GenLLVM (definition typ (block typ * list (block typ)))
     :=
       ctxs <- get_variable_ctxs;;

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -1996,7 +1996,7 @@ Section InstrGenerators.
        | Raw _ => false
        end.
   (* Don't want to generate CFGs, actually. Want to generated TLEs *)
-Print show_args_list.
+  
   Definition gen_definition (name : global_id) (ret_t : typ) (args : list (typ)) : GenLLVM (definition typ (block typ * list (block typ)))
     :=
       ctxs <- get_variable_ctxs;;
@@ -2013,10 +2013,12 @@ Print show_args_list.
       bs <- gen_blocks ret_t;;
 
       let args_t := map snd args in
-      let f_type := TYPE_Function ret_t args_t false in
+      let f_type := TYPE_Function ret_t args_t in
+      let param_attr_slots := map (fun t => []) args in
       let prototype :=
           mk_declaration name f_type
-                         ([], [])
+                         ([], param_attr_slots)
+                         None None None None
                          []
                          []
       in

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -2002,9 +2002,11 @@ Section InstrGenerators.
       ctxs <- get_variable_ctxs;;
 
       (* Add arguments to context *)
-      args <- map_monad (fun t =>
-                        i <- new_raw_id;;
-                        ret (i, t)) args;;
+      args <- map_monad
+               (fun t =>
+                  i <- new_raw_id;;
+                  ret (i, t))
+               args;;
       let args_ctx := map (fun '(i, t) => (ID_Local i, t)) args in
       append_to_ctx args_ctx;;
 
@@ -2053,13 +2055,13 @@ Section InstrGenerators.
            helpers <- gen_helper_function_tle_size z;;
            ret (helper::helpers)
        end.
-    
+
   Definition gen_helper_function_tle_multiple : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     :=
     (* sz <- lift (arbitrary : G N)*)
     sz <- lift_GenLLVM (choose (0,2)%nat);; (* TODO: Use the above line instead. Use this for testing purposes *)
     gen_helper_function_tle_size sz.
-  
+
   Definition gen_global : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     := fmap ret gen_helper_function_tle.
 

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -1092,6 +1092,9 @@ Section ExpGenerators.
     | _ => false 
     end.
 
+  Definition filter_fun_typs (ctx: var_context) : var_context :=
+    filter (fun '(_, t) => contains_typ t (TYPE_Function TYPE_Void []) soft) ctx.
+
   (* Can't use choose for these functions because it gets extracted to
      ocaml's Random.State.int function which has small bounds. *)
 
@@ -1752,6 +1755,7 @@ Section InstrGenerators.
     let agg_typs_in_ctx := filter_agg_typs ctx in
     let ptr_typs_in_ctx := filter_ptr_typs ctx in
     let vec_typs_in_ctx := filter_vec_typs ctx in
+    let fun_typs_in_ctx := filter_fun_typs ctx in
     let insertvalue_typs_in_ctx := filter_insertvalue_typs agg_typs_in_ctx ctx in
     oneOf_LLVM
       ([ t <- gen_op_typ;; i <- ret INSTR_Op <*> gen_op t;; ret (t, i)
@@ -1766,7 +1770,8 @@ Section InstrGenerators.
          ++ (if seq.nilp agg_typs_in_ctx then [] else [gen_extractvalue])
          ++ (if seq.nilp insertvalue_typs_in_ctx then [] else [x <- elems_LLVM insertvalue_typs_in_ctx;;
                                                                gen_insertvalue x])
-         ++ (if seq.nilp (filter_vec_typs ctx) then [] else [gen_extractelement; gen_insertelement])).
+         ++ (if seq.nilp (filter_vec_typs ctx) then [] else [gen_extractelement; gen_insertelement])
+         ++ (if seq.nilp (fun_typs_in_ctx) then [] else [gen_call])).
 
   (* TODO: Generate instructions with ids *)
   (* Make sure we can add these new ids to the context! *)

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -1047,7 +1047,7 @@ Section ExpGenerators.
         end
     | TYPE_Vector sz subtyp =>
         match t with
-        | TYPE_Array sz' subtyp' =>
+        | TYPE_Vector sz' subtyp' =>
             match flag with
             | soft => true
             | hard =>  (sz =? sz')%N && ((normalized_typ_eq subtyp subtyp') || (contains_typ subtyp t flag))
@@ -1065,7 +1065,7 @@ Section ExpGenerators.
         end
     | TYPE_Packed_struct fields =>
         match t with
-        | TYPE_Struct fields' =>
+        | TYPE_Packed_struct fields' =>
             match flag with
             | soft => true
             | hard =>  normalized_typ_eq t_from t || fold_left (fun acc x => acc || x) (map (fun y => contains_typ y t flag) fields) false

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -2047,21 +2047,11 @@ Section InstrGenerators.
   Definition gen_helper_function_tle : GenLLVM (toplevel_entity typ (block typ * list (block typ)))
     := ret TLE_Definition <*> gen_helper_function.
 
-  Fixpoint gen_helper_function_tle_size (sz: nat) : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
-    := match sz with
-       | 0%nat =>
-           ret nil
-       | S z =>
-           helper <- gen_helper_function_tle;;
-           helpers <- gen_helper_function_tle_size z;;
-           ret (helper::helpers)
-       end.
-
   Definition gen_helper_function_tle_multiple : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     :=
-    (* sz <- lift (arbitrary : G N)*)
-    sz <- lift_GenLLVM (choose (0,2)%nat);; (* TODO: Use the above line instead. Use this for testing purposes *)
-    gen_helper_function_tle_size sz.
+    sz <- lift (arbitrary : G nat);;
+    (* sz <- lift_GenLLVM (choose (0,2)%nat);; *) (* TODO: Use the above line instead. Use this for testing purposes *)
+    vectorOf_LLVM sz gen_helper_function_tle.
 
   Definition gen_global : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     := fmap ret gen_helper_function_tle.

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -2031,7 +2031,10 @@ Section InstrGenerators.
       gen_definition name ret_t args.
 
   Definition gen_helper_function: GenLLVM (definition typ (block typ * list (block typ)))
-    := gen_new_definition (TYPE_I 8) [].
+    :=
+    ret_t <- hide_ctx (gen_sized_typ);;
+    args <-  listOf_LLVM (hide_ctx gen_sized_typ);;
+    gen_new_definition ret_t [].
 
   Definition gen_helper_function_tle : GenLLVM (toplevel_entity typ (block typ * list (block typ)))
     := ret TLE_Definition <*> gen_helper_function.
@@ -2050,7 +2053,7 @@ Section InstrGenerators.
   Definition gen_helper_function_tle_multiple : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     :=
     (* sz <- lift (arbitrary : G N)*)
-    sz <- lift_GenLLVM (choose (0,2)%nat);;
+    sz <- lift_GenLLVM (choose (0,2)%nat);; (* TODO: Use the above line instead. Use this for testing purposes *)
     gen_helper_function_tle_size sz.
   
   Definition gen_global : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -1996,7 +1996,7 @@ Section InstrGenerators.
        | Raw _ => false
        end.
   (* Don't want to generate CFGs, actually. Want to generated TLEs *)
-
+Print show_args_list.
   Definition gen_definition (name : global_id) (ret_t : typ) (args : list (typ)) : GenLLVM (definition typ (block typ * list (block typ)))
     :=
       ctxs <- get_variable_ctxs;;
@@ -2048,8 +2048,7 @@ Section InstrGenerators.
   Fixpoint gen_helper_function_tle_size (sz: nat) : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     := match sz with
        | 0%nat =>
-           helper <- gen_helper_function_tle;;
-           ret [helper]
+           ret nil
        | S z =>
            helper <- gen_helper_function_tle;;
            helpers <- gen_helper_function_tle_size z;;

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -346,6 +346,19 @@ Section GenerationState.
            set_ptrtoint_ctx ptoi_ctx
        end.
 
+  Definition filter_global_from_variable_ctxs (ctxs : all_var_contexts) : all_var_contexts
+    := let is_global_id (id: ident) :=
+         match id with
+         | ID_Global _ => true
+         | ID_Local _ => false
+         end in
+       match ctxs with
+       | (ctx, ptoi_ctx) =>
+           let globals_in_ctx := filter (fun '(id, _) => is_global_id id) ctx in
+           let globals_in_ptoi_ctx := filter (fun '(_, id, _) => is_global_id id) ptoi_ctx in
+           (globals_in_ctx, globals_in_ptoi_ctx)
+       end.
+
   Definition add_to_ctx (x : (ident * typ)) : GenLLVM unit
     := ctx <- get_ctx;;
        let new_ctx := x :: ctx in
@@ -1933,7 +1946,7 @@ Section InstrGenerators.
 
   Definition gen_blocks (t : typ) : GenLLVM (block typ * list (block typ))
     := sized_LLVM (fun n => fmap snd (gen_blocks_sz n t [])).
-
+  
   (* Don't want to generate CFGs, actually. Want to generated TLEs *)
   Definition gen_definition (name : global_id) (ret_t : typ) (args : list (local_id * typ)) : GenLLVM (definition typ (block typ * list (block typ)))
     :=

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -346,6 +346,7 @@ Section GenerationState.
            set_ptrtoint_ctx ptoi_ctx
        end.
 
+  (* TODO: Do we need this? *)
   Definition filter_global_from_variable_ctxs (ctxs : all_var_contexts) : all_var_contexts
     := let is_global_id (id: ident) :=
          match id with
@@ -1946,7 +1947,13 @@ Section InstrGenerators.
 
   Definition gen_blocks (t : typ) : GenLLVM (block typ * list (block typ))
     := sized_LLVM (fun n => fmap snd (gen_blocks_sz n t [])).
-  
+
+  Definition is_main (name : global_id)
+    := match name with
+       | Name sname => String.string_dec sname "main"%string 
+       | Anon _
+       | Raw _ => false
+       end.
   (* Don't want to generate CFGs, actually. Want to generated TLEs *)
   Definition gen_definition (name : global_id) (ret_t : typ) (args : list (local_id * typ)) : GenLLVM (definition typ (block typ * list (block typ)))
     :=
@@ -1967,8 +1974,15 @@ Section InstrGenerators.
                          []
       in
       (* Reset context *)
-      restore_variable_ctxs ctxs;;
-      ret (mk_definition (block typ * list (block typ)) prototype (map fst args) bs).
+      (* TODO: Check if reset context is only applied in main function*)
+      if is_main name
+      then
+        restore_variable_ctxs ([], []);;
+        ret (mk_definition (block typ * list (block typ)) prototype (map fst args) bs)
+      else
+        let '(ctx, ptoi_ctx) := ctxs in
+        restore_variable_ctxs ((ID_Global name, f_type)::ctx, ptoi_ctx);;
+        ret (mk_definition (block typ * list (block typ)) prototype (map fst args) bs).
 
   Definition gen_new_definition (ret_t : typ) (args : list (local_id * typ)) : GenLLVM (definition typ (block typ * list (block typ)))
     :=

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -526,6 +526,13 @@ Section TypGenerators.
               | _ => false
               end) ctx.
 
+  Definition filter_non_fun_typs (ctx : list (ident * typ)) : list (ident * typ) :=
+    filter (fun '(_, t) =>
+              match t with
+              | TYPE_Function _ _ => false
+              | _ => true
+              end) ctx.
+  
   (* TODO: These currently don't generate pointer types either. *)
 
   (* Not sized in the QuickChick sense, sized in the LLVM sense. *)
@@ -701,7 +708,8 @@ Section TypGenerators.
                 (* ; TYPE_Metadata *)
                 (* ; TYPE_X86_mmx *)
                 (* ; TYPE_Opaque *)
-                ])).
+          ])).
+  
   Program Fixpoint gen_typ_non_void_size (sz : nat) {measure sz} : GenLLVM typ :=
     match sz with
     | 0%nat => gen_typ_non_void_0

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -532,7 +532,7 @@ Section TypGenerators.
               | TYPE_Function _ _ => false
               | _ => true
               end) ctx.
-  
+
   (* TODO: These currently don't generate pointer types either. *)
 
   (* Not sized in the QuickChick sense, sized in the LLVM sense. *)
@@ -710,7 +710,7 @@ Section TypGenerators.
                 (* ; TYPE_X86_mmx *)
                 (* ; TYPE_Opaque *)
           ])).
-  
+
   Program Fixpoint gen_typ_non_void_size (sz : nat) {measure sz} : GenLLVM typ :=
     match sz with
     | 0%nat => gen_typ_non_void_0
@@ -1008,7 +1008,7 @@ Section ExpGenerators.
    *)
   Definition filter_type (ty : typ) (ctx : list (ident * typ)) : list (ident * typ)
     := filter (fun '(i, t) => normalized_typ_eq (normalize_type ctx ty) (normalize_type ctx t)) ctx.
-  
+
   Variant contains_flag :=
   | soft
   | hard.
@@ -1089,7 +1089,7 @@ Section ExpGenerators.
             end
         | _ => false
         end
-    | _ => false 
+    | _ => false
     end.
 
   Definition filter_fun_typs (ctx: var_context) : var_context :=
@@ -1654,12 +1654,12 @@ Definition gen_call : GenLLVM (typ * instr typ) :=
   let fun_in_ctx := filter (fun '(_, t) => contains_typ t (TYPE_Function TYPE_Void []) soft) ctx in
   '(id, tfun) <- oneOf_LLVM (map ret fun_in_ctx);;
   let '(ret_t, args) := get_ret_params_from_tfun tfun in
-  args_exp <- map_monad
+  args_texp <- map_monad
                (fun (arg_typ:typ) =>
                   arg_exp <- gen_exp_size 0 arg_typ;;
                   ret (arg_typ, arg_exp))
                args;;
-  ret (ret_t, INSTR_Call (tfun, EXP_Ident id) []).
+  ret (ret_t, INSTR_Call (tfun, EXP_Ident id) args_texp).
 
   Definition gen_texp : GenLLVM (texp typ)
     := t <- gen_typ;;
@@ -1991,7 +1991,7 @@ Section InstrGenerators.
 
   Definition is_main (name : global_id)
     := match name with
-       | Name sname => String.string_dec sname "main"%string 
+       | Name sname => String.string_dec sname "main"%string
        | Anon _
        | Raw _ => false
        end.
@@ -2038,7 +2038,7 @@ Section InstrGenerators.
 
   Definition gen_global : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     := fmap ret gen_helper_function_tle.
-  
+
   Definition gen_main : GenLLVM (definition typ (block typ * list (block typ)))
     := gen_definition (Name "main") (TYPE_I 8) [].
 

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -2105,7 +2105,7 @@ Section InstrGenerators.
   Definition gen_helper_function: GenLLVM (definition typ (block typ * list (block typ)))
     :=
     ret_t <- hide_ctx gen_sized_typ_ptrinctx;;
-    args <-  listOf_LLVM (hide_ctx gen_sized_typ_ptrinctx);;
+    args  <- listOf_LLVM (hide_ctx gen_sized_typ_ptrinctx);;
     gen_new_definition ret_t args.
 
   Definition gen_helper_function_tle : GenLLVM (toplevel_entity typ (block typ * list (block typ)))

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -2036,6 +2036,23 @@ Section InstrGenerators.
   Definition gen_helper_function_tle : GenLLVM (toplevel_entity typ (block typ * list (block typ)))
     := ret TLE_Definition <*> gen_helper_function.
 
+  Fixpoint gen_helper_function_tle_size (sz: nat) : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
+    := match sz with
+       | 0%nat =>
+           helper <- gen_helper_function_tle;;
+           ret [helper]
+       | S z =>
+           helper <- gen_helper_function_tle;;
+           helpers <- gen_helper_function_tle_size z;;
+           ret (helper::helpers)
+       end.
+    
+  Definition gen_helper_function_tle_multiple : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
+    :=
+    (* sz <- lift (arbitrary : G N)*)
+    sz <- lift_GenLLVM (choose (0,2)%nat);;
+    gen_helper_function_tle_size sz.
+  
   Definition gen_global : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     := fmap ret gen_helper_function_tle.
 
@@ -2047,7 +2064,7 @@ Section InstrGenerators.
 
   Definition gen_llvm :GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     :=
-    globals <- gen_global;;
+    globals <- gen_helper_function_tle_multiple;;
     main <- gen_main_tle;;
     ret (globals ++ [main]).
 


### PR DESCRIPTION
For testing purposes, can only generate 0, 1, or 2 functions. Can edit function `gen_helper_function_tle_multiple` to generate a wider range number of functions. Currently, the solution for function recursion is that the function cannot call itself but only functions created before it. Will update to include recursion call