### PR TITLE
Support the Coq Platform by explicitly using the coq-flocq3 package.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ COQLIBDIR = ../lib
 MLDIR = ml
 EXTRACTDIR = ml/extracted
 
-OPAMPKGS=coq coq-ext-lib coq-paco coq-ceres coq-flocq coq-mathcomp-ssreflect coq-simple-io coq-itree cppo dune menhir qcheck ocamlbuild
+OPAMPKGS=coq coq-ext-lib coq-paco coq-ceres coq-flocq3 coq-mathcomp-ssreflect coq-simple-io coq-itree cppo dune menhir qcheck ocamlbuild
 
 QUICKCHICKDIR=../lib/QuickChick
 FLOCQQUICKCHICKDIR=../lib/flocq-quickchick

--- a/src/coq/Numeric/Archi.v
+++ b/src/coq/Numeric/Archi.v
@@ -18,7 +18,7 @@
 (** Architecture-dependent parameters for PowerPC *)
 
 Require Import ZArith List.
-From Flocq Require Import Binary Bits.
+From Flocq3 Require Import Binary Bits.
 
 Definition ptr64 := false.
 

--- a/src/coq/Numeric/Floats.v
+++ b/src/coq/Numeric/Floats.v
@@ -20,7 +20,7 @@
 Require Import Coqlib Zbits Integers.
 Require Import Coq.micromega.Lia.
 (*From Flocq*)
-From Flocq Require Import Binary Bits Core.
+From Flocq3 Require Import Binary Bits Core.
 Require Import IEEE754_extra.
 Require Import Program.
 Require Archi.

--- a/src/coq/Numeric/IEEE754_extra.v
+++ b/src/coq/Numeric/IEEE754_extra.v
@@ -21,7 +21,7 @@
 Require Import Psatz.
 Require Import Bool.
 Require Import Eqdep_dec.
-From Flocq Require Import Core Digits Operations Round Bracket Sterbenz Binary Round_odd.
+From Flocq3 Require Import Core Digits Operations Round Bracket Sterbenz Binary Round_odd.
 
 Require Import Coq.micromega.Lia.
 Local Open Scope Z_scope.

--- a/src/coq/Semantics/DynamicValues.v
+++ b/src/coq/Semantics/DynamicValues.v
@@ -8,7 +8,7 @@ Require Import Ceres.Ceres.
 
 Require Import Integers Floats.
 
-From Flocq.IEEE754 Require Import
+From Flocq3.IEEE754 Require Import
      Bits
      BinarySingleNaN
      Binary.
@@ -1378,13 +1378,13 @@ Class VInt I : Type :=
     end.
 
   Definition not_nan32 (f:ll_float) : bool :=
-    negb (Flocq.IEEE754.Binary.is_nan _ _ f).
+    negb (Flocq3.IEEE754.Binary.is_nan _ _ f).
 
   Definition ordered32 (f1 f2:ll_float) : bool :=
     andb (not_nan32 f1) (not_nan32 f2).
 
   Definition not_nan64 (f:ll_double) : bool :=
-    negb (Flocq.IEEE754.Binary.is_nan _ _ f).
+    negb (Flocq3.IEEE754.Binary.is_nan _ _ f).
 
   Definition ordered64 (f1 f2:ll_double) : bool :=
     andb (not_nan64 f1) (not_nan64 f2).

--- a/src/coq/Semantics/IntrinsicsDefinitions.v
+++ b/src/coq/Semantics/IntrinsicsDefinitions.v
@@ -18,7 +18,7 @@ From Vellvm Require Import
 From ITree Require Import
      ITree.
 
-From Flocq.IEEE754 Require Import
+From Flocq3.IEEE754 Require Import
      BinarySingleNaN
      Binary
      Bits.

--- a/src/coq/Utils/ParserHelper.v
+++ b/src/coq/Utils/ParserHelper.v
@@ -1,6 +1,6 @@
 Require Import ZArith Lia Basics RelationClasses Program.
 Require Import SpecFloat.
