### PR TITLE
Add poison value.

### DIFF
--- a/src/coq/QC/ReprAST.v
+++ b/src/coq/QC/ReprAST.v
@@ -275,6 +275,7 @@ Section ReprInstances.
     | EXP_Zero_initializer => "EXP_Zero_initializer"
     | EXP_Cstring s => "(EXP_Cstring [" ++ (contents id (List.map texp s)) ++ "])"
     | EXP_Undef => "EXP_Undef"
+    | EXP_Poison => "EXP_Poison"
     | EXP_Struct fields => "(EXP_Struct [" ++ (contents id (List.map texp fields)) ++ "])"
     | EXP_Packed_struct fields => "(EXP_Packed_struct [" ++ (contents id (List.map texp fields)) ++ "])"
     | EXP_Array fields => "(EXP_Array [" ++ (contents id (List.map texp fields)) ++ "])"

--- a/src/coq/QC/ShowAST.v
+++ b/src/coq/QC/ShowAST.v
@@ -587,6 +587,7 @@ Section ShowInstances.
                            DList_join (map (fun '(ty, ex) => (dshow_c_string ex)) elts) @@ string_to_DString  """"
 
     | EXP_Undef => string_to_DString "undef"
+    | EXP_Poison => string_to_DString "poison"
 
     | EXP_Struct fields =>
         string_to_DString "{" @@

--- a/src/coq/Semantics/Denotation.v
+++ b/src/coq/Semantics/Denotation.v
@@ -254,6 +254,12 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
       | Some t => ret (UVALUE_Undef t)
       end
 
+    | EXP_Poison =>
+      match top with
+      | None   => raise "denote_exp given untyped EXP_Poison"
+      | Some t => ret (UVALUE_Poison t)
+      end
+
     (* Question: should we do any typechecking for aggregate types here? *)
     (* Option 1: do no typechecking: *)
     | EXP_Struct es =>

--- a/src/coq/Syntax/AstLib.v
+++ b/src/coq/Syntax/AstLib.v
@@ -420,6 +420,7 @@ Section ExpInd.
   Hypothesis IH_Zero_initializer : P ((EXP_Zero_initializer)).
   Hypothesis IH_Cstring : forall (elts: list (T * (exp T))), (forall p, In p elts -> P (snd p)) -> P ((EXP_Cstring elts)).
   Hypothesis IH_Undef   : P ((EXP_Undef)).
+  Hypothesis IH_Poison  : P ((EXP_Poison)).
   Hypothesis IH_Struct  : forall (fields: list (T * (exp T))), (forall p, In p fields -> P (snd p)) -> P ((EXP_Struct fields)).
   Hypothesis IH_Packed_struct : forall (fields: list (T * (exp T))), (forall p, In p fields -> P (snd p)) -> P ((EXP_Packed_struct fields)).
   Hypothesis IH_Array   : forall (elts: list (T * (exp T))), (forall p, In p elts -> P (snd p)) -> P ((EXP_Array elts)).
@@ -459,6 +460,7 @@ Section ExpInd.
       }
 
     - apply IH_Undef.
+    - apply IH_Poison.
     - apply IH_Struct.
       { revert fields.
         fix IHfields 1. intros [|u fields']. intros. inversion H.

--- a/src/coq/Syntax/LLVMAst.v
+++ b/src/coq/Syntax/LLVMAst.v
@@ -348,6 +348,7 @@ Inductive exp : Set :=
                       *)
 
 | EXP_Undef
+| EXP_Poison
 | EXP_Struct          (fields: list (T * exp))
 | EXP_Packed_struct   (fields: list (T * exp))
 | EXP_Array           (elts: list (T * exp))

--- a/src/coq/Syntax/Scope.v
+++ b/src/coq/Syntax/Scope.v
@@ -233,6 +233,7 @@ Section REGISTER_OPERATIONS.
                       | EXP_Zero_initializer
                       | EXP_Cstring _
                       | EXP_Undef
+                      | EXP_Poison
                         => []
 
                       | OP_Conversion _ _ e _

--- a/src/coq/Syntax/Traversal.v
+++ b/src/coq/Syntax/Traversal.v
@@ -101,7 +101,8 @@ Section Endo.
         | EXP_Bool    _
         | EXP_Null
         | EXP_Zero_initializer
-        | EXP_Undef => e
+        | EXP_Undef
+        | EXP_Poison => e
         | EXP_Cstring elts =>
           EXP_Cstring (List.map (fun '(t,e) => (endo t, f_exp e)) elts)
         | EXP_Struct fields =>
@@ -475,6 +476,7 @@ Section TFunctor.
         | EXP_Zero_initializer               => EXP_Zero_initializer
         | EXP_Cstring elts                   => EXP_Cstring (tfmap ftexp elts)
         | EXP_Undef                          => EXP_Undef
+        | EXP_Poison                         => EXP_Poison
         | EXP_Struct fields                  => EXP_Struct (tfmap ftexp fields)
         | EXP_Packed_struct fields           => EXP_Packed_struct (tfmap ftexp fields)
         | EXP_Array elts                     => EXP_Array (tfmap ftexp elts)

--- a/src/ml/libvellvm/llvm_lexer.mll
+++ b/src/ml/libvellvm/llvm_lexer.mll
@@ -351,6 +351,7 @@
   ("false" , KW_FALSE);
   ("null"  , KW_NULL);
   ("undef" , KW_UNDEF);
+  ("poison", KW_POISON);
   ("zeroinitializer" , KW_ZEROINITIALIZER);
   ("c" , KW_C);
 

--- a/src/ml/libvellvm/llvm_parser.mly
+++ b/src/ml/libvellvm/llvm_parser.mly
@@ -75,6 +75,7 @@ let ann_linkage_opt (m : linkage option) : (typ annotation) option =
 %token<Floats.float> HEXCONSTANT
 %token KW_NULL
 %token KW_UNDEF
+%token KW_POISON
 %token KW_TRUE
 %token KW_FALSE
 %token KW_ZEROINITIALIZER
@@ -1302,6 +1303,7 @@ expr_val:
   | KW_FALSE                                          { fun _ -> EXP_Bool false       }
   | KW_NULL                                           { fun _ -> EXP_Null             }
   | KW_UNDEF                                          { fun _ -> EXP_Undef            }
+  | KW_POISON                                         { fun _ -> EXP_Poison           }
   | KW_ZEROINITIALIZER                                { fun _ -> EXP_Zero_initializer }
   | LCURLY l=separated_list(csep, tconst) RCURLY      { fun _ -> EXP_Struct l         }
   | LTLCURLY l=separated_list(csep, tconst) RCURLYGT  { fun _ -> EXP_Packed_struct l  }


### PR DESCRIPTION
- Adding poison in printing and syntax.
- Add poison into lexer and parser.
- Add EXP_Poison case to denote_exp

Will get this merged once it's confirmed that it builds. It seems to build locally, but I'm a little skeptical that it didn't break any proofs about `denote_exp` (I guess maybe the poison case is handled automatically by the tactics written for the undef cases?)