### PR TITLE
Add simple linker.

### DIFF
--- a/src/coq/Utils/Util.v
+++ b/src/coq/Utils/Util.v
@@ -1397,13 +1397,13 @@ Definition map_prod {A B C D} (p:A * B) (f:A -> C) (g:B -> D) : (C * D) :=
 Definition flip := @Basics.flip.
 Definition comp := @Basics.compose.
 
-Notation "g `o` f" := (Basics.compose g f) 
+Notation "g ∘ f" := (Basics.compose g f) 
   (at level 40, left associativity).
 
 Lemma map_prod_distr_comp : forall A B C D E F
   (p:A * B) (f1:A -> C) (f2:B -> D) (g1:C -> E) (g2:D -> F),
   map_prod (map_prod p f1 f2) g1 g2 =
-  map_prod p (g1 `o` f1) (g2 `o` f2).
+  map_prod p (g1 ∘ f1) (g2 ∘ f2).
 Proof using.
   unfold map_prod, Basics.compose. auto.
 Qed.


### PR DESCRIPTION
Added the `link` function, with type ` list toplevel_entity -> list toplevel_entity -> list toplevel_entity`, and introduced it into the `TopLevel` call chain at sites like `interpreter_gen`, `model_gen_*`, etc. 

The code ended up being quite short once I reduced it. Tests and proof of linker postcondition are probably worth it. I'll work on those tomorrow. 

I made type aliases `ll_tle` for `toplevel_entity typ (block typ * list (block typ))`, and
`ll_tle_program` for `list ll_tle`. 
I think this makes the code I wrote and the code that references a variable `(prog : ll_tle_program)` cleaner. 

Lastly, the list of predefined definitions is currently empty. I'll add code to populate it (or hardcode it, depending on your preference) tomorrow. 