-Require Import Flocq3.IEEE754.Binary Flocq3.Core.Defs Flocq.Core.Zaux.
+Require Import Flocq3.IEEE754.Binary Flocq3.Core.Defs Flocq3.Core.Zaux.
 Require Import ExtLib.Structures.Monads ExtLib.Data.Monads.OptionMonad.
 Require Import Floats.
 

--- a/src/coq/Utils/ParserHelper.v
+++ b/src/coq/Utils/ParserHelper.v
@@ -1,6 +1,6 @@
 Require Import ZArith Lia Basics RelationClasses Program.
 Require Import SpecFloat.
-Require Import Flocq.IEEE754.Binary Flocq.Core.Defs Flocq.Core.Zaux.
+Require Import Flocq3.IEEE754.Binary Flocq3.Core.Defs Flocq.Core.Zaux.
 Require Import ExtLib.Structures.Monads ExtLib.Data.Monads.OptionMonad.
 Require Import Floats.
 
@@ -8,8 +8,8 @@ Require Import Floats.
 Open Scope Z.
 
 (* a basic float - a pair of two integers - mantissa and exponent *)
-Definition bfloat := Flocq.Core.Defs.float radix2.
-Definition BFloat := Flocq.Core.Defs.Float radix2.
+Definition bfloat := Flocq3.Core.Defs.float radix2.
+Definition BFloat := Flocq3.Core.Defs.Float radix2.
 
 (** * converting between floats in the same cohort *)
 
@@ -138,7 +138,7 @@ Section Correctness.
 
   (** ** Flocq's Binary.bounded rewritten in a form close to IEEE-754 *)
   Lemma bounded_closed_form (prec emax : Z)
-        (prec_gt_0 : Flocq.Core.FLX.Prec_gt_0 prec) (Hmax : (prec < emax)%Z)
+        (prec_gt_0 : Flocq3.Core.FLX.Prec_gt_0 prec) (Hmax : (prec < emax)%Z)
         (m : positive) (e : Z) :
     bounded prec emax m e = true
     <->

--- a/src/ml/extracted/Extract.v
+++ b/src/ml/extracted/Extract.v
@@ -63,11 +63,11 @@ in fun msg -> print_string (camlstring_of_coqstring msg ^ ""\n"")".
 (* Extract Inlined Constant LLVMAst.float => "float". *)
 
 (* Cutting the dependency to R. *)
-Extract Inlined Constant Flocq.Core.Defs.F2R => "(fun _ -> assert false)".
-Extract Inlined Constant Flocq.IEEE754.Binary.FF2R => "(fun _ -> assert false)".
-Extract Inlined Constant Flocq.IEEE754.Binary.B2R => "(fun _ -> assert false)".
-Extract Inlined Constant Flocq.IEEE754.Binary.round_mode => "(fun _ -> assert false)".
-Extract Inlined Constant Flocq.Calc.Bracket.inbetween_loc => "(fun _ -> assert false)".
+Extract Inlined Constant Flocq3.Core.Defs.F2R => "(fun _ -> assert false)".
+Extract Inlined Constant Flocq3.IEEE754.Binary.FF2R => "(fun _ -> assert false)".
+Extract Inlined Constant Flocq3.IEEE754.Binary.B2R => "(fun _ -> assert false)".
+Extract Inlined Constant Flocq3.IEEE754.Binary.round_mode => "(fun _ -> assert false)".
+Extract Inlined Constant Flocq3.Calc.Bracket.inbetween_loc => "(fun _ -> assert false)".
 
 Extract Inlined Constant Archi.ppc64 => "false".
 


### PR DESCRIPTION
Thanks for all the hard work on vellvm!

I'm trying to use the [Coq Platform]() for a variety of tasks, and as of this writing, vellvm makes that slightly awkward because it depends on Flocq version 3, but expects to find it at the logical path `Flocq`, which, in the Coq Platform, refers to Flocq version 4. Luckily, the Coq Platform maintainers provide distinct virtual packages, coq-flocq3 and coq-flocq4, for this reason. This Pull Request simply changes vellvm to depend on coq-flocq3 and use the `Flocq3` logical path instead. The system compiles and all of the tests but one pass, which I will report an issue about.