### PR TITLE
add iptr to parser

### DIFF
--- a/src/coq/Semantics/DynamicValues.v
+++ b/src/coq/Semantics/DynamicValues.v
@@ -1938,11 +1938,13 @@ Module DVALUE(A:Vellvm.Semantics.MemoryAddress.ADDRESS)(IP:Vellvm.Semantics.Memo
       | Inttoptr =>
         match t1, t2 with
         | DTYPE_I _, DTYPE_Pointer => Conv_ItoP x
+        | DTYPE_IPTR , DTYPE_Pointer => Conv_ItoP x
         | _, _ => Conv_Illegal "ERROR: Inttoptr got illegal arguments"
         end
       | Ptrtoint =>
         match t1, t2 with
         | DTYPE_Pointer, DTYPE_I _ => Conv_PtoI x
+        | DTYPE_Pointer, DTYPE_IPTR => Conv_PtoI x
         | _, _ => Conv_Illegal "ERROR: Ptrtoint got illegal arguments"
         end
 

--- a/src/ml/libvellvm/llvm_lexer.mll
+++ b/src/ml/libvellvm/llvm_lexer.mll
@@ -300,6 +300,7 @@
   | "fast"           -> KW_FAST
 
   (*types*)
+  | "iptr"      -> KW_IPTR
   | "void"      -> KW_VOID
   | "half"      -> KW_HALF
   | "float"     -> KW_FLOAT

--- a/src/ml/libvellvm/llvm_parser.mly
+++ b/src/ml/libvellvm/llvm_parser.mly
@@ -328,6 +328,7 @@ let ann_linkage_opt (m : linkage option) : (typ annotation) option =
 %token KW_ARCP 
 %token KW_FAST
 %token<Camlcoq.N.t> I
+%token KW_IPTR
 %token KW_VOID 
 %token KW_HALF 
 %token KW_FLOAT 
@@ -928,6 +929,7 @@ typ_args:
 
 typ:
   | n=I                                               { TYPE_I n              }
+  | KW_IPTR                                           { TYPE_IPTR             }
   | KW_VOID                                           { TYPE_Void             }
   | KW_HALF                                           { TYPE_Half             }
   | KW_FLOAT                                          { TYPE_Float            }
@@ -939,7 +941,7 @@ typ:
   | KW_X86_MMX                                        { TYPE_X86_mmx          }
   | t=typ STAR                                        { TYPE_Pointer t        }
   | LSQUARE n=INTEGER KW_X t=typ RSQUARE              { TYPE_Array (n_of_z n, t)  }
-  | t=typ LPAREN args=typ_args RPAREN                    { let (ts,v) = args in TYPE_Function (t, ts, v) }
+  | t=typ LPAREN args=typ_args RPAREN                 { let (ts,v) = args in TYPE_Function (t, ts, v) }
   | LCURLY ts=separated_list(csep, typ) RCURLY        { TYPE_Struct ts        }
   | LTLCURLY ts=separated_list(csep, typ) RCURLYGT    { TYPE_Packed_struct ts }
   | KW_OPAQUE                                         { TYPE_Opaque           }

--- a/tests/iptr/iptr.ll
+++ b/tests/iptr/iptr.ll
@@ -1,0 +1,23 @@
+define i1 @test() {
+  %p = alloca iptr
+  store iptr 17, iptr* %p
+  %int = ptrtoint iptr* %p to iptr
+  %ptr = inttoptr iptr %int to iptr*
+  %v = load iptr, iptr* %ptr
+  %c = icmp eq iptr* %p, %ptr
+  ret i1 %c
+}
+
+define i32 @main(i32 %argc, i8** %argv) {
+  %v = call i1 @test()
+  br i1 %v, label %true, label %false
+
+true:
+  ret i32 1
+
+false:
+  ret i32 0
+}  
+  
+
+;; ASSERT EQ: i1 1 = call i1 @test() 


### PR DESCRIPTION
Adds the `iptr` concrete syntax as a new type and maps it to Syntax.TYPE_IPTR.
Adds the `tests/iptr` directory and `iptr.ll` test case.

Note that running the vellvm interpreter on `tests/iptr/iptr.ll` fails (incorrectly?!) claiming that the argument to `ptrtoint` is invalid...