### PR TITLE
Fix the bug on bitcast vector generator

### DIFF
--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -1594,8 +1594,13 @@ Fixpoint gen_bitcast_typ (t_from : typ) : GenLLVM typ :=
         | subtyp =>
             let trivial_typs := [(1%N, TYPE_I 1); (8%N, TYPE_I 8); (32%N, TYPE_I 32); (32%N, TYPE_Float); (64%N, TYPE_I 64); (64%N, TYPE_Double)] in
             let size_of_vec := get_bit_size_from_typ t_from in
-            let choices := fold_left (fun acc '(s,t) => let sz' := (size_of_vec / s)%N in
-                                                 if (sz' =? 0)%N then acc else acc ++ [TYPE_Vector sz' t]) trivial_typs [] in
+            let choices :=
+              fold_left
+                (fun acc '(s,t) =>
+                   let '(sz', m) := N.div_eucl size_of_vec s in
+                   if orb (sz' =? 0)%N (negb (m =? 0)%N)
+                   then acc
+                   else acc ++ [TYPE_Vector sz' t]) trivial_typs [] in
             ret choices
         end
     | TYPE_Pointer subtyp =>

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -1606,7 +1606,8 @@ Fixpoint gen_bitcast_typ (t_from : typ) : GenLLVM typ :=
     | TYPE_Pointer subtyp =>
         (* TODO: Clean up. Figure out what can subtyp of pointer be *)
         (* new_subtyp <- gen_bitcast_typ subtyp;; *)
-        new_subtyp <- gen_sized_typ;;
+        (* new_subtyp <- gen_sized_typ;; *)
+        new_subtyp <- gen_typ_le_size (get_size_from_typ subtyp);;
         ret [TYPE_Pointer new_subtyp]
     | _ => ret [t_from] (* TODO: Add more types *) (* This currently is to prevent types like pointer of struct from failing *)
     end in


### PR DESCRIPTION
Fixing bitcast generator, before it may generate code like `%v8 = bitcast <1 x i1> %v4 to <0 x i8>`. Clang will complain about this. Essentially we need to not only check the division but also the mod. 