### PR TITLE
DiffList refactor for ShowAST. 

### DIFF
--- a/src/_CoqProject
+++ b/src/_CoqProject
@@ -125,3 +125,4 @@
 ./coq/QC/ReprAST.v
 ./coq/QC/Utils.v
 ./coq/QC/GenAST.v
+./coq/QC/DList.v

--- a/src/coq/QC/DList.v
+++ b/src/coq/QC/DList.v
@@ -1,0 +1,81 @@
+From ExtLib Require Export Functor.
+From Coq Require Import List String.
+Import ListNotations Ascii.
+Local Open Scope string_scope.
+
+Section DList.
+
+  Definition DList (A : Type) := list A -> list A.
+
+  Definition DList_to_list {A} (dl : DList A) : list A
+    := dl [].
+
+  Definition DList_append {A} (dl1 dl2 : DList A) : DList A
+    := fun xs => dl1 (dl2 xs).
+
+  Definition DList_singleton {A} (a : A) : DList A
+    := cons a.
+
+  Definition DList_cons {A} (a : A) (dl : DList A) : DList A
+    := DList_append (DList_singleton a) dl.
+
+  Definition DList_empty {A} : DList A
+    := fun xs => xs.
+
+  Definition DList_from_list {A} (l : list A) : DList A
+    := fold_left (fun x s => DList_append x (DList_singleton s)) l DList_empty.
+
+  Definition DList_map {A B} (f : A -> B) (dl : DList A) : DList B
+    := fold_right (fun a => DList_cons (f a)) (@DList_empty B) (DList_to_list dl).
+
+  #[global] Instance DList_Functor : Functor DList.
+  Proof.
+    split.
+    intros A B X X0.
+    eapply DList_map; eauto.
+  Defined.
+
+  Definition DString := DList ascii.
+
+  (* TODO: move this? *)
+  Fixpoint string_fold_left {A} (f : A -> ascii -> A) (s:string) (acc:A) : A :=
+    match s with
+    | EmptyString => acc
+    | String ch s =>
+        string_fold_left f s (f acc ch)
+    end.
+
+  Definition rev_string (s : string) : string
+    := string_fold_left (fun acc x => String x acc) s EmptyString.
+
+  (* TODO: move this? *)
+  Definition rev_tail_rec {X} (xs : list X)
+    := fold_left (fun acc x => x :: acc) xs [].
+
+  Definition string_of_list_ascii_tail_rec (s : list ascii) : string
+    := rev_string (fold_left (fun acc ch => String ch acc) s EmptyString).
+
+  Definition list_ascii_of_string_tail_rec (s : string) : list ascii
+    := rev_tail_rec (string_fold_left (fun acc ch => ch :: acc) s []).
+
+  Definition DString_to_string (ds : DString) : string :=
+    string_of_list_ascii_tail_rec (ds []).
+
+  Definition string_to_DString (s : string) : DString := app (list_ascii_of_string_tail_rec s).
+
+  Definition list_to_DString (ls : list string) : DString :=
+    fold_left (fun x s => DList_append x (string_to_DString s)) ls DList_empty.
+
+  Definition EmptyDString := string_to_DString EmptyString.
+
+  Fixpoint concat_DString (sep : DString) (ls : list DString) :=
+    match ls with
+    | nil => EmptyDString
+    | cons x nil => x
+    | cons x xs => DList_append (DList_append x sep) (concat_DString sep xs)
+    end.
+
+  Definition DList_join {A} (ls : list (DList A)) :=
+    fold_left DList_append ls DList_empty.
+
+End DList.

--- a/src/coq/QC/GenAST.v
+++ b/src/coq/QC/GenAST.v
@@ -22,7 +22,7 @@ Require Import List.
 
 Import ListNotations.
 
-From Vellvm Require Import LLVMAst Utilities AstLib Syntax.CFG Syntax.TypeUtil Syntax.TypToDtyp DynamicTypes Semantics.TopLevel QC.Utils Handlers.Handlers.
+From Vellvm Require Import LLVMAst Utilities AstLib Syntax.CFG Syntax.TypeUtil Syntax.TypToDtyp DynamicTypes Semantics.TopLevel QC.Utils Handlers.Handlers DList.
 Require Import Integers.
 
 
@@ -43,45 +43,12 @@ From ExtLib.Structures Require Export
      Functor.
 Open Scope Z_scope.
 
-
 (* Disable guard checking. This file is only used for generating test
     cases. Some of our generation functions terminate in non-trivial
     ways, but since they're only used to generate test cases (and are
     not used in proofs) it's not terribly important to prove that they
     actually terminate.  *)
 Unset Guard Checking.
-(** Difference lists *)
-Section DList.
-  Definition DList (A : Type) := list A -> list A.
-
-  Definition DList_to_list {A} (dl : DList A) : list A
-    := dl [].
-
-  Definition DList_append {A} (dl1 dl2 : DList A) : DList A
-    := fun xs => dl1 (dl2 xs).
-
-  Definition DList_singleton {A} (a : A) : DList A
-    := cons a.
-
-  Definition DList_cons {A} (a : A) (dl : DList A) : DList A
-    := DList_append (DList_singleton a) dl.
-
-  Definition DList_empty {A} : DList A
-    := fun xs => xs.
-
-  Definition DList_from_list {A} (l : list A) : DList A
-    := fold_right DList_cons DList_empty l.
-
-  Definition DList_map {A B} (f : A -> B) (dl : DList A) : DList B
-    := fold_right (fun a => DList_cons (f a)) (@DList_empty B) (DList_to_list dl).
-
-  #[global] Instance DList_Functor : Functor DList.
-  Proof.
-    split.
-    intros A B X X0.
-    eapply DList_map; eauto.
-  Defined.
-End DList.
 
 Section Helpers.
   Fixpoint is_sized_type_h (t : typ) : bool

--- a/src/coq/QC/QCShowTesting.v
+++ b/src/coq/QC/QCShowTesting.v
@@ -1,0 +1,17 @@
+(** Testing show instances for Vellvm. Currently the show instances
+    seem to be causing stack overflows for larger programs. *)
+Require Import ExtrOcamlBasic.
+Require Import ExtrOcamlString.
+
+From QuickChick Require Import QuickChick.
+From Vellvm Require Import ShowAST ReprAST GenAST TopLevel LLVMAst DynamicValues QCVellvm.
+
+Extraction Blacklist String List Char Core Z Format.
+
+Extract Constant defNumTests    => "100".
+Extract Constant defSize    => "50".
+QCInclude "../../ml/*".
+QCInclude "../../ml/libvellvm/*".
+
+Extract Inlined Constant Error.failwith => "(fun _ -> raise)".
+QuickChick (forAll (run_GenLLVM gen_PROG) vellvm_agrees_with_clang).

--- a/src/coq/QC/ShowAST.v
+++ b/src/coq/QC/ShowAST.v
@@ -4,8 +4,7 @@
     program should give you a string that can be read by clang.
  *)
 
-
-From Vellvm Require Import LLVMAst Utilities AstLib Syntax.CFG DynamicTypes.
+From Vellvm Require Import LLVMAst Utilities AstLib Syntax.CFG DynamicTypes DList.
 
 Require Import Integers Floats.
 
@@ -32,67 +31,92 @@ Fixpoint concatStr (l : list string) : string :=
 (*  ------------------------------------------------------------------------- *)
 
 
+Class DShow (A : Type) := { dshow : A -> DString }.
+
+#[global] Infix "@@" := (DList_append) (right associativity, at level 60).
+
+#[global] Instance DShowList {A} `{DShow A} : DShow (list A) :=
+  { dshow := fun x => DList_join (map dshow x) }.
+
+#[global] Instance DShowPair {A B : Type} `{_ : DShow A} `{_ : DShow B} : DShow (A * B) :=
+{|
+  dshow p := match p with (a,b) => string_to_DString "(" @@ dshow a @@ string_to_DString "," @@ dshow b @@ string_to_DString ")" end
+|}.
+
+#[global] Instance DShowShow {A} `{DShow A} : Show A :=
+{|
+  show a := DString_to_string (dshow a);
+|}.
+
 Section ShowInstances.
   Local Open Scope string.
 
-  Context {T:Set}.
-  Context `{Show T}.
+  Context {T : Set}.
+  Context `{DShow T}.
 
-
-  Definition show_raw_id (rid : raw_id) : string
+  Definition dshow_raw_id (rid : raw_id) : DString
     := match rid with
-       | Name s => s
-       | Anon i => show i
-       | Raw i  => show i
+       | Name s => string_to_DString s
+       | Anon i => string_to_DString (show i)
+       | Raw i  => string_to_DString (show i)
        end.
 
-  #[global] Instance showRawId : Show raw_id
-    := {| show := show_raw_id |}.
+  #[global] Instance dshowRawId : DShow raw_id
+    := {| dshow := dshow_raw_id |}.
 
-  Definition show_ident (i : ident) : string
+  Definition dshow_ident (i : ident) : DString
     := match i with
-       | ID_Global r => "@" ++ show_raw_id r
-       | ID_Local r  => "%" ++ show_raw_id r
+      | ID_Global r => string_to_DString "@" @@ dshow_raw_id r
+      | ID_Local r  => string_to_DString "%" @@ dshow_raw_id r
        end.
 
