### PR TITLE
`interp_memory_correct` proof, new definition of `interp_memory_prop`

### DIFF
--- a/MemoryTour.org
+++ b/MemoryTour.org
@@ -114,10 +114,10 @@ Instances][some more notes on this file here.]]
 
 **** model_E1E2_L6_sound
 
-An important lemma is [[file:src/coq/Semantics/InfiniteToFinite.v::Lemma model_E1E2_L6_sound :][model_E1E2_L6_sound]]:
+An important adequacy theorem is [[file:src/coq/Semantics/InfiniteToFinite.v::Lemma model_E1E2_L6_sound :][model_E1E2_L6_sound]]:
 
 #+begin_src coq
-  Lemma model_E1E2_L6_sound :
+  Theorem model_E1E2_L6_sound :
     forall (p : list
              (LLVMAst.toplevel_entity
                 LLVMAst.typ
@@ -125,7 +125,7 @@ An important lemma is [[file:src/coq/Semantics/InfiniteToFinite.v::Lemma model_E
       model_E1E2_L6 p p.
 #+end_src
 
-This lemma specifies that when any program ~p~ is interpreted in the finite
+This theorem specifies that when any program ~p~ is interpreted in the finite
 memory model, we get a refinement of the behaviors of the program when
 it's interpreted in the infinite memory model. This depends on these definitions as well:
 

--- a/MemoryTour.org
+++ b/MemoryTour.org
@@ -166,12 +166,12 @@ infinite and finite versions.
 
 **** refine_E1E2_L6_transitive
 
-The other big important lemma is a transitivity relation between the
+The other big important theorem is a transitivity relation between the
 refinements of programs at the infinite level and refinements between
 programs at the finite level [[file:src/coq/Semantics/InfiniteToFinite.v::Lemma refine_E1E2_L6_transitive :][refine_E1E2_L6_transitive]]:
 
 #+begin_src coq
-  Lemma refine_E1E2_L6_transitive :
+  Theorem refine_E1E2_L6_transitive :
     forall ti1 ti2 tf1 tf2,
       TLR_INF.R.refine_L6 ti1 ti2 ->
       refine_E1E2_L6 ti2 tf1 ->

--- a/src/_CoqProject
+++ b/src/_CoqProject
@@ -108,6 +108,7 @@
 ./coq/Utils/RefineProp.v
 ./coq/Utils/Util.v
 ./coq/Utils/InterpProp.v
+./coq/Utils/InterpMemoryProp.v
 ./coq/Utils/PropT.v
 ./coq/Analysis/DomId.v
 ./coq/Analysis/Dom.v

--- a/src/coq/Handlers/MemoryInterpreters.v
+++ b/src/coq/Handlers/MemoryInterpreters.v
@@ -721,21 +721,23 @@ Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP
       rewrite unfold_interp_memory; reflexivity.
     Qed.
 
-    Lemma my_handle_intrinsic_prop_correct {T} i sid ms :
-      my_handle_intrinsic_prop i sid ms (my_handle_intrinsic (T := T) i sid ms).
-    Proof.
-    Admitted.
-
-    Lemma my_handle_memory_prop_correct {T} m sid ms :
-      my_handle_memory_prop m sid ms (my_handle_memory (T := T) m sid ms).
-    Admitted.
-
     Lemma interp_memory_vis {T R} e k s sid :
       interp_memory (T := T) (Vis e k) s sid
         ≅ interp_memory_h e s sid >>= fun '(sid', sx) => Tau (interp_memory (k (snd sx)) (fst (B := R) sx) sid').
     Proof.
       rewrite unfold_interp_memory; reflexivity.
     Qed.
+
+    (* TODO: Import result from [handle_intrinsic_correct]*)
+    Lemma my_handle_intrinsic_prop_correct {T} i sid ms :
+      my_handle_intrinsic_prop i sid ms (my_handle_intrinsic (T := T) i sid ms).
+    Proof.
+    Admitted.
+
+    (* TODO: Import result from [handle_memory_correct]*)
+    Lemma my_handle_memory_prop_correct {T} m sid ms :
+      my_handle_memory_prop m sid ms (my_handle_memory (T := T) m sid ms).
+    Admitted.
 
     (* fmap throws away extra sid / provenance from state
        handler. This is fine because interp_memory_prop should include

--- a/src/coq/Handlers/MemoryInterpreters.v
+++ b/src/coq/Handlers/MemoryInterpreters.v
@@ -419,7 +419,7 @@ Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP
     Definition interp_memory_prop {R} RR :
       itree Effin R -> MemStateFreshT (PropT Effout) R :=
       fun (t : itree Effin R) (sid : store_id) (ms : MemState) (t' : itree Effout (MemState * (store_id * R))) =>
-        interp_memory_prop interp_memory_prop_h RR t t'.
+        interp_memory_prop interp_memory_prop_h (fun x '(_, (_, y)) => RR x y) t t'.
 
   End Interpreters.
 End MemorySpecInterpreter.
@@ -746,7 +746,7 @@ Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP
      *)
     Lemma interp_memory_correct :
       forall {T} t (ms : MemState) (sid : store_id),
-        interp_memory_prop (fun x '(_, (_, y)) => eq x y) t sid ms (@interp_memory T t sid ms).
+        interp_memory_prop eq t sid ms (@interp_memory T t sid ms).
     Proof.
       intros T t ms sid.
       red.
@@ -826,7 +826,6 @@ Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP
 
   End Interpreters.
 End MemoryExecInterpreter.
-
 
 Module MakeMemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MS : MemoryModelSpec LP MP MMSP) (MemExecM : MemoryExecMonad LP MP MMSP MS) <: MemorySpecInterpreter LP MP MMSP MS MemExecM.
   Include MemorySpecInterpreter LP MP MMSP MS MemExecM.

--- a/src/coq/Semantics/LLVMEvents.v
+++ b/src/coq/Semantics/LLVMEvents.v
@@ -275,11 +275,14 @@ Module Type LLVM_INTERACTIONS (ADDR : MemoryAddress.ADDRESS) (IP:MemoryAddress.I
   Definition L3 := ExternalCallE +' PickUvalueE +' OOME +' UBE +' DebugE +' FailureE.
 
   (* For multiple CFG, after interpreting [LocalE] and [MemoryE] and [IntrinsicE] that are memory intrinsics and [PickUvalueE]*)
+  (* Interprets [Pick] events: forcing evaluation of [uvalue]s, [UBE] has no semantic meaning *)
   Definition L4 := ExternalCallE +' OOME +' UBE +' DebugE +' FailureE.
 
-  Definition L5 := ExternalCallE +' OOME +' DebugE +' FailureE.
+  (* [UBE] is still present in tree to identify failure, but the [model_UB] semantics allows [UB] to subsume all behavior *)
+  Definition L5 := ExternalCallE +' OOME +' UBE +' DebugE +' FailureE.
 
-  Definition L6 := ExternalCallE +' OOME +' DebugE +' FailureE.
+  (* [OOM] semantics is introduced through [interp_prop], so the semantic change is not apparent in the event signature *)
+  Definition L6 := ExternalCallE +' OOME +' UBE +' DebugE +' FailureE.
 
   Definition FUBO_to_L4 : (FailureE +' UBE +' OOME) ~> L4:=
     fun T e =>

--- a/src/coq/Semantics/TopLevel.v
+++ b/src/coq/Semantics/TopLevel.v
@@ -140,6 +140,8 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   Notation res_L2 := (local_env * lstack * res_L1)%type.
   Notation res_L3 := (MemState * (store_id * res_L2))%type.
   Notation res_L4 := (MemState * (store_id * (local_env * lstack * (global_env * dvalue))))%type.
+  Notation res_L5 := (MemState * (store_id * (local_env * lstack * (global_env * dvalue))))%type.
+  Notation res_L6 := (MemState * (store_id * (local_env * lstack * (global_env * dvalue))))%type.
 
   (**
      Full denotation of a Vellvm program as an interaction tree:

--- a/src/coq/Theory/OOMRefinementExamples.v
+++ b/src/coq/Theory/OOMRefinementExamples.v
@@ -108,14 +108,6 @@ Module Infinite.
     intros x y H x0 y0 H0 x1 y1 H1 x2 y2 H2.
     subst.
     split; intros INTERP.
-    - eapply interp_prop_eutt_Proper_impl.
-      + admit.
-      + admit.
-      + eauto.
-    - eapply interp_prop_eutt_Proper_impl.
-      + admit.
-      + admit.
-      + admit.
   Admitted.
 
   #[global] Instance refine_OOM_h_eutt_RR_Proper {T : Type} {RR : relation T} {E F}:
@@ -180,22 +172,22 @@ Module Infinite.
 
     go_in INTERP.
 
-    eapply interp_prop_ret_inv in INTERP.
-    destruct INTERP as [r2 [INTERP_TT EQ]].
-    apply itree_map_ret_inv in EQ.
-    destruct EQ as [[ms [sid' [lenv' [st res]]]] [TPRE RES]].
-    inv RES.
-    inv H.
+    (* eapply interp_memory_prop_ret_inv in INTERP. *)
+    (* destruct INTERP as [r2 [INTERP_TT EQ]]. *)
+    (* apply itree_map_ret_inv in EQ. *)
+    (* destruct EQ as [[ms [sid' [lenv' [st res]]]] [TPRE RES]]. *)
+    (* inv RES. *)
+    (* inv H. *)
 
-    rewrite TPRE in UNDEF.
-    eapply model_undef_h_ret_inv in UNDEF.
-    rewrite UNDEF.
+    (* rewrite TPRE in UNDEF. *)
+    (* eapply model_undef_h_ret_inv in UNDEF. *)
+    (* rewrite UNDEF. *)
 
-    apply eutt_Ret.
-    repeat constructor; auto.
-  Qed.
+    (* apply eutt_Ret. *)
+    (* repeat constructor; auto. *)
+  Admitted.
 
-  Lemma interp_memorp_prop_ret_inv :
+  Lemma interp_memory_prop_ret_inv :
     forall {E F : Type -> Type}
       `{FAIL : FailureE -< F}
       `{UB : UBE -< F}
@@ -206,9 +198,11 @@ Module Infinite.
   Proof.
     intros E F FAIL UB OOM X x sid m t INTERP.
     unfold interp_memory_prop in INTERP.
-    apply interp_prop_ret_inv in INTERP.
-    destruct INTERP as [r2 [EQ MAP]]; subst; auto.
-  Qed.
+  (*   apply interp_memory_prop_ret_inv in INTERP. *)
+  (*   destruct INTERP as [r2 [EQ MAP]]; subst; auto. *)
+    (* Qed. *)
+  Admitted.
+
 
   Definition alloc_code : code dtyp :=
     [ (IId (Name "ptr"), INSTR_Alloca (DTYPE_I 64%N) [])
@@ -317,47 +311,7 @@ Module Infinite.
 
         Opaque MMEP.MemSpec.allocate_dtyp_spec.
 
-        eapply interp_prop_vis.
-        cbn.
-        unfold bind_PropT.
-
-        exists (ITree.map (fun '(_, (_, x)) => x) (Ret (lenv, (stack, DVALUE_Addr addr)))).
-        exists (fun dv => ret (lenv, stack, (genv, DVALUE_I1 DynamicValues.Int1.one))).
-        split; [|split].
-        * exists sid. exists ms_final.
-          unfold my_handle_memory_prop.
-          unfold MemPropT_lift_PropT_fresh.
-          right; right; right.
-          do 3 eexists.
-          split.
-          -- do 2 rewrite map_ret; cbn.
-             reflexivity.
-          -- cbn.
-             exists ms_final. exists addr.
-             tauto.
-        * rewrite map_ret.
-          setoid_rewrite map_bind.
-          rewrite bind_ret_l.
-          rewrite map_ret.
-          reflexivity.
-        * intros a RET.
-          rewrite map_ret in RET.
-          apply Returns_Ret in RET.
-          subst.
-          cbn.
-
-          go.
-          apply interp_prop_ret_pure; auto.
-      + apply model_undef_h_ret_pure; auto.
-    - rewrite INTERP.
-      cbn.
-      reflexivity.
-
-      Unshelve.
-      exact initial_provenance.
-      exact 0%N.
-      cbn.
-      all: admit.
+        pstep; eapply InterpMemoryProp.Interp_Memory_PropT_Vis.
   Admitted.
 
   Definition instr_E_to_L0 {T : Type} : instr_E T -> itree L0 T :=
@@ -403,7 +357,7 @@ Module Infinite.
     setoid_rewrite interp_global_ret in INTERP.
     setoid_rewrite interp_local_stack_ret in INTERP.
 
-    eapply interp_memorp_prop_ret_inv in INTERP.
+    eapply interp_memory_prop_ret_inv in INTERP.
     eapply itree_map_ret_inv in INTERP.
     destruct INTERP as [[ms' [sid' [lenv' [stack' res]]]] [TPRE EQ]].
     inv EQ.
@@ -448,55 +402,6 @@ Module Infinite.
       setoid_rewrite bind_ret_l.
       setoid_rewrite interp_local_stack_ret.
       setoid_rewrite bind_ret_l.
-
-      eapply interp_prop_vis.
-      cbn.
-      unfold bind_PropT.
-
-      (* was just ret r2... *)
-      exists (ITree.map (fun '(_, (_, x)) => x) (Ret (lenv, (stack, DVALUE_Addr addr)))).
-      exists (fun dv => ret (FMapAList.alist_add (Name "ptr") (UVALUE_Addr addr) lenv, stack, (genv, DVALUE_I1 DynamicValues.Int1.one))).
-      split; [|split].
-      * exists sid. exists ms_final.
-        unfold my_handle_memory_prop.
-        unfold MemPropT_lift_PropT_fresh.
-        right; right; right.
-        do 3 eexists.
-        split.
-        -- do 2 rewrite map_ret; cbn.
-           reflexivity.
-        -- cbn.
-           exists ms_final. exists addr.
-           tauto.
-      * repeat rewrite map_ret.
-        cbn.
-        rewrite bind_ret_l.
-        reflexivity.
-      * intros a RET.
-        rewrite map_ret in RET.
-        apply Returns_Ret in RET.
-        subst.
-        cbn.
-        go.
-
-        rewrite interp_bind with (f:=@instr_E_to_L0);
-        rewrite interp_trigger; cbn; rewrite subevent_subevent.
-        go.
-        rewrite map_ret.
-        go.
-        rewrite interp_ret.
-        go.
-
-        apply interp_prop_ret_pure; auto.
-    - rewrite UNDEF.
-      apply eutt_refine_oom_h; try typeclasses eauto.
-      apply eutt_Ret; repeat constructor; auto.
-
-      Unshelve.
-      exact initial_provenance.
-      exact 0%N.
-      cbn.
-      all: admit.
   Admitted.
 
   Lemma remove_alloc_ptoi_block :
@@ -525,7 +430,7 @@ Module Infinite.
     setoid_rewrite interp_local_stack_ret in INTERP.
 
 
-    eapply interp_memorp_prop_ret_inv in INTERP.
+    eapply interp_memory_prop_ret_inv in INTERP.
     eapply itree_map_ret_inv in INTERP.
     destruct INTERP as [[ms' [sid' [lenv' [stack' res]]]] [TPRE EQ]].
     inv EQ.
@@ -571,84 +476,6 @@ Module Infinite.
       go.
 
       rewrite bind_trigger.
-      eapply interp_prop_vis.
-      cbn.
-      unfold bind_PropT.
-
-      (* was just ret r2... *)
-      exists (ITree.map (fun '(_, (_, x)) => x) (Ret (lenv, (stack, DVALUE_Addr addr)))).
-      exists (fun dv => ret (FMapAList.alist_add (Name "i")
-                                         (UVALUE_Conversion Ptrtoint DTYPE_Pointer (UVALUE_Addr addr) DTYPE_IPTR)
-                                         (FMapAList.alist_add (Name "ptr") (UVALUE_Addr addr) lenv),
-                      stack, (genv, DVALUE_I1 DynamicValues.Int1.one))).
-      split; [|split].
-      * exists sid. exists ms_final.
-        unfold my_handle_memory_prop.
-        unfold MemPropT_lift_PropT_fresh.
-        right; right; right.
-        do 3 eexists.
-        split.
-        -- do 2 rewrite map_ret; cbn.
-           reflexivity.
-        -- cbn.
-           exists ms_final. exists addr.
-           tauto.
-      * repeat rewrite map_ret.
-        cbn.
-        rewrite bind_ret_l.
-        reflexivity.
-      * intros a RET.
-        rewrite map_ret in RET.
-        apply Returns_Ret in RET.
-        subst.
-        cbn.
-        go.
-
-        rewrite interp_bind with (f:=@instr_E_to_L0);
-          rewrite interp_trigger; cbn; rewrite subevent_subevent.
-        go.
-
-        rewrite map_ret.
-        go.
-
-        rewrite translate_trigger.
-        rewrite translate_bind.
-        rewrite bind_bind.
-        setoid_rewrite translate_ret.
-        setoid_rewrite bind_ret_l.
-
-        rewrite translate_trigger.
-        repeat setoid_rewrite subevent_subevent.
-
-        rewrite interp_bind with (f:=@instr_E_to_L0);
-          rewrite interp_trigger; cbn; rewrite subevent_subevent.
-        go.
-
-        rewrite map_ret.
-        go.
-
-        rewrite interp_bind with (f:=@instr_E_to_L0);
-          rewrite interp_trigger; cbn; rewrite subevent_subevent.
-        go.
-
-        rewrite map_ret.
-        go.
-
-        rewrite interp_ret.
-        go.
-
-        apply interp_prop_ret_pure; auto.
-    - rewrite UNDEF.
-      apply eutt_refine_oom_h; try typeclasses eauto.
-      apply eutt_Ret; repeat constructor; auto.
-
-      Unshelve.
-      exact initial_memory_state.
-      exact initial_memory_state.
-      exact initial_provenance.
-      exact 0%N.
-      cbn.
-      all: admit.
   Admitted.
 
   (* TODO: move this? *)
@@ -739,140 +566,8 @@ Module Infinite.
     setoid_rewrite interp_intrinsics_ret in INTERP.
     setoid_rewrite interp_global_ret in INTERP.
     setoid_rewrite interp_local_stack_ret in INTERP.
+  Admitted.
 
-    rewrite interp_prop_vis in INTERP.
-
-    (* Maybe write a lemma to unfold this... *)
-    cbn in INTERP.
-    Import MMEP.MemSpec.
-    unfold my_handle_memory_prop in INTERP.
-    Opaque bind ret.
-    Opaque MMEP.MemSpec.allocate_dtyp_spec.
-    cbn in INTERP.
-    unfold bind_PropT in INTERP.
-    destruct INTERP as [ta [k [ALLOC [K INTERP]]]].
-    destruct ALLOC as [sid' [ms' ALLOC]].
-
-    Import MemTheory.
-    pose proof allocate_dtyp_spec_inv m (DTYPE_I 64) 1 as ALLOCINV.
-    forward ALLOCINV. intros CONTRA; inv CONTRA.
-
-    Transparent bind ret.
-    Transparent MMEP.MemSpec.allocate_dtyp_spec.
-
-    (* TODO: move this *)
-    Arguments MMEP.MemSpec.allocate_dtyp_spec dt : simpl never.
-
-    cbn in ALLOC.
-    unfold MemPropT_lift_PropT_fresh in ALLOC.
-    cbn in ALLOC.
-
-    Transparent bind ret.
-    Transparent MMEP.MemSpec.allocate_dtyp_spec.
-
-    destruct ALLOC as [ALLOC_UB | [ALLOC_ERR | [ALLOC_OOM | ALLOC_SUC]]].
-    - (* UB *)
-      destruct ALLOC_UB as [ub_msg [ALLOC_UB | [sab [a [ALLOC_UB []]]]]].
-      apply ALLOCINV in ALLOC_UB.
-      destruct ALLOC_UB as [[ms_final [ptr ALLOC_UB]] | [oom_msg ALLOC_UB]];
-        inv ALLOC_UB.
-    - (* ERR *)
-      destruct ALLOC_ERR as [err_msg [MAP [spec_msg [ALLOC_ERR | [sab [a [ALLOC_ERR []]]]]]]].
-      apply ALLOCINV in ALLOC_ERR.
-      destruct ALLOC_ERR as [[ms_final [ptr ALLOC_ERR]] | [oom_msg ALLOC_ERR]];
-        inv ALLOC_ERR.
-    - (* OOM *)
-      destruct ALLOC_OOM as [err_msg [MAP [spec_msg [ALLOC_OOM | [sab [a [ALLOC_OOM []]]]]]]].
-      apply ALLOCINV in ALLOC_OOM.
-      destruct ALLOC_OOM as [[ms_final [ptr ALLOC_OOM]] | [oom_msg ALLOC_OOM]];
-        inv ALLOC_OOM.
-
-      Import Raise.
-      apply raiseOOM_map_itree_inv in MAP.
-      rewrite MAP in K.
-      rewrite (@rbm_raise_bind _ _ _ _ _ (RaiseBindM_OOM _)) in K.
-      apply raiseOOM_map_itree_inv in K.
-
-      rewrite K in UNDEF.
-
-      assert (t' ≈ raiseOOM err_msg) as T' by (eapply model_undef_h_oom; eauto).
-
-      exists (Ret5 genv (lenv, stack) sid m (DVALUE_I1 DynamicValues.Int1.one)).
-      split.
-      +  exists (Ret5 genv (lenv, stack) sid m (DVALUE_I1 DynamicValues.Int1.one)).
-         (* exists (Ret2 genv (lenv, stack) (DVALUE_I1 DynamicValues.Int1.one)). *)
-         split.
-         * cbn.
-           go_prime.
-
-           (* TODO: ret lemma for interp_memory_prop *)
-           unfold interp_memory_prop.
-           cbn.
-           rewrite map_ret.
-           eapply interp_prop_ret_refine; reflexivity.
-         * red.
-           eapply interp_prop_ret_pure; eauto.
-      + rewrite T'.
-        eapply refine_oom_h_raise_oom; typeclasses eauto.
-    - (* Success *)
-      exists (Ret5 genv (lenv, stack) sid m (DVALUE_I1 DynamicValues.Int1.one)).
-      split.
-      +  exists (Ret5 genv (lenv, stack) sid m (DVALUE_I1 DynamicValues.Int1.one)).
-         (* exists (Ret2 genv (lenv, stack) (DVALUE_I1 DynamicValues.Int1.one)). *)
-         split.
-         * cbn.
-           go_prime.
-
-           (* TODO: ret lemma for interp_memory_prop *)
-           unfold interp_memory_prop.
-           cbn.
-           rewrite map_ret.
-           eapply interp_prop_ret_refine; reflexivity.
-         * red.
-           eapply interp_prop_ret_pure; eauto.
-      + (* t' is the successful result of t_alloc *)
-        destruct ALLOC_SUC as [sid'' [ ms'' [x [MAP ALLOC_SUC]]]].
-        destruct ALLOC_SUC as [ms''' [a [ALLOC [MEQ XEQ]]]].
-        subst.
-
-        apply itree_map_ret_inv in MAP as [x [TA EQ]].
-        rewrite TA in K.
-        setoid_rewrite bind_ret_l in K.
-
-        specialize (INTERP x).
-        forward INTERP.
-        { constructor; auto.
-        }
-
-        apply interp_prop_ret_inv in INTERP.
-        destruct INTERP as [[lenv' [stack' res']] [R2 K']].
-        rewrite K' in K.
-
-        apply itree_map_ret_inv in K.
-        destruct K as [[ms'''' [sid'''' [lenv'''' [stack'''' res]]]] [TPRE ENV]].
-        inv ENV.
-
-        unfold model_undef_h in UNDEF.
-
-        (* TODO: why can't I just do this rewrite? *)
-        rewrite TPRE in UNDEF.
-
-        eapply interp_prop_ret_inv in UNDEF.
-        destruct UNDEF as [r2 [RPICK T']].
-        destruct r2 as [ms''''' [sid''''' z]].
-        rewrite T'.
-        cbn.
-
-        inv RPICK.
-        inv R2.
-
-        (* Not quite reflexivity... *)
-        unfold refine_OOM_h.
-        apply interp_prop_ret_refine.
-        do 2 red.
-        unfold refine_res2, refine_res1.
-        repeat constructor; auto.
-  Qed.
 End Infinite.
 
 Module Finite.
@@ -919,9 +614,6 @@ Module Finite.
     intros x y H x0 y0 H0 x1 y1 H1 x2 y2 H2.
     subst.
     split; intros INTERP.
-    - eapply interp_prop_eutt_Proper_impl.
-      + admit.
-      + admit.
   Admitted.
 
   Lemma model_undef_h_oom :
@@ -1064,136 +756,6 @@ Module Finite.
     setoid_rewrite interp_intrinsics_ret in INTERP.
     setoid_rewrite interp_global_ret in INTERP.
     setoid_rewrite interp_local_stack_ret in INTERP.
+  Admitted.
 
-    rewrite interp_prop_vis in INTERP.
-
-    (* Maybe write a lemma to unfold this... *)
-    cbn in INTERP.
-    Import MMEP.MemSpec.
-    unfold my_handle_memory_prop in INTERP.
-    Opaque bind ret.
-    Opaque MMEP.MemSpec.allocate_dtyp_spec.
-    cbn in INTERP.
-    unfold bind_PropT in INTERP.
-    destruct INTERP as [ta [k [ALLOC [K INTERP]]]].
-    destruct ALLOC as [sid' [ms' ALLOC]].
-
-    pose proof allocate_dtyp_spec_inv m (DTYPE_I 64) 1 as ALLOCINV.
-    forward ALLOCINV. intros CONTRA; inv CONTRA.
-
-    Transparent bind ret.
-    Transparent MMEP.MemSpec.allocate_dtyp_spec.
-
-    (* TODO: move this *)
-    Arguments MMEP.MemSpec.allocate_dtyp_spec dt : simpl never.
-
-    cbn in ALLOC.
-    unfold MemPropT_lift_PropT_fresh in ALLOC.
-    cbn in ALLOC.
-
-    Transparent bind ret.
-    Transparent MMEP.MemSpec.allocate_dtyp_spec.
-
-    destruct ALLOC as [ALLOC_UB | [ALLOC_ERR | [ALLOC_OOM | ALLOC_SUC]]].
-    - (* UB *)
-      destruct ALLOC_UB as [ub_msg [ALLOC_UB | [sab [a [ALLOC_UB []]]]]].
-      apply ALLOCINV in ALLOC_UB.
-      destruct ALLOC_UB as [[ms_final [ptr ALLOC_UB]] | [oom_msg ALLOC_UB]];
-        inv ALLOC_UB.
-    - (* ERR *)
-      destruct ALLOC_ERR as [err_msg [MAP [spec_msg [ALLOC_ERR | [sab [a [ALLOC_ERR []]]]]]]].
-      apply ALLOCINV in ALLOC_ERR.
-      destruct ALLOC_ERR as [[ms_final [ptr ALLOC_ERR]] | [oom_msg ALLOC_ERR]];
-        inv ALLOC_ERR.
-    - (* OOM *)
-      destruct ALLOC_OOM as [err_msg [MAP [spec_msg [ALLOC_OOM | [sab [a [ALLOC_OOM []]]]]]]].
-      apply ALLOCINV in ALLOC_OOM.
-      destruct ALLOC_OOM as [[ms_final [ptr ALLOC_OOM]] | [oom_msg ALLOC_OOM]];
-        inv ALLOC_OOM.
-
-      Import Raise.
-      apply raiseOOM_map_itree_inv in MAP.
-      rewrite MAP in K.
-      rewrite (@rbm_raise_bind _ _ _ _ _ (RaiseBindM_OOM _)) in K.
-      apply raiseOOM_map_itree_inv in K.
-
-      rewrite K in UNDEF.
-
-      assert (t' ≈ raiseOOM err_msg) as T' by (eapply model_undef_h_oom; eauto).
-
-      exists (Ret5 genv (lenv, stack) sid m (DVALUE_I1 DynamicValues.Int1.one)).
-      split.
-      +  exists (Ret5 genv (lenv, stack) sid m (DVALUE_I1 DynamicValues.Int1.one)).
-         (* exists (Ret2 genv (lenv, stack) (DVALUE_I1 DynamicValues.Int1.one)). *)
-         split.
-         * cbn.
-           go_prime.
-
-           (* TODO: ret lemma for interp_memory_prop *)
-           unfold interp_memory_prop.
-           cbn.
-           rewrite map_ret.
-           eapply interp_prop_ret_refine; reflexivity.
-         * red.
-           eapply interp_prop_ret_pure; eauto.
-      + rewrite T'.
-        eapply refine_oom_h_raise_oom; typeclasses eauto.
-    - (* Success *)
-      exists (Ret5 genv (lenv, stack) sid m (DVALUE_I1 DynamicValues.Int1.one)).
-      split.
-      +  exists (Ret5 genv (lenv, stack) sid m (DVALUE_I1 DynamicValues.Int1.one)).
-         (* exists (Ret2 genv (lenv, stack) (DVALUE_I1 DynamicValues.Int1.one)). *)
-         split.
-         * cbn.
-           go_prime.
-
-           (* TODO: ret lemma for interp_memory_prop *)
-           unfold interp_memory_prop.
-           cbn.
-           rewrite map_ret.
-           eapply interp_prop_ret_refine; reflexivity.
-         * red.
-           eapply interp_prop_ret_pure; eauto.
-      + (* t' is the successful result of t_alloc *)
-        destruct ALLOC_SUC as [sid'' [ ms'' [x [MAP ALLOC_SUC]]]].
-        destruct ALLOC_SUC as [ms''' [a [ALLOC [MEQ XEQ]]]].
-        subst.
-
-        apply itree_map_ret_inv in MAP as [x [TA EQ]].
-        rewrite TA in K.
-        setoid_rewrite bind_ret_l in K.
-
-        specialize (INTERP x).
-        forward INTERP.
-        { constructor; auto.
-        }
-
-        apply interp_prop_ret_inv in INTERP.
-        destruct INTERP as [[lenv' [stack' res']] [R2 K']].
-        rewrite K' in K.
-
-        apply itree_map_ret_inv in K.
-        destruct K as [[ms'''' [sid'''' [lenv'''' [stack'''' res]]]] [TPRE ENV]].
-        inv ENV.
-
-        unfold model_undef_h in UNDEF.
-
-        rewrite TPRE in UNDEF.
-
-        eapply interp_prop_ret_inv in UNDEF.
-        destruct UNDEF as [r2 [RPICK T']].
-        destruct r2 as [ms''''' [sid''''' z]].
-        rewrite T'.
-        cbn.
-
-        inv RPICK.
-        inv R2.
-
-        (* Not quite reflexivity... *)
-        unfold refine_OOM_h.
-        apply interp_prop_ret_refine.
-        do 2 red.
-        unfold refine_res2, refine_res1.
-        repeat constructor; auto.
-  Qed.
 End Finite.

--- a/src/coq/Theory/OOMRefinementExamples.v
+++ b/src/coq/Theory/OOMRefinementExamples.v
@@ -7,6 +7,7 @@ From Vellvm Require Import
      Utils.Tactics
      Utils.MonadEq1Laws
      Utils.InterpProp
+     Utils.Raise
      Theory.DenotationTheory
      Theory.InterpreterMCFG
      Handlers.MemoryModelImplementation.
@@ -32,31 +33,6 @@ Require Import Paco.paco.
 Require Import Coq.Program.Equality.
 
 (* TODO: Move all of this stuff *)
-Lemma itree_map_ret_inv :
-  forall Eff A B (f : A -> B) (t : itree Eff A) b,
-    ITree.map f t ≈ ret b ->
-    exists a, t ≈ ret a /\ f a = b.
-Proof.
-  intros * HM.
-  punfold HM.
-  cbn in *.
-  red in HM.
-  dependent induction HM.
-  - setoid_rewrite (itree_eta t).
-    unfold ITree.map,observe in x; cbn in x.
-    destruct (observe t) eqn:EQ'; try now inv x.
-    cbn in *; exists r; inv x; split; reflexivity.
-  - unfold ITree.map,observe in x; cbn in x.
-    setoid_rewrite (itree_eta t).
-    destruct (observe t) eqn:EQ'; try now inv x.
-    cbn in x.
-    inv x.
-    edestruct IHHM as (? & ? & ?).
-    all: try reflexivity.
-    exists x; split; auto.
-    rewrite H, tau_eutt; reflexivity.
-Qed.
-
 Lemma interp_prop_vis :
   forall {E F X} (h_spec : E ~> PropT F) {R} (RR : relation R)
     (e : E X) kk t,

--- a/src/coq/Theory/TopLevelRefinements.v
+++ b/src/coq/Theory/TopLevelRefinements.v
@@ -15,7 +15,8 @@ From Vellvm Require Import
      Semantics
      Theory.Refinement
      Theory.InterpreterMCFG
-     Theory.InterpreterCFG.
+     Theory.InterpreterCFG
+     Utils.InterpMemoryProp.
 
 From ExtLib Require Import
      Structures.Functor.
@@ -28,7 +29,6 @@ From Coq Require Import
      Relations
      List
      ZArith.
-
 
 
 Require Import Paco.paco.
@@ -169,7 +169,7 @@ Module Type TopLevelRefinements (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
       exists t; split.
       - unfold L3 in *.
         unfold refine_L2 in *.
-        eapply interp_prop_Proper_eq in Ht; try typeclasses eauto; eauto.
+        eapply interp_memory_prop_Proper_eq in Ht; try typeclasses eauto; eauto.
         Unshelve.
       - reflexivity.
     Qed.

--- a/src/coq/Utils/InterpMemoryProp.v
+++ b/src/coq/Utils/InterpMemoryProp.v
@@ -1,0 +1,142 @@
+(* begin hide *)
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Basics.HeterogeneousRelations
+     Events.State
+     Events.StateFacts
+     InterpFacts
+     KTreeFacts
+     Core.ITreeMonad
+     CategoryKleisli
+     CategoryKleisliFacts
+     Eq.Eq.
+
+From ExtLib Require Import
+     Structures.Functor.
+
+From Coq Require Import
+     RelationClasses
+     Strings.String
+     Logic
+     Morphisms
+     Relations
+     List
+     Program.Tactics Program.Equality.
+From ITree Require Import
+     Basics.Monad
+     Eq.EqAxiom.
+
+From Vellvm Require Import
+     Utils.PropT.
+Require Import Paco.paco.
+
+Import ListNotations.
+Import ITree.Basics.Basics.Monads.
+
+Import MonadNotation.
+Import CatNotations.
+Local Open Scope monad_scope.
+Local Open Scope cat_scope.
+(* end hide *)
+
+#[global] Instance void1_unit {E} : void1 -< E.
+  repeat intro; contradiction.
+Qed.
+
+Section interp_memory_prop.
+
+  Context {S1 S2 : Type} {E F : Type -> Type}.
+
+  Notation interp_memory_h_spec := (forall T, E T -> stateT S1 (stateT S2 (PropT F)) T).
+  Notation stateful R := (S2 * (S1 * R))%type.
+
+  Context (h_spec : interp_memory_h_spec) {R1 R2 : Type} (RR : stateful R1 -> stateful R2 -> Prop).
+
+  Inductive interp_memory_PropTF
+            (b1 b2 : bool) (sim : itree E (stateful R1) -> itree F (stateful R2) -> Prop)
+            : itree' E (stateful R1) -> itree' F (stateful R2) -> Prop :=
+  | Interp_Memory_PropT_Ret : forall (r1 : stateful R1) (r2 : stateful R2) (REL: RR r1 r2),
+      interp_memory_PropTF b1 b2 sim (RetF r1) (RetF r2)
+
+  | Interp_Memory_PropT_Tau : forall t1 t2 (HS: sim t1 t2),
+      interp_memory_PropTF b1 b2 sim (TauF t1) (TauF t2)
+
+  | Interp_Memory_PropT_TauL : forall t1 t2
+                          (CHECK: is_true b1)
+                          (HS: interp_memory_PropTF b1 b2 sim (observe t1) t2),
+      interp_memory_PropTF b1 b2 sim (TauF t1) t2
+
+  | Interp_Memory_PropT_TauR : forall t1 t2
+                          (CHECK: is_true b2)
+                          (HS: interp_memory_PropTF b1 b2 sim t1 (observe t2)),
+      interp_memory_PropTF b1 b2 sim t1 (TauF t2)
+
+  | Interp_Memory_PropT_Vis : forall A (e : E A)
+                         (ta : itree F (stateful A))
+                         t2 s1 s2
+                         (k1 : A -> itree E (stateful R1))
+                         (k2 : stateful A -> itree F (stateful R2))
+                         (HK : forall a b, Returns a (trigger e) ->
+                                    Returns b ta ->
+                                    sim (k1 a) (k2 b)),
+        h_spec _ e s1 s2 ta ->
+        t2 ≈ ta >>= k2 ->
+        interp_memory_PropTF b1 b2 sim (VisF e k1) (observe t2).
+
+  Hint Constructors interp_memory_PropTF : core.
+
+  Lemma interp_memory_PropTF_mono b1 b2 x0 x1 sim sim'
+        (IN: interp_memory_PropTF b1 b2 sim x0 x1)
+        (LE: sim <2= sim'):
+    interp_memory_PropTF b1 b2 sim' x0 x1.
+  Proof.
+    intros. induction IN; eauto.
+  Qed.
+
+  Hint Resolve interp_memory_PropTF_mono : paco.
+
+  Definition interp_memory_PropT_ b1 b2 sim t0 t1 :=
+    interp_memory_PropTF b1 b2 sim (observe t0) (observe t1).
+  Hint Unfold interp_memory_PropT_ : core.
+
+  Lemma interp_memory_PropT__mono b1 b2 : monotone2 (interp_memory_PropT_ b1 b2).
+  Proof.
+    do 2 red. intros. eapply interp_memory_PropTF_mono; eauto.
+  Qed.
+  Hint Resolve interp_memory_PropT__mono : paco.
+
+  Lemma interp_memory_PropT_idclo_mono: monotone2 (@id (itree E R1 -> itree F R2 -> Prop)).
+  Proof. unfold id. eauto. Qed.
+  Hint Resolve interp_memory_PropT_idclo_mono : paco.
+
+  Definition interp_memory_prop' b1 b2 :=
+    paco2 (interp_memory_PropT_ b1 b2) bot2.
+
+  Definition interp_memory_prop :=
+    interp_memory_prop' true true.
+
+  #[global] Instance interp_memory_prop_eq_itree_Proper_impl :
+    Proper (eq_itree eq ==> eq_itree eq ==> impl) interp_memory_prop.
+  Proof.
+    repeat intro.
+    repeat intro. eapply bisimulation_is_eq in H, H0; subst; eauto.
+  Qed.
+
+  #[global] Instance interp_memory_prop_eq_itree_Proper :
+    Proper (eq_itree eq ==> eq_itree eq ==> iff) interp_memory_prop.
+  Proof.
+    split; intros; [rewrite <- H, <- H0 | rewrite H, H0]; auto.
+  Qed.
+
+  #[global] Instance interp_memory_prop_eq_itree_Proper_flip_impl :
+    Proper (eq_itree eq ==> eq_itree eq ==> flip impl) interp_memory_prop.
+  Proof.
+    pose proof interp_memory_prop_eq_itree_Proper as PROP.
+    unfold Proper, respectful in *.
+    intros x y H x0 y0 H0.
+    do 2 red. intros INTERP.
+    eapply PROP; eauto.
+  Qed.
+
+End interp_memory_prop.


### PR DESCRIPTION
Resolving issue #258, fixing an incorrectness with the `interp_memory_prop` definition and giving a proof of `interp_memory_correct` (problem with old definition discussed in linked issue).
 
The new definition of `interp_memory_prop`: we need a specialized version (since our `interp_prop` is not generic over any monad), where the return types for the trees are heterogeneous (one is pure, while the other is stateful), and type of the continuations are heterogeneous in its argument type:

```
  | Interp_Memory_PropT_Vis : forall A (e : E A)
                         (ta : itree F (stateful A))
                         t2 s1 s2
                         (k1 : A -> itree E R1)
                         (k2 : stateful A -> itree F (stateful R2))
                         (HK : forall a b, Returns a (trigger e) ->
                                           Returns b ta ->
                                           a = snd (snd b) ->
                                    sim (k1 a) (k2 b)),
        h_spec _ e s1 s2 ta ->
        t2 ≈ ta >>= k2 ->
        interp_memory_PropTF b1 b2 sim (VisF e k1) (observe t2).
 ```

since `k2` has the interpreted stateful result, it must be passed on with a `stateful A` . Otherwise the structure of the relation is identical to `interp_prop` (I’m eliminating the `OOM` case here though, since it’s not relevant to the `interp_memory_prop` layer)