### PR TITLE
`raise_oom`, `raise_error`, `raise_ub` absurd inversions

### DIFF
--- a/src/coq/Handlers/MemoryInterpreters.v
+++ b/src/coq/Handlers/MemoryInterpreters.v
@@ -63,7 +63,8 @@ Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP
 
   Section Interpreters.
 
-    Notation E := ExternalCallE.
+    Context {E : Type -> Type}.
+
     Notation F := (PickUvalueE +' OOME +' UBE +' DebugE +' FailureE).
 
     Notation Effin := (E +' IntrinsicE +' MemoryE +' F).
@@ -395,9 +396,9 @@ Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP
     Definition interp_memory_prop_h : forall T, Effin T -> MemStateFreshT (PropT Effout) T
       := case_ E_trigger (case_ my_handle_intrinsic_prop (case_ my_handle_memory_prop F_trigger)).
 
-    Definition interp_memory_prop {R} RR :
-      itree Effin R -> MemStateFreshT (PropT Effout) R :=
-      fun (t : itree Effin R) (sid : store_id) (ms : MemState) (t' : itree Effout (MemState * (store_id * R))) =>
+    Definition interp_memory_prop {R1 R2} (RR : R1 -> R2 -> Prop) :
+      itree Effin R1 -> MemStateFreshT (PropT Effout) R2 :=
+      fun (t : itree Effin R1) (sid : store_id) (ms : MemState) (t' : itree Effout (MemState * (store_id * R2))) =>
         interp_memory_prop interp_memory_prop_h (fun x '(_, (_, y)) => RR x y) t t'.
 
   End Interpreters.
@@ -424,6 +425,7 @@ Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP
 
   Section Interpreters.
 
+    Context {E : Type -> Type}.
     Notation E := ExternalCallE.
     Notation F := (PickUvalueE +' OOME +' UBE +' DebugE +' FailureE).
 

--- a/src/coq/Handlers/MemoryModelImplementation.v
+++ b/src/coq/Handlers/MemoryModelImplementation.v
@@ -210,7 +210,8 @@ Module MemoryBigIntptrInfiniteSpec <: MemoryModelInfiniteSpec LLVMParamsBigIntpt
   Import SpecInterp.
   Import ExecInterp.
 
-  Notation Eff := (ExternalCallE +' PickUvalueE +' OOME +' UBE +' DebugE +' FailureE).
+  Context {E : Type -> Type}.
+  Notation Eff := (E +' PickUvalueE +' OOME +' UBE +' DebugE +' FailureE).
 
   Import Eq.
   Import MMSP.

--- a/src/coq/Semantics/InterpretationStack.v
+++ b/src/coq/Semantics/InterpretationStack.v
@@ -69,7 +69,7 @@ Module Type InterpreterStack_common (LP : LLVMParams) (MEM : Memory LP).
       let L2_trace       := interp_local_stack L1_trace l in
       L2_trace.
 
-    Definition interp_mcfg3 {R} RR (t: itree L0 R) g l sid m : PropT L3 (MemState * (store_id * (local_env * stack * (global_env * R)))) :=
+    Definition interp_mcfg3 {R} RR (t: itree L0 R) g l sid m : PropT L3 (MemState * (store_id * (local_env * @stack local_env * (global_env * R)))) :=
       let uvalue_trace   := interp_intrinsics t in
       let L1_trace       := interp_global uvalue_trace g in
       let L2_trace       := interp_local_stack L1_trace l in
@@ -83,7 +83,7 @@ Module Type InterpreterStack_common (LP : LLVMParams) (MEM : Memory LP).
       let L3_trace       := interp_memory L2_trace sid m in
       L3_trace.
 
-    Definition interp_mcfg4 {R} RR_mem RR_pick (t: itree L0 R) g l sid m : PropT L4 (MemState * (store_id * (local_env * stack * (global_env * R)))) :=
+    Definition interp_mcfg4 {R} RR_mem RR_pick (t: itree L0 R) g l sid m : PropT L4 (MemState * (store_id * (local_env * @stack local_env * (global_env * R)))) :=
       let uvalue_trace   := interp_intrinsics t in
       let L1_trace       := interp_global uvalue_trace g in
       let L2_trace       := interp_local_stack L1_trace l in
@@ -99,7 +99,7 @@ Module Type InterpreterStack_common (LP : LLVMParams) (MEM : Memory LP).
       let L4_trace       := exec_undef L3_trace in
       L4_trace.
 
-    Definition interp_mcfg5 {R} RR_mem RR_pick (t: itree L0 R) g l sid m : PropT L4 (MemState * (store_id * (local_env * stack * (global_env * R)))) :=
+    Definition interp_mcfg5 {R} RR_mem RR_pick (t: itree L0 R) g l sid m : PropT L4 (MemState * (store_id * (local_env * @stack local_env * (global_env * R)))) :=
       let uvalue_trace   := interp_intrinsics t in
       let L1_trace       := interp_global uvalue_trace g in
       let L2_trace       := interp_local_stack L1_trace l in


### PR DESCRIPTION
Discharging obligations of the kind `~(raise_oom m \approx raise_ub)` (and friends)

Had to change the event signatures to leave all the events concrete except for the call events (`CallE`, `ExternalCallE`), since these obligations were not provable when leaving the event signatures totally abstract.