-  #[global] Instance showIdent : Show ident
-    := {| show := show_ident |}.
+  #[global] Instance dshowIdent : DShow ident
+    := {| dshow := dshow_ident |}.
 
-
-  Fixpoint show_typ (t : typ) : string :=
+  Fixpoint dshow_typ (t : typ) : DString  :=
     match t with
-    | TYPE_I sz                 => "i" ++ show sz
-    | TYPE_IPTR                 => "iptr"
-    | TYPE_Pointer t            => show_typ t ++ "*"
-    | TYPE_Void                 => "void"
-    | TYPE_Half                 => "half"
-    | TYPE_Float                => "float"
-    | TYPE_Double               => "double"
-    | TYPE_X86_fp80             => "x86_fp80"
-    | TYPE_Fp128                => "fp128"
-    | TYPE_Ppc_fp128            => "ppc_fp128"
-    | TYPE_Metadata             => "metadata"
-    | TYPE_X86_mmx              => "x86_mmx"
-    | TYPE_Array sz t           => "[" ++ show sz ++ " x " ++ show_typ t ++ "]"
+    | TYPE_I sz                 => string_to_DString "i" @@
+                                    string_to_DString (show sz)
+    | TYPE_IPTR                 => string_to_DString "iptr"
+    | TYPE_Pointer t            => dshow_typ t @@ string_to_DString "*"
+    | TYPE_Void                 => string_to_DString "void"
+    | TYPE_Half                 => string_to_DString "half"
+    | TYPE_Float                => string_to_DString "float"
+    | TYPE_Double               => string_to_DString "double"
+    | TYPE_X86_fp80             => string_to_DString "x86_fp80"
+    | TYPE_Fp128                => string_to_DString "fp128"
+    | TYPE_Ppc_fp128            => string_to_DString "ppc_fp128"
+    | TYPE_Metadata             => string_to_DString "metadata"
+    | TYPE_X86_mmx              => string_to_DString "x86_mmx"
+    | TYPE_Array sz t           =>
+        list_to_DString ["["; show sz; " x "] @@ dshow_typ t @@
+        string_to_DString "]"
     | TYPE_Function ret args varargs =>
         let varargs_str :=
           if Nat.eqb (List.length args) 0 then
-            (if varargs then "..." else "")
+            (if varargs then string_to_DString "..." else string_to_DString  "")
           else
-            (if varargs then ", ..." else "")
-        in
-        show_typ ret ++ " (" ++ concat ", " (map show_typ args) ++ varargs_str ++ ")"
-    | TYPE_Struct fields        => "{" ++ concat ", " (map show_typ fields) ++ "}"
-    | TYPE_Packed_struct fields => "<{" ++ concat ", " (map show_typ fields) ++ "}>"
-    | TYPE_Opaque               => "opaque"
-    | TYPE_Vector sz t          => "<" ++ show sz ++ " x " ++ show_typ t ++ ">"
-    | TYPE_Identified id        => show id
+            (if varargs then string_to_DString ", ..." else string_to_DString "")
+        in dshow_typ ret @@ string_to_DString  " (" @@
+           concat_DString (string_to_DString ", ") (map dshow_typ args) @@ varargs_str @@ string_to_DString ")"
+
+    | TYPE_Struct fields        => string_to_DString "{" @@
+                                   concat_DString (string_to_DString ", ") (map dshow_typ fields) @@
+                                   string_to_DString "}"
+    | TYPE_Packed_struct fields =>
+        string_to_DString "<{" @@ concat_DString (string_to_DString ", ") (map dshow_typ fields) @@
+        string_to_DString "}>"
+
+    | TYPE_Opaque               => string_to_DString "opaque"
+    | TYPE_Vector sz t          => string_to_DString "<" @@
+                                   string_to_DString (show sz) @@
+                                   string_to_DString " x " @@ dshow_typ t @@
+                                   string_to_DString ">"
+    | TYPE_Identified id        => dshow id
     end.
 
-  #[global] Instance showTyp:  Show typ :=
-    {|
-      show := show_typ
-    |}.
+  #[global] Instance dshowTyp : DShow typ :=
+    {| dshow := dshow_typ |}.
 
   Definition show_dtyp (t : dtyp) : string
     := match t with
@@ -133,7 +157,6 @@ Section ShowInstances.
   #[global] Instance showLinkage : Show linkage
     := {| show := show_linkage |}.
 
-
   Definition show_dll_storage (d : dll_storage) : string :=
     match d with
     | DLLSTORAGE_Dllimport => "dllimport"
@@ -173,39 +196,41 @@ Section ShowInstances.
   #[global] Instance showCConv : Show cconv
     := {| show := show_cconv |}.
 
-  Definition show_param_attr (p : param_attr) : string :=
+  Definition show_param_attr (p : param_attr) : DString :=
     match p with
-    | PARAMATTR_Zeroext => "zeroext"
-    | PARAMATTR_Signext => "signext"
-    | PARAMATTR_Inreg => "inreg"
-    | PARAMATTR_Byval t => "byval(" ++ show t ++ ")"
-    | PARAMATTR_Byref t => "byref(" ++ show t ++ ")"
-    | PARAMATTR_Preallocated t => "preallocated(" ++ show t ++ ")"
-    | PARAMATTR_Inalloca t => "inalloca(" ++ show t ++ ")"
-    | PARAMATTR_Sret t => "sret(" ++ show t ++ ")"
-    | PARAMATTR_Elementtype t => "elementtype(" ++ show t ++ ")"
-    | PARAMATTR_Align a => "align " ++ show a
-    | PARAMATTR_Noalias => "noalias"
-    | PARAMATTR_Nocapture => "nocapture"
-    | PARAMATTR_Readonly => "readonly"
-    | PARAMATTR_Nofree => "nofree"
-    | PARAMATTR_Nest => "nest"
-    | PARAMATTR_Returned => "returned"
-    | PARAMATTR_Nonnull => "nonnull"
-    | PARAMATTR_Dereferenceable a => "dereferenceable(" ++ show a ++ ")"
-    | PARAMATTR_Dereferenceable_or_null a => "dereferenceable_or_null(" ++ show a ++ ")"
-    | PARAMATTR_Swiftself => "swiftself"
-    | PARAMATTR_Swiftasync => "swiftasync"
-    | PARAMATTR_Swifterror => "swifterror"
-    | PARAMATTR_Immarg => "immarg"
-    | PARAMATTR_Noundef => "noundef"
-    | PARAMATTR_Alignstack a => "alignstack(" ++ show a ++ ")"
-    | PARAMATTR_Allocalign => "allocalign"
-    | PARAMATTR_Allocptr => "allocptr"
+    | PARAMATTR_Zeroext => string_to_DString "zeroext"
+    | PARAMATTR_Signext => string_to_DString "signext"
+    | PARAMATTR_Inreg => string_to_DString "inreg"
+    | PARAMATTR_Byval t => string_to_DString "byval(" @@ dshow t @@ string_to_DString ")"
+    | PARAMATTR_Byref t => string_to_DString "byref(" @@ dshow t @@ string_to_DString ")"
+    | PARAMATTR_Preallocated t => string_to_DString "preallocated(" @@ dshow t @@ string_to_DString ")"
+    | PARAMATTR_Inalloca t => string_to_DString "inalloca(" @@ dshow t @@ string_to_DString ")"
+    | PARAMATTR_Sret t => string_to_DString "sret(" @@ dshow t @@ string_to_DString ")"
+    | PARAMATTR_Elementtype t => string_to_DString "elementtype(" @@ dshow t @@ string_to_DString ")"
+    | PARAMATTR_Align a => string_to_DString "align " @@ string_to_DString (show a)
+    | PARAMATTR_Noalias => string_to_DString "noalias"
+    | PARAMATTR_Nocapture => string_to_DString "nocapture"
+    | PARAMATTR_Readonly => string_to_DString "readonly"
+    | PARAMATTR_Nofree => string_to_DString "nofree"
+    | PARAMATTR_Nest => string_to_DString "nest"
+    | PARAMATTR_Returned => string_to_DString "returned"
+    | PARAMATTR_Nonnull => string_to_DString "nonnull"
+    | PARAMATTR_Dereferenceable a => string_to_DString "dereferenceable(" @@ string_to_DString (show a) @@
+                                    string_to_DString ")"
+    | PARAMATTR_Dereferenceable_or_null a => string_to_DString "dereferenceable_or_null(" @@
+                                            string_to_DString (show a) @@ string_to_DString ")"
+    | PARAMATTR_Swiftself => string_to_DString "swiftself"
+    | PARAMATTR_Swiftasync => string_to_DString "swiftasync"
+    | PARAMATTR_Swifterror => string_to_DString "swifterror"
+    | PARAMATTR_Immarg => string_to_DString "immarg"
+    | PARAMATTR_Noundef => string_to_DString "noundef"
+    | PARAMATTR_Alignstack a => string_to_DString "alignstack(" @@ string_to_DString (show a)  @@ string_to_DString ")"
+    | PARAMATTR_Allocalign => string_to_DString "allocalign"
+    | PARAMATTR_Allocptr => string_to_DString "allocptr"
     end.
 
-  #[global] Instance showParamAttr : Show param_attr
-    := { show := show_param_attr }.
+  #[global] Instance dshowParamAttr : DShow param_attr
+    := { dshow := show_param_attr }.
 
   Definition show_fn_attr (f : fn_attr) : string :=
     match f with
