### PR TITLE
Fix for gen exp for function type

### DIFF
--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -87,7 +87,7 @@ Section Helpers.
     := match t with
        | TYPE_I sz => true
        | TYPE_IPTR => true
-       | TYPE_Pointer t => true
+       | TYPE_Pointer t => is_sized_type_h t
        | TYPE_Void => false
        | TYPE_Half => true
        | TYPE_Float => true
@@ -1569,6 +1569,7 @@ Definition filter_first_class_typs (ctx : var_context) : var_context :=
             | TYPE_Struct _
             | TYPE_Packed_struct _ => false
             | TYPE_Array _ _ => false
+            | TYPE_Pointer (TYPE_Function _ _ _) => false
             | _ => true
             end) ctx.
 


### PR DESCRIPTION
Previously, it is allowed for something like `alloca ... @g4 ...` where `@g4` is a function to generate (apologize for not being able to give an example since I lost track....). However, I don't think we should allow that. The reason why this is happening is because we store function as a pointer in the context. Maybe it's worth consider to only store them as function (and then whenever we want to call we add a `TYPE_Pointer` around the `TYPE_Function` that we want to call from). 