@@ -440,7 +465,7 @@ Section ShowInstances.
        | Fast => "fast"
        end.
 
-  #[global] Instance showFastMatch : Show fast_math
+  #[global] Instance showFastMath : Show fast_math
     := {| show := show_fast_math |}.
 
   (*These are Constant Expressions*)
@@ -490,8 +515,22 @@ Section ShowInstances.
     else if (n =? 34)%nat then "\22"
     (*Special case for decimal 92/hex 5C*)
     else if (n =? 92)%nat then "\\"
-    else (string_of_list_ascii ((ascii_of_nat n) :: [])).
+         else (string_of_list_ascii ((ascii_of_nat n) :: [])).
 
+  Definition dshow_c_string (ex : exp T) : DString :=
+    let n : nat := ex_to_nat ex in
+    let x : Z := ex_to_int ex in
+    if ((n <? 32) || (126 <? n))%nat then (
+        let conversion_str := NilEmpty.string_of_uint (N.to_hex_uint (Z.to_N x)) in
+        let conversion := NilEmpty.string_of_uint (N.to_hex_uint (Z.to_N x)) in
+        if ((length conversion_str) =? (Z.to_nat 1))%nat then string_to_DString "\0" @@ string_to_DString conversion
+        else string_to_DString "\" @@ string_to_DString conversion
+      )
+    (*Special case for decimal 34/hex 22*)
+    else if (n =? 34)%nat then string_to_DString "\22"
+    (*Special case for decimal 92/hex 5C*)
+    else if (n =? 92)%nat then string_to_DString "\\"
+         else DList_cons (ascii_of_nat n) DList_empty.
 
   Definition is_op (e : exp T) : bool :=
     match e with
@@ -514,106 +553,163 @@ tes on cstring on LLVMAst.v *)
     | _ => true
     end.
 
-  Definition add_parens (b : bool) (s : string) : string :=
-    if b then "(" ++ s ++ ")" else s.
+  Definition add_parens (b : bool) (ds : DString) : DString :=
+    if b then string_to_DString "(" @@ ds @@ string_to_DString ")" else ds.
 
-  Fixpoint show_exp (b: bool) (v : exp T) :=
-
+  Fixpoint dshow_exp (b: bool) (v : exp T) : DString :=
     match v with
-    | EXP_Ident id => show id
-    | EXP_Integer x => show x
-    | EXP_Float f => show f
-    | EXP_Double f => show f
-    | EXP_Hex f => double_to_hex_string f
-    | EXP_Bool b => show b
-    | EXP_Null => "null"
-    | EXP_Zero_initializer => "zeroinitializer"
+    | EXP_Ident id => dshow id
+    | EXP_Integer x => string_to_DString (show x)
+    | EXP_Float f => string_to_DString (show f)
+    | EXP_Double f => string_to_DString (show f)
+    | EXP_Hex f => string_to_DString (double_to_hex_string f)
+    | EXP_Bool b => string_to_DString (show b)
+    | EXP_Null => string_to_DString "null"
+    | EXP_Zero_initializer => string_to_DString "zeroinitializer"
     (* see notes on cstring on LLVMAst.v *)
     (* I'm using string_of_list_ascii bc I couldn't find any other function that converted asciis to strings  *)
-    | EXP_Cstring elts => "c" ++ """" ++
-                             concat "" (map (fun '(ty,ex) => show_c_string ex) elts)  ++ """"
-    | EXP_Undef => "undef"
-    | EXP_Struct fields => "{"  ++ concat ", " (map (fun '(ty,ex) => show ty ++ " " ++  show_exp false ex) fields) ++ "}"
-    | EXP_Packed_struct fields => "<{"  ++ concat ", " (map (fun '(ty,ex) => show ty ++ " " ++  show_exp false ex) fields) ++ "}>"
-    | EXP_Array elts => "["  ++ concat ", " (map (fun '(ty,ex) => show ty ++ " " ++  show_exp false ex) elts) ++ "]"
-    | EXP_Vector elts => "<"  ++ concat ", " (map (fun '(ty,ex) => show ty ++ " " ++  show_exp false ex) elts) ++ ">"
+    | EXP_Cstring elts => string_to_DString "c" @@ string_to_DString """" @@
+                           DList_join (map (fun '(ty, ex) => (dshow_c_string ex)) elts) @@ string_to_DString  """"
+
+    | EXP_Undef => string_to_DString "undef"
+
+    | EXP_Struct fields =>
+        string_to_DString "{" @@
+          concat_DString (string_to_DString ", ")
+          (map (fun '(ty, ex) =>
+                  DList_join [dshow ty ; string_to_DString " "] @@
+                    dshow_exp false ex) fields) @@ string_to_DString "}"
+
+    | EXP_Packed_struct fields =>
+        string_to_DString "<{" @@
+          concat_DString (string_to_DString ", ")
+          (map (fun '(ty, ex) =>
+                  DList_join [dshow ty ; string_to_DString " "] @@
+                    dshow_exp false ex) fields) @@ string_to_DString "}>"
+
+    | EXP_Array elts =>
+        string_to_DString "[" @@
+          concat_DString (string_to_DString ", ")
+          (map (fun '(ty, ex) => DList_join [dshow ty ; string_to_DString " "] @@ dshow_exp false ex) elts) @@ string_to_DString "]"
+    | EXP_Vector elts => string_to_DString "<" @@ concat_DString (string_to_DString ", ") (map (fun '(ty, ex) => DList_join [dshow ty ; string_to_DString " "] @@ dshow_exp false ex) elts) @@ string_to_DString ">"
+
     | OP_IBinop iop t v1 v2 =>
-       let second_expression :=  if b then  show t ++ " " ++ show_exp true v2 else show_exp true v2 in
-       show iop ++ " " ++ add_parens b (show t ++ " " ++  show_exp true v1 ++ ", " ++ second_expression)
+        let second_expression :=
+          if b
+          then dshow t @@ string_to_DString " " @@ dshow_exp true v2
+          else dshow_exp true v2
+       in string_to_DString (show iop) @@ string_to_DString " " @@ add_parens b (dshow t @@ string_to_DString " " @@ dshow_exp true v1 @@ string_to_DString ", " @@ second_expression)
+
     | OP_ICmp cmp t v1 v2 =>
-        let second_expression :=  if b then  show t ++ " " ++ show_exp true v2 else show_exp true v2 in
-        "icmp " ++  show cmp ++ " " ++  add_parens b (show t ++ " " ++  show_exp true v1 ++ ", " ++ second_expression)
+        let second_expression :=
+          if b
+          then dshow t @@ string_to_DString " " @@ dshow_exp true v2
+          else dshow_exp true v2
+        in list_to_DString ["icmp " ; show cmp ; " "] @@ add_parens b (dshow t @@ string_to_DString " " @@ dshow_exp true v1 @@ string_to_DString ", " @@ second_expression)
+
     | OP_FBinop fop fmath t v1 v2 =>
         let fmath_string :=
-          match fmath with
-          | nil => " "
-          | _ =>  " " ++ concat " " (map (fun x => show x) fmath) ++  " "
-          end in
-        show fop ++ " " ++ add_parens b (fmath_string ++ show t ++ " " ++  show_exp true v1 ++ ", " ++  show_exp true v2)
-    | OP_FCmp cmp t v1 v2 =>
-        "fcmp " ++  add_parens b (show cmp ++ " " ++ show t ++ " " ++  show_exp true v1 ++ ", " ++  show_exp true v2)
-    | OP_Conversion conv t_from v t_to => show conv ++ " " ++ add_parens b (show t_from ++ " " ++  show_exp true v ++ " to " ++ show t_to)
-   | OP_GetElementPtr t ptrval idxs =>
-        let (tptr, exp) := ptrval in
+          string_to_DString
+            match fmath with
+            | nil => " "
+            | _ =>  " " ++ concat " " (map (fun x => show x) fmath) ++  " "
+            end
+        in list_to_DString [show fop ; " "] @@ add_parens b (fmath_string @@ dshow t @@ string_to_DString " " @@  dshow_exp true v1 @@ string_to_DString ", " @@ dshow_exp true v2)
 
-       "getelementptr " ++  add_parens b (show t ++ ", " ++ show tptr ++ " " ++ show_exp true exp ++  fold_left (fun str '(ty, ex) => str ++ ", " ++ show ty ++ " " ++ show_exp true ex) idxs "")
+    | OP_FCmp cmp t v1 v2 =>
+        string_to_DString "fcmp " @@ add_parens b (list_to_DString [show cmp ; " "] @@ dshow t @@ string_to_DString " " @@ dshow_exp true v1 @@
+                                                 string_to_DString ", " @@ dshow_exp true v2)
+
+    | OP_Conversion conv t_from v t_to => list_to_DString [show conv ; " "] @@ add_parens b (dshow t_from @@ string_to_DString " " @@ dshow_exp true v @@
+                                                                                             string_to_DString " to " @@ dshow t_to)
+
+    | OP_GetElementPtr t ptrval idxs =>
+        let (tptr, exp) := ptrval in
+        string_to_DString "getelementptr " @@ add_parens b (dshow t @@ string_to_DString ", " @@ dshow tptr @@ string_to_DString " " @@ dshow_exp true exp @@
+                                                              fold_left (fun str '(ty, ex) => str @@ string_to_DString ", " @@ dshow ty @@ string_to_DString " " @@ dshow_exp true ex) idxs DList_empty)
 
     | OP_ExtractElement vec idx =>
         let (tptr, exp) := vec in
         let (tidx, iexp) := idx in
-        "extractelement " ++  add_parens b ( show tptr ++ " " ++  show_exp true exp ++ ", " ++ show tidx ++ " " ++  show_exp true iexp)
+        string_to_DString "extractelement " @@ add_parens b (dshow tptr @@ string_to_DString " " @@ dshow_exp true exp @@ string_to_DString ", " @@ dshow tidx @@ string_to_DString " " @@  dshow_exp true iexp)
+
     | OP_InsertElement vec elt idx =>
         let (tptr, exp) := vec in
         let (telt, eexp) := elt in
         let (tidx, iexp) := idx in
-         "insertelement " ++ add_parens b (show tptr ++ " " ++  show_exp true exp ++ ", " ++ show telt ++ " " ++  show_exp true eexp ++ ", " ++ show tidx ++ " " ++ show_exp true iexp)
+        string_to_DString "insertelement " @@ add_parens b (dshow tptr @@ string_to_DString " " @@ dshow_exp true exp @@ string_to_DString ", " @@ dshow telt @@ string_to_DString " " @@
+                                                          dshow_exp true eexp @@ string_to_DString ", " @@ dshow tidx @@ string_to_DString " " @@ dshow_exp true iexp)
+
     | OP_ShuffleVector vec1 vec2 idxmask =>
         let (type1, expression1) := vec1 in
         let (type2, expression2) := vec2 in
         let (type3, expression3) := idxmask in
-        "shufflevector " ++  add_parens b (show type1 ++  show_exp true expression1  ++ ", " ++ show type2 ++  show_exp true expression2 ++ ", " ++ show type3 ++  show_exp true expression3)
+        string_to_DString "shufflevector " @@ add_parens b (dshow type1 @@ dshow_exp true expression1 @@ string_to_DString ", " @@ dshow type2 @@ dshow_exp true expression2 @@
+                                                              string_to_DString ", " @@ dshow type3 @@ dshow_exp true expression3)
     (* This one, extractValue *)
     | OP_ExtractValue vec idxs =>
         let (tptr, exp) := vec in
-       "extractvalue " ++  add_parens b ( show tptr ++ " " ++  show_exp true exp ++ ", " ++ concat ", " (map (fun x => show x) idxs))
+        string_to_DString "extractvalue " @@ add_parens b (dshow tptr @@ string_to_DString " " @@ dshow_exp true exp @@ string_to_DString ", " @@
+                                                         concat_DString (string_to_DString ", ") (map (fun x => string_to_DString (show x)) idxs))
+
+
     | OP_InsertValue vec elt idxs =>
         let (tptr, exp) := vec in
         let (telt, eexp) := elt in
-        "insertvalue " ++  add_parens b (show tptr ++ " " ++  show_exp false exp ++ ", " ++ show telt ++ " " ++  show_exp false eexp ++ ", " ++ concat ", " (map (fun x => show x) idxs))
+        string_to_DString "insertvalue " @@ add_parens b (dshow tptr @@ string_to_DString " " @@ dshow_exp false exp @@ string_to_DString ", " @@ dshow telt @@ string_to_DString " " @@
+                                                            dshow_exp false eexp @@ string_to_DString ", " @@ concat_DString (string_to_DString ", ") (map (fun x => string_to_DString (show x)) idxs))
+
     | OP_Select (tc, cnd) (t1, v1) (t2, v2) =>
-        "select "  ++  add_parens b (show tc ++ " " ++  show_exp true cnd ++ ", " ++ show t1 ++ " " ++  show_exp true v1  ++ ", " ++ show t2 ++ " " ++  show_exp true v2)
-    | OP_Freeze (ty, ex) => "freeze " ++ add_parens b (show ty ++ " " ++ show_exp true ex)
+        string_to_DString "select "  @@ add_parens b (dshow tc @@ string_to_DString " " @@ dshow_exp true cnd @@ string_to_DString ", " @@ dshow t1 @@ string_to_DString " " @@
+                                                    dshow_exp true v1  @@ string_to_DString ", " @@ dshow t2 @@ string_to_DString " " @@  dshow_exp true v2)
+
+    | OP_Freeze (ty, ex) => string_to_DString "freeze " @@ add_parens b (dshow ty @@ string_to_DString " " @@ dshow_exp true ex)
     end.
 
+  #[global] Instance dshowExp : DShow (exp T) :=
+    {| dshow := dshow_exp false |}.
 
-  #[global] Instance showExp : Show (exp T)
-    := {| show := show_exp false |}.
+  #[global] Instance dshowTEXP : DShow (texp T) :=
+    {| dshow te := let '(t, e) := te in dshow t @@ string_to_DString " "
+                              @@ dshow e |}.
 
-  #[global] Instance showTExp : Show (texp T)
-    := {| show te :=
-         match te with
-         | (t, e) => show t ++ " " ++ show e
-         end
-       |}.
+  #[global] Instance dshowTExp : DShow (texp T)
+    := {| dshow te := let '(t, e) := te in dshow t @@ string_to_DString " " @@ dshow e |}.
 
-  Definition show_phi_block (p : block_id * exp T) : string :=
+  Definition show_phi_block (p : block_id * exp T) : DString :=
     let '(bid, e) := p in
-    "[ " ++ show_exp true e ++ ", " ++ "%" ++ show bid ++ " ]".
+    string_to_DString "[ " @@ dshow_exp true e @@ list_to_DString [", "; "%"] @@ dshow bid @@ string_to_DString " ]".
 
   Definition intersperse (sep : string) (l : list string) : string
     := fold_left (fun acc s => if StringOrdFacts.eqb "" acc then s else acc ++ sep ++ s) l "".
 
-  #[global] Instance showPhi : Show (phi T)
-    := {| show p :=
-         let '(Phi t phis) := p in
-         "phi " ++ show t ++ " " ++ intersperse ", " (map show_phi_block phis)
-       |}.
+  Definition dintersperse (sep : DString) (l : list DString) : DString
+    := fold_left (fun acc s => if StringOrdFacts.eqb "" (DString_to_string acc) then s else acc @@ sep @@ s) l (string_to_DString "").
 
+  Fixpoint dconcat (sep : DString) (ls : list DString) :=
+    match ls with
+    | nil => string_to_DString EmptyString
+    | cons x nil => x
+    | cons x xs => x @@ sep @@ dconcat sep xs
+    end.
+
+  #[global] Instance dshowPhi : DShow (phi T)
+    := {| dshow p :=
+         let '(Phi t phis) := p in
+         DList_join [string_to_DString "phi " ; dshow t ; string_to_DString " "] @@
+           concat_DString (string_to_DString ", ") (map show_phi_block phis)
+       |}.
 
   Definition show_opt_prefix {A} `{Show A} (prefix : string) (ma : option A) : string
     := match ma with
        | None   => ""
        | Some a => prefix ++ show a
+       end.
+
+  Definition dshow_opt_prefix {A} `{DShow A} (prefix : DString) (ma : option A) : DString
+    := match ma with
+       | None   => string_to_DString ""
+       | Some a => prefix @@ dshow a
        end.
 
   Definition show_opt_list {A} `{Show A} (ma : option A) : list string
@@ -622,42 +718,73 @@ tes on cstring on LLVMAst.v *)
        | Some a => [show a]
        end.
 
+  Definition dshow_opt_list {A} `{DShow A} (ma : option A) : list DString
+    := match ma with
+       | None   => []
+       | Some a => [dshow a]
+       end.
 
-  Definition show_ordering (o : ordering) : string :=
-    match o with
-    |Unordered => "unordered"
-    |Monotonic => "monotonic"
-    |Acquire => "acquire"
-    |Release => "release"
-    |Acq_rel => "acq_rel"
-    |Seq_cst => "seq_cst"
-    end.
+  Definition show_ordering (o : ordering) : DString :=
+    string_to_DString
+      match o with
+      |Unordered => "unordered"
+      |Monotonic => "monotonic"
+      |Acquire => "acquire"
+      |Release => "release"
+      |Acq_rel => "acq_rel"
+      |Seq_cst => "seq_cst"
+      end.
 
-  #[global] Instance showOrdering : Show (ordering)
-    := {| show := show_ordering |}.
+  #[global] Instance dshowOrdering : DShow (ordering)
+    := {| dshow := show_ordering |}.
 
-  Definition show_cmpxchg (c : cmpxchg T) : string :=
-    let p_weak := match c.(c_weak) with
-                  |None => ""
-                  |Some x => show x
-                  end in
-    let p_volatile := match c.(c_volatile) with
-                      |None => ""
-                      |Some x => show x
-                      end in
-    let p_syncscope := match c.(c_syncscope) with
-                       |None => ""
-                       |Some x => "[syncscope(""" ++ show x ++ """)]"
-                       end in
-    let p_align := match c.(c_align) with
-                   |None => ""
-                   |Some x => ", align " ++ show x
-                   end in
+  Definition show_cmpxchg (c : cmpxchg T) : DString :=
+    let p_weak :=
+      string_to_DString
+        match c.(c_weak) with
+        |None => ""
+        |Some x => show x
+        end in
+    let p_volatile :=
+      string_to_DString
+        match c.(c_volatile) with
+        |None => ""
+        |Some x => show x
+        end in
+    let p_syncscope :=
+      string_to_DString
+        match c.(c_syncscope) with
+        |None => ""
+        |Some x => "[syncscope(""" ++ show x ++ """)]"
+        end in
+    let p_align :=
+      string_to_DString
+        match c.(c_align) with
+        |None => ""
+        |Some x => ", align " ++ show x
+        end in
 
-    concatStr ["cmpxchg "; p_weak; p_volatile; show c.(c_ptr); ", ";  show c.(c_cmp_type); show c.(c_cmp); ", " ; show c.(c_new) ; p_syncscope ; show c.(c_success_ordering); show c.(c_failure_ordering) ; p_align ;  "yields  { "; show c.(c_cmp_type) ; ", i1 } "].
+    DList_join
+      [string_to_DString "cmpxchg ";
+       p_weak;
+       p_volatile;
+       dshow c.(c_ptr);
+       string_to_DString ", ";
+       dshow c.(c_cmp_type);
+       string_to_DString (show c.(c_cmp));
+       string_to_DString ", " ;
+       dshow c.(c_new);
+       p_syncscope;
+       dshow c.(c_success_ordering);
+       dshow c.(c_failure_ordering);
+       p_align;
+       string_to_DString "yields  { ";
+       dshow c.(c_cmp_type);
+       string_to_DString ", i1 } "
+      ].
 
-  #[global] Instance showCmpxchg : Show (cmpxchg T)
-    := {| show := show_cmpxchg |}.
+  #[global] Instance dshowCmpxchg : DShow (cmpxchg T)
+    := {| dshow := show_cmpxchg |}.
 
   Definition show_a_rmw_operation (a :  atomic_rmw_operation) : string :=
     match a with
@@ -679,7 +806,7 @@ tes on cstring on LLVMAst.v *)
   #[global] Instance showARmwOperation : Show (atomic_rmw_operation)
     := {| show := show_a_rmw_operation |}.
 
-  Definition show_atomic_rmw (a : atomicrmw T) : string :=
+  Definition show_atomic_rmw (a : atomicrmw T) : DString :=
     let p_volatile := match a.(a_volatile) with
                       |None => ""
                       |Some x => show x
@@ -694,34 +821,47 @@ tes on cstring on LLVMAst.v *)
                    |Some x => ", align " ++ show x
                    end in
 
-    concatStr ["atomicrmw" ;  p_volatile ; show a.(a_operation) ; show a.(a_ptr) ; ", " ;
-               show a.(a_val) ; p_syncscope ; show a.(a_ordering) ; p_align ; "yields " ;
-               show a.(a_type)].
+    DList_join
+      [string_to_DString "atomicrmw";
+       string_to_DString p_volatile;
+       string_to_DString (show a.(a_operation));
+       dshow a.(a_ptr);
+       string_to_DString ", ";
+       dshow a.(a_val);
+       string_to_DString p_syncscope;
+       dshow a.(a_ordering);
+       string_to_DString p_align;
+       string_to_DString "yields ";
+       dshow a.(a_type)].
 
-  #[global] Instance showAtomicrmw : Show (atomicrmw T)
-    := {| show := show_atomic_rmw |}.
+  #[global] Instance showAtomicrmw : DShow (atomicrmw T)
+    := {| dshow := show_atomic_rmw |}.
 
-
-  Fixpoint show_metadata (md : metadata T)  : string :=
+  Fixpoint dshow_metadata (md : metadata T)  : DString :=
     match md with
-    | METADATA_Const tv => show tv
-    | METADATA_Null => "null"
-    | METADATA_Nontemporal => "!nontemporal"
-    | METADATA_Invariant_load => "!invariant.load"
-    | METADATA_Invariant_group => "!invariant.group"
-    | METADATA_Nonnull => "!nonnull"
-    | METADATA_Dereferenceable => "!dereferenceable"
-    | METADATA_Dereferenceable_or_null => "!dereferenceable_or_null"
-    | METADATA_Align => "!align"
-    | METADATA_Noundef => "!noundef"
-    | METADATA_Id i => "!" ++ show i
-    | METADATA_String s => "!" ++ show s
-    | METADATA_Named strs => "!{" ++ intersperse " , " (List.map (fun x => "!" ++ x) strs) ++ "}"
-    | METADATA_Node mds => "!{" ++ intersperse " , " (List.map show_metadata mds) ++ "}"
+    | METADATA_Const tv => dshow tv
+    | METADATA_Null => string_to_DString "null"
+    | METADATA_Nontemporal => string_to_DString "!nontemporal"
+    | METADATA_Invariant_load => string_to_DString "!invariant.load"
+    | METADATA_Invariant_group => string_to_DString "!invariant.group"
+    | METADATA_Nonnull => string_to_DString "!nonnull"
+    | METADATA_Dereferenceable => string_to_DString "!dereferenceable"
+    | METADATA_Dereferenceable_or_null => string_to_DString "!dereferenceable_or_null"
+    | METADATA_Align => string_to_DString "!align"
+    | METADATA_Noundef => string_to_DString "!noundef"
+    | METADATA_Id i => string_to_DString "!" @@ dshow i
+    | METADATA_String s => string_to_DString "!" @@ string_to_DString (show s)
+    | METADATA_Named strs => string_to_DString "!{" @@
+                              concat_DString (string_to_DString " , ") (map (fun x => string_to_DString "!" @@
+                                                                                     string_to_DString x) strs)
+                              @@ string_to_DString "}"
+    | METADATA_Node mds => string_to_DString "!{"
+                            @@ concat_DString (string_to_DString " , ") (map dshow_metadata mds)
+                            @@ string_to_DString "}"
     end.
 
-  #[global] Instance showMetadata (md : metadata T) : Show (metadata T) :=
-    {| show := show_metadata |}.
+  #[global] Instance dshowMetadata (md : metadata T) : DShow (metadata T) :=
+    { dshow := dshow_metadata }.
 
   Definition show_unnamed_addr (u:unnamed_addr) : string :=
     match u with
@@ -731,7 +871,6 @@ tes on cstring on LLVMAst.v *)
 
   #[global] Instance showUnnamedAddr : Show unnamed_addr :=
     {| show := show_unnamed_addr |}.
-
 
   Definition show_tailcall (t:tailcall) : string :=
     match t with
@@ -744,10 +883,9 @@ tes on cstring on LLVMAst.v *)
     Instance showTailcall : Show tailcall :=
     {| show := show_tailcall |}.
 
-  Definition show_texp (x : texp T) : string :=
-    match x with
-    | (t, exp) => show t ++ " " ++ show_exp true exp
-      end.
+  Definition dshow_texp (x : texp T) : DString :=
+    let '(t, exp) := x in
+    dshow t @@ string_to_DString " " @@ dshow_exp true exp.
 
   Definition show_opt_space {A} (x:option A) : string :=
     match x with
@@ -761,16 +899,21 @@ tes on cstring on LLVMAst.v *)
     | _::_ => (concat c l) ++ " "
     end.
 
-  Definition show_call_arg '(te, atts) :=
-    let '(t, e) := (te:texp T) in
-    let attrs := concat_with_space " " (List.map show (atts:list param_attr)) in
-    (show (t:T)) ++ " " ++ attrs ++ (show_exp true (e:exp T)).
+  Definition show_call_arg (x : texp T * list param_attr) : DString :=
+    let '(te, atts) := x in
+    let '(t, e) := te in
+    let attrs := concat_DString (string_to_DString " ") (map dshow atts) @@ string_to_DString " " in
+    dshow t @@ string_to_DString  " " @@
+    attrs @@ dshow_exp true e.
 
-  Definition show_instr (i : instr T) : string
+  #[global] Instance dshowCallArg : DShow (texp T * list param_attr) :=
+    { dshow := show_call_arg }.
+
+  Definition dshow_instr (i : instr T) : DString
     := match i with
-       | INSTR_Comment s => "; " ++ s
+       | INSTR_Comment s => string_to_DString "; " @@  string_to_DString s
 
-       | INSTR_Op e => show e
+       | INSTR_Op e => dshow e
 
        | INSTR_Call fn args anns =>
            let tail := find_option ann_tail anns in
@@ -779,21 +922,21 @@ tes on cstring on LLVMAst.v *)
            let ret_attrs := filter_option ann_ret_attribute anns in
            let addrspace := find_option ann_addrspace anns in
            let fn_attrs := filter_option ann_fun_attribute anns in
-           (show_opt_prefix "" tail) ++ (show_opt_space tail)
-             ++
-             "call " ++
-             (concat_with_space " "
-                     ((map show_fast_math fast_math_flags)
-                        ++
-                        (show_opt_list cconv)
-                        ++
-                        (map show_param_attr ret_attrs)
-                        ++
-                        (show_opt_list addrspace)
-                     )
-             ) ++
-             show fn ++ "(" ++ (concat ", " (map show_call_arg args)) ++ ") " ++
-             (concat " " (map show_fn_attr fn_attrs))
+           string_to_DString (show_opt_prefix "" tail) @@ string_to_DString (show_opt_space tail)
+             @@ string_to_DString "call " @@
+             concat_DString (string_to_DString " ") (map (fun x => string_to_DString (show_fast_math x)) fast_math_flags)
+             @@
+             list_to_DString (show_opt_list cconv)
+             @@
+             DList_join (map show_param_attr ret_attrs)
+             @@
+             list_to_DString (show_opt_list addrspace) 
+
+             @@ string_to_DString " " @@
+             dshow fn @@ string_to_DString "(" @@
+             concat_DString (string_to_DString ", ") (map show_call_arg args) @@
+             string_to_DString ") " @@
+             concat_DString (string_to_DString " ") (map (fun x => string_to_DString (show_fn_attr x)) fn_attrs)
 
        | INSTR_Alloca t anns =>
            let inalloca := match find_option ann_inalloca anns with
@@ -803,7 +946,7 @@ tes on cstring on LLVMAst.v *)
            in
            let nb := find_option ann_num_elements anns in
            let align := find_option ann_align anns in
-           "alloca " ++ inalloca ++ show t ++ show_opt_prefix ", " nb ++ show_opt_prefix ", align " align
+           list_to_DString ["alloca " ; inalloca] @@ dshow t @@ dshow_opt_prefix (string_to_DString ", ") nb @@ string_to_DString (show_opt_prefix ", align " align)
 
        | INSTR_Load t ptr anns =>
            let volatile := match find_option ann_volatile anns with
@@ -813,12 +956,14 @@ tes on cstring on LLVMAst.v *)
            in
            let align := find_option ann_align anns in
            let meta := filter_option ann_metadata anns in
-           let meta_str := concatStr (List.map (fun '(m1, m2) =>
-                                                  ", "
-                                                    ++ (show_metadata (m1:metadata T)) ++ " " ++
-                                                    (show_metadata (m2:metadata T))) meta)
+           let meta_str := DList_join (map (fun '(m1, m2) =>
+                                                  string_to_DString ", "
+                                                    @@ dshow_metadata m1 @@ string_to_DString " " @@
+                                                    dshow_metadata m2)  meta)
            in
-           "load " ++ volatile ++ show t ++ ", " ++ show_texp ptr ++ (show_opt_prefix ", align " align) ++ meta_str
+           list_to_DString ["load "; volatile] @@ dshow t @@ string_to_DString ", " @@ dshow_texp ptr @@
+           string_to_DString (show_opt_prefix ", align " align) @@
+           meta_str
 
        | INSTR_Store tval ptr anns =>
            let volatile := match find_option ann_volatile anns with
@@ -828,51 +973,55 @@ tes on cstring on LLVMAst.v *)
            in
            let align := find_option ann_align anns in
            let meta := filter_option ann_metadata anns in
-           let meta_str := concatStr (List.map (fun '(m1, m2) =>
-                                                  ", "
-                                                    ++ (show_metadata (m1:metadata T)) ++ " " ++
-                                                    (show_metadata (m2:metadata T))) meta)
+           let meta_str := DList_join (map (fun '(m1, m2) =>
+                                                  string_to_DString ", "
+                                                    @@ dshow_metadata m1 @@ string_to_DString " " @@
+                                                    dshow_metadata m2) meta)
            in
-           "store " ++ volatile ++ show_texp tval ++ ", " ++ show_texp ptr ++ show_opt_prefix ", align " align ++ meta_str
+           string_to_DString "store " @@ string_to_DString volatile @@ dshow_texp tval @@
+           string_to_DString ", " @@ dshow_texp ptr @@ string_to_DString (show_opt_prefix ", align " align)
+                                                        @@ meta_str
 
        | INSTR_Fence syncscope ordering => let printable_sync := match syncscope with
                                                                  | None => ""
                                                                  | Some x => "[syncscope(""" ++ show x ++ """)]"
                                                                  end in
-                                           "fence " ++ printable_sync ++ show ordering  ++" ; yields void"
+                                          list_to_DString ["fence " ; printable_sync ] @@
+                                            dshow ordering @@
+                                            string_to_DString " ; yields void"
 
-       | INSTR_AtomicCmpXchg c => show_cmpxchg c
+       | INSTR_AtomicCmpXchg c => dshow c
 
        | INSTR_AtomicRMW a => show_atomic_rmw a
 
-       | INSTR_VAArg (va_list_and_arg_list) (t)  => "va_arg " ++ show va_list_and_arg_list ++ ", " ++ show t
+       | INSTR_VAArg va_list_and_arg_list t  =>
+           string_to_DString "va_arg " @@ dshow va_list_and_arg_list @@ string_to_DString ", " @@ dshow t
 
-       | INSTR_LandingPad => "skipping implementation at the moment"
+       | INSTR_LandingPad => string_to_DString "skipping implementation at the moment"
        end.
 
-  #[global] Instance showInstr : Show (instr T)
-    := {| show := show_instr |}.
+  #[global] Instance dshowInstr : DShow (instr T) := { dshow := dshow_instr }.
 
-  #[global] Instance showInstrId : Show instr_id
-    := {| show i :=
+  #[global] Instance dshowInstrId : DShow instr_id
+    := {| dshow i :=
          match i with
-         | IId raw => ("%" ++ show raw)%string
-         | IVoid n => ("void<" ++ show n ++ ">")%string
+         | IId raw => string_to_DString "%" @@ dshow raw
+         | IVoid n => string_to_DString "void<" @@ string_to_DString (show n) @@ string_to_DString ">"
          end
        |}.
 
-  Definition show_instr_id (inst : instr_id * instr T) : string
+  Definition dshow_instr_id (inst : instr_id * instr T) : DString
     :=
     let '(iid, i) := inst in
     match iid with
     | IId _ =>
-        (show iid ++ " = " ++ show i)%string
+        dshow iid @@ string_to_DString " = " @@ dshow i
     | IVoid n =>
-        show i
+        dshow i
     end.
 
-  #[global] Instance showInstrWithId : Show (instr_id * instr T)
-    := {| show := show_instr_id |}.
+  #[global] Instance dshowInstrWithId : DShow (instr_id * instr T)
+    := {| dshow := dshow_instr_id |}.
 
   Definition show_tint_literal (t : tint_literal) : string :=
     match t with
@@ -882,97 +1031,114 @@ tes on cstring on LLVMAst.v *)
   #[global] Instance showTintLiteral : Show tint_literal :=
     {| show := show_tint_literal |}.
 
-  Definition show_terminator (t : terminator T) : string
+  Definition dshow_terminator (t : terminator T) : DString
     := match t with
-       | TERM_Ret v => "ret " ++ show_texp v
-       | TERM_Ret_void => "ret void"
-       | TERM_Br te b1 b2 => "br " ++ show_texp te ++ ", label %" ++ show b1 ++ ", label %" ++ show b2
-       | TERM_Br_1 b => "br label %" ++ show b
-       | TERM_Switch v def_dest brs => concatStr["switch "; show_texp v; ", label %"; show def_dest;
-                                                 " ["; fold_left (fun str '(x, y) =>
-                                                                    str ++ show x ++ ", label %" ++ show y ++ " ") brs "";
-                                                 "]"]
+       | TERM_Ret v => string_to_DString "ret " @@ dshow_texp v
+       | TERM_Ret_void => string_to_DString "ret void"
+       | TERM_Br te b1 b2 =>
+           string_to_DString "br " @@ dshow_texp te @@
+           DList_join [string_to_DString ", label %" ; dshow b1 ; string_to_DString ", label %" ; dshow b2]
+       | TERM_Br_1 b => string_to_DString "br label %" @@ dshow b
 
-       | TERM_IndirectBr v brs => concatStr["indirectbr "; show_texp v; show brs]
-       | TERM_Resume v => "remove " ++ show_texp v
-       | TERM_Invoke fnptrval args to_label unwind_label => concatStr["invoke "; show fnptrval;
-                                                                      "( "; show args; "to label ";
-                                                                      show to_label; "unwind label ";
-                                                                      show unwind_label]
+       | TERM_Switch v def_dest brs => string_to_DString "switch " @@ dshow_texp v @@
+                                      string_to_DString ", label %" @@
+                                      dshow def_dest @@ string_to_DString " [" @@
+                                      fold_left (fun str '(x, y) => str @@ list_to_DString [show x; ", label %"] @@
+                                                                   dshow y @@ string_to_DString " ") brs DList_empty @@ string_to_DString "]"
 
-       | TERM_Unreachable => "unreachable"
+       | TERM_IndirectBr v brs => string_to_DString "indirectbr " @@ dshow_texp v @@
+                                   dshow brs
+
+       | TERM_Resume v => string_to_DString "remove " @@ dshow_texp v
+
+       | TERM_Invoke fnptrval args to_label unwind_label =>
+           string_to_DString "invoke " @@ dshow fnptrval @@
+             string_to_DString "( " @@ dshow args @@ string_to_DString "to label " @@
+             dshow to_label @@ string_to_DString "unwind label " @@ dshow unwind_label
+
+       | TERM_Unreachable => string_to_DString "unreachable"
        end.
 
-  #[global] Instance showTerminator : Show (terminator T)
-    := {| show := show_terminator |}.
+  #[global] Instance dshowTerminator : DShow (terminator T) := {dshow := dshow_terminator}.
 
-  Definition show_code (indent : string) (c : code T) : string
-    := concatStr (map (fun iid => indent ++ show_instr_id iid ++ newline) c).
+  Definition dshow_code (indent : string) (c : code T) : DString
+    := DList_join (map (fun iid => string_to_DString indent @@  dshow_instr_id iid @@ string_to_DString newline) c).
 
-  #[global] Instance showCode : Show (code T)
-    := {| show := show_code "    " |}.
+  #[global] Instance dshowCode : DShow (code T) := { dshow := dshow_code "    " }.
 
-  Definition show_block (indent : string) (b : block T) : string
+  Definition dnewline := string_to_DString newline.
+
+  Definition dshow_block (indent : string) (b : block T) : DString
     :=
-    let phis   := concatStr (map (fun '(l, p) => indent ++ "%" ++ show l ++ " = " ++ show p ++ newline) (blk_phis b)) in
-    let code   := show_code indent (blk_code b) in
-    let term   := indent ++ show (blk_term b) ++ newline in
-    show (blk_id b) ++ ":" ++ newline
-         ++ phis
-         ++ code
-         ++ term.
-  #[global] Instance showBlock: Show (block T) :=
-    {|
-      show := show_block "    "
-    |}.
+    let ind := string_to_DString indent in
+    let phis := DList_join (map (fun '(l, p) =>
+                                   ind @@
+                                     DList_join
+                                     [string_to_DString "%" ;
+                                      dshow l ;
+                                      string_to_DString " = " ;
+                                      dshow p ;
+                                      dnewline
+                              ])
+                              (blk_phis b)) in
+    let code   := dshow_code indent (blk_code b) in
+    let term   := DList_join [ind ; dshow (blk_term b) ; dnewline] in
+    DList_join [dshow (blk_id b); string_to_DString ":"; dnewline]
+         @@ phis
+         @@ code
+         @@ term.
 
-  Definition show_typ_instr (typ_instr: T * instr T) : string :=
+  #[global] Instance dshowBlock : DShow (block T) := { dshow := dshow_block  "    " }.
+
+  Definition dshow_typ_instr (typ_instr: T * instr T) : DString :=
     let (t, i) := typ_instr in
-    "(" ++ (show t) ++ ", " ++ (show i) ++ ")".
+    string_to_DString "(" @@ dshow t @@ string_to_DString ", " @@ dshow i @@ string_to_DString ")".
 
-  #[global] Instance showTypInstr: Show (T * instr T) :=
+  #[global] Instance dshowTypInstr: DShow (T * instr T) :=
     {|
-      show := show_typ_instr
+      dshow := dshow_typ_instr
     |}.
 
-  Definition show_arg (arg : local_id * T * list param_attr) : string
+  Definition dshow_arg (arg : local_id * T * list param_attr) : DString
     := let '(i, t, parameter_attributes) := arg in
-       show t ++ (match parameter_attributes with
-                  | [] => ""
-                  | _ => " " ++ concat " " (map (fun x => show x) (parameter_attributes))
-                  end) ++ " %" ++ show i.
+       dshow t @@
+         (match parameter_attributes with
+          | [] => string_to_DString ""
+          | _ => string_to_DString " " @@ concat_DString (string_to_DString " ") (map dshow (parameter_attributes))
+          end) @@ string_to_DString " %" @@ dshow i.
 
-  Definition show_arg_list (args : list (local_id * T * list param_attr)) (varargs:bool) : string
+  #[global] Instance dshowArg : DShow (local_id * T * list param_attr) :=
+    { dshow := dshow_arg }.
+
+  Definition dshow_arg_list (args : list (local_id * T * list param_attr)) (varargs:bool) : DString
     :=
     let vararg_str :=
       if Nat.eqb (List.length args) 0 then
-        (if varargs then "..." else "")
+        (if varargs then string_to_DString "..." else string_to_DString "")
       else
-        (if varargs then ", ..." else "")
+        (if varargs then string_to_DString ", ..." else string_to_DString "")
     in
-    let arg_str := concat ", " (map show_arg args)
+    let arg_str := concat_DString (string_to_DString ", ") (map dshow args)
     in
-      concatStr ["("; arg_str; vararg_str ; ")"].
-
-
-  (* TODO: REALLY?!? *)
-  Fixpoint zip {X Y} (xs : list X) (ys : list Y) : list (X * Y)
-    := match xs, ys with
-       | [], _ => []
-       | _, [] => []
-       | (x::xs), (y::ys) => (x, y) :: zip xs ys
-       end.
-
-  Fixpoint zip3 {X Y Z} (xs : list X) (ys : list Y) (zs : list Z) : list (X * Y *  Z)
-    := match xs, ys, zs with
-       | [], _, _ => []
-       | _, [], _ => []
-       | _, _, [] => []
-       | (x::xs), (y::ys), (z::zs) => (x, y, z) :: zip3 xs ys zs
-       end.
-
+    string_to_DString "(" @@ arg_str @@ vararg_str @@ string_to_DString ")".
 
 End ShowInstances.
+
+(* TODO: REALLY?!? *)
+Fixpoint zip {X Y} (xs : list X) (ys : list Y) : list (X * Y)
+  := match xs, ys with
+     | [], _ => []
+     | _, [] => []
+     | (x::xs), (y::ys) => (x, y) :: zip xs ys
+     end.
+
+Fixpoint zip3 {X Y Z} (xs : list X) (ys : list Y) (zs : list Z) : list (X * Y * Z)
+  := match xs, ys, zs with
+     | [], _, _ => []
+     | _, [], _ => []
+     | _, _, [] => []
+     | (x::xs), (y::ys), (z::zs) => (x, y, z) :: zip3 xs ys zs
+     end.
 
 (** Return empty string when None *)
 (** Adds a space -- is this the right place to do that? *)
@@ -982,15 +1148,25 @@ Definition maybe_to_string {X} (to_string : X -> string) (ox : option X) :=
   | Some x => ((to_string x) ++ " ")%string
   end.
 
-(** Return empty stringwhen None *)
+Definition maybe_to_dstring {X} (to_string : X -> DString) (ox : option X) :=
+  match ox with
+  | None => string_to_DString ""
+  | Some x => (to_string x) @@ string_to_DString " "
+  end.
+
+(** Return empty string when None *)
+
 Definition maybe_show {X} `{Show X} (ox : option X) : string :=
   maybe_to_string show ox.
 
-Definition show_definition (defn : definition typ (block typ * list (block typ))) : string
+Definition maybe_dshow {X} `{DShow X} (ox : option X) : DString :=
+  maybe_to_dstring dshow ox.
+
+Definition dshow_definition (defn : definition typ (block typ * list (block typ))) : DString
   :=
   let name  := defn.(df_prototype).(dc_name) in
   let ftype := defn.(df_prototype).(dc_type) in
-  let '(return_attributes, argument_attributes):= defn.(df_prototype).(dc_param_attrs) in
+  let '(return_attributes, argument_attributes) := defn.(df_prototype).(dc_param_attrs) in
 
   match ftype with
   | TYPE_Function ret_t args_t vararg =>
@@ -1001,17 +1177,18 @@ Definition show_definition (defn : definition typ (block typ * list (block typ))
          lead to tricky to catch problems otherwise.  *)
       let arg_length := List.length arg_names in
       if negb (Nat.eqb arg_length (List.length args_t) && (Nat.eqb arg_length (List.length argument_attributes)))
-      then "Function """ ++ show name ++ """ has mismatched arguments and argument attributes length"
+      then string_to_DString "Function """ @@ dshow name @@ string_to_DString """ has mismatched arguments and argument attributes length"
       else
         let args := zip3 arg_names args_t argument_attributes in
 
         let blocks :=
-          match df_instrs defn with
-          | (b, bs) => concat newline (map (show_block "    ") (b::bs))
-          end in
+          let '(b, bs) := df_instrs defn in
+          concat_DString dnewline (map dshow (b::bs))
+        in
 
-        let ret_attributes := concat " " (map (fun x => show x) (return_attributes)) in
-        let printable_ret_attrs := if ret_attributes then concatStr [" "; ret_attributes] else "" in
+        let ret_attributes := concat_DString (string_to_DString " ") (map (fun x => dshow x) (return_attributes)) @@
+        string_to_DString " " in
+        let printable_ret_attrs := ret_attributes in
 
         let linkage := maybe_show (dc_linkage defn.(df_prototype)) in
         let visibility := maybe_show (dc_visibility defn.(df_prototype)) in
@@ -1030,21 +1207,21 @@ Definition show_definition (defn : definition typ (block typ * list (block typ))
 
         let gc := maybe_show (dc_gc defn.(df_prototype)) in
 
-        concatStr ["define "; linkage; visibility ; dll_storage ;
-                   cconv ; printable_ret_attrs ; show ret_t; " @"; show name; show_arg_list args vararg;
-                   section ; align ; gc ; " {"; newline ;
-                   blocks;
-                   "}";
-                   newline]
+        DList_join [ list_to_DString ["define "; linkage; visibility; dll_storage ; cconv] @@
+                       printable_ret_attrs @@ dshow ret_t] @@ string_to_DString " @" @@ dshow name @@
+                     dshow_arg_list args vararg @@
+                     list_to_DString [section ; align ; gc ; " {"; newline] @@
+                     blocks @@
+                     list_to_DString ["}";  newline]
 
-  | _ => "Invalid type on function: " ++ show name
+  | _ => string_to_DString "Invalid type on function: " @@ dshow name
   end.
 
-Global Instance showDefinition: Show (definition typ (block typ * list (block typ))) :=
-  {| show := show_definition |}.
+#[global] Instance dshowDefinition: DShow (definition typ (block typ * list (block typ))) :=
+  {| dshow := dshow_definition |}.
 
 (* Why can I not make show functions implicit?  *)
-Definition show_declaration (decl: declaration typ) : string :=
+Definition dshow_declaration (decl: declaration typ) : DString :=
   let name := decl.(dc_name) in
   let (ret_attrs, args_attrs) := decl.(dc_param_attrs) in
   match decl.(dc_type) with
@@ -1072,33 +1249,35 @@ Definition show_declaration (decl: declaration typ) : string :=
         else
           (if vararg then ", ..." else "")
       in
-      concatStr ["declare "; link; vis; dll; cc;
-                 concatStr[intersperse " " (map show ret_attrs)]; " " ;
-
-                 show ret_t; " @"; show name;  "(";
-                 concat ", " (map (fun '(x, y) => concatStr[show x; " "; match y with
-                                                                      | [] => ""
-                                                                      | z :: tl => show z
-                                                                      end ])
-                                  (List.combine args_t args_attrs));
-                 vararg_str ;
-                 ")"; section; align; gc]
-  | _ => "Invalid type on function: " ++ show name
+      string_to_DString
+        (concatStr ["declare "; link; vis; dll; cc]) @@
+        DList_join [dintersperse (string_to_DString " ") (map dshow ret_attrs)] @@
+        string_to_DString " " @@
+        dshow ret_t @@ string_to_DString " @" @@ dshow name @@ string_to_DString "(" @@
+        dconcat (string_to_DString ", ") (map (fun '(x, y) =>
+                                                 DList_join
+                                                   [dshow x; string_to_DString " ";
+                                                    match y with
+                                                    | [] => string_to_DString ""
+                                                    | z :: tl => dshow z
+                                                    end ])
+                       (List.combine args_t args_attrs)) @@
+        string_to_DString vararg_str @@
+        string_to_DString ")" @@ string_to_DString section @@ string_to_DString align @@ string_to_DString gc
+  | _ => string_to_DString "Invalid type on function: " @@ dshow name
   end.
 
-Global Instance showDeclaration: Show (declaration typ) :=
-  {| show := show_declaration |}.
+#[global] Instance dshowDeclaration: DShow (declaration typ) :=
+  {| dshow := dshow_declaration |}.
 
-
-
-Definition show_global (g : global typ) : string :=
+Definition dshow_global (g : global typ) : DString :=
   let name  := g.(g_ident) in
   let gtype := g.(g_typ) in
   let linkage := maybe_show (g_linkage g) in
   let visibility := maybe_show (g_visibility g) in
   let dll_storage := maybe_show (g_dll_storage g) in
   let thread_local := maybe_show (g_thread_local_storage g) in
-  let g_exp := maybe_show g.(g_exp) in
+  let g_exp := maybe_dshow g.(g_exp) in
   let unnamed_addr := maybe_show (g_unnamed_addr g) in
   let addrspace := maybe_show (g_addrspace g) in
   let externally_initialized := if g.(g_externally_initialized) then "external " else "" in
@@ -1114,33 +1293,50 @@ Definition show_global (g : global typ) : string :=
       (fun a => concatStr ["align "; show a; " "])
       (g_align g) in
 
-  concatStr ["@"; show name ; " = " ; linkage ; visibility;
-             dll_storage ; thread_local;
-             unnamed_addr; addrspace;
-             externally_initialized; g_or_c;
-             show gtype; " "; g_exp;  section ; align].
+  DList_join
+    [string_to_DString "@"; dshow name; string_to_DString " = ";
+     string_to_DString linkage ; string_to_DString visibility;
+     string_to_DString dll_storage ; string_to_DString thread_local;
+     string_to_DString unnamed_addr; string_to_DString addrspace;
+     string_to_DString externally_initialized; string_to_DString g_or_c;
+     dshow gtype; string_to_DString " "; g_exp; string_to_DString section ; string_to_DString align
+    ].
 
-Global Instance showGlobal : Show (global typ) :=
-  {| show := show_global |}.
+#[global] Instance dshowGlobal : DShow (global typ) :=
+  {| dshow := dshow_global |}.
 
-Definition show_tle (tle : toplevel_entity typ (block typ * list (block typ))) : string
+Definition quoted_dstring (str : string) : DString
+  := string_to_DString (show str).
+
+Definition dshow_tle (tle : toplevel_entity typ (block typ * list (block typ))) : DString
   := match tle with
      (*Why is show_definition rather than show being used here*)
-     | TLE_Definition defn => show defn
-     | TLE_Comment msg => ";" ++ show msg (*What if the comment is multiple lines? *)
-     | TLE_Target tgt => "target triple = " ++  show tgt
-     | TLE_Datalayout layout => "target datalayout = " ++ show layout
-     | TLE_Source_filename s => "source_filename = " ++ show s
-     | TLE_Declaration decl => show decl
-     | TLE_Global g => show g
-     | TLE_Metadata id md => "!" ++ show id ++ " = " ++ show_metadata md (* Can't use implicit *)
-     | TLE_Type_decl id t => concatStr [show_ident id ;  " = type " ; show t ]
-     | TLE_Attribute_group i attrs => concatStr ["attributes #" ; show i ; " = { " ;
-                                                concat " " (map (fun x => show x) (attrs)) ; " }"  ]
+     | TLE_Definition defn => dshow defn
+     | TLE_Comment msg => string_to_DString ";" @@ quoted_dstring msg (*What if the comment is multiple lines? *)
+     | TLE_Target tgt => string_to_DString "target triple = " @@ quoted_dstring tgt
+     | TLE_Datalayout layout => string_to_DString "target datalayout = " @@ quoted_dstring layout
+     | TLE_Source_filename s => string_to_DString "source_filename = " @@ quoted_dstring s
+     | TLE_Declaration decl => dshow decl
+     | TLE_Global g => dshow g
+     | TLE_Metadata id md => string_to_DString "!" @@ dshow id @@ string_to_DString " = " @@ dshow_metadata md (* Can't use implicit *)
+     | TLE_Type_decl id t => DList_join [dshow_ident id ; string_to_DString " = type "; dshow t ]
+     | TLE_Attribute_group i attrs =>
+         DList_join
+           [string_to_DString "attributes #"; string_to_DString (show i); string_to_DString " = { " ;
+            dconcat (string_to_DString " ") (map (fun x => string_to_DString (show x)) (attrs)); string_to_DString " }"
+           ]
      end.
 
-Global Instance showTLE: Show (toplevel_entity typ (block typ  * list (block typ))) :=
-  {| show := show_tle |}.
+#[global] Instance dshowTLE: DShow (toplevel_entity typ (block typ  * list (block typ))) :=
+  {| dshow := dshow_tle |}.
 
-Global Instance showProg : Show (list (toplevel_entity typ (block typ * list (block typ)))) :=
-  {| show tles := concat (newline ++ newline) (map show_tle tles) |}.
+#[global] Instance dshowProg : DShow (list (toplevel_entity typ (block typ * list (block typ)))) :=
+  {| dshow tles := dconcat (dnewline @@ dnewline) (map dshow_tle tles) |}.
+
+Definition show_exp {T : Set} `{DShow T} (b: bool) (v : exp T) : string := show v.
+Definition showProg (p: list (toplevel_entity typ (block typ * list (block typ)))) : string := show p.
+Definition show_tle (tle : toplevel_entity typ (block typ * list (block typ))) : string := show tle.
+Definition show_typ (t : typ) : string := show t.
+
+#[global] Instance showTyp : Show typ :=
+  {| show := show_typ |}.

--- a/src/ml/libvellvm/llvm_printer.ml
+++ b/src/ml/libvellvm/llvm_printer.ml
@@ -3,12 +3,12 @@
 (*  ------------------------------------------------------------------------- *)
 
 open Format
-open LLVMAst
+open LLVMAst 
 
 let toplevel_entities (fmt : Format.formatter) (tles: (LLVMAst.typ , (LLVMAst.typ LLVMAst.block) * ((LLVMAst.typ LLVMAst.block) list)) LLVMAst.toplevel_entities) : unit =
   Format.pp_print_string fmt (Camlcoq.camlstring_of_coqstring (ShowAST.showProg tles))
 
 
 let string_of_typ (t:LLVMAst.typ) = Camlcoq.camlstring_of_coqstring (ShowAST.show_typ t)
-let string_of_exp (e:LLVMAst.typ LLVMAst.exp) = Camlcoq.camlstring_of_coqstring (ShowAST.show_exp ShowAST.show_typ false e)
+let string_of_exp (e:LLVMAst.typ LLVMAst.exp) = Camlcoq.camlstring_of_coqstring (ShowAST.show_exp (ShowAST.dshowTyp) false e)
 


### PR DESCRIPTION
QC tests can now be run reliably using ShowAST.v at around size 20. Instances in ShowAST have been refactored to return DStrings with corresponding DShow instances, which are converted to strings upon calling a Show instance. 