### PR TITLE
Parse landingpad

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -1,2 +1,2 @@
-(lang dune 3.0)
-(using menhir 2.0)
+(lang dune 3.14)
+(using menhir 3.0)

--- a/src/ml/extracted/dune
+++ b/src/ml/extracted/dune
@@ -1,11 +1,11 @@
 (env
  (dev
   (flags
-   (:standard -g -w -20-32-33-39)))
+   (:standard -g -w -20-32-33-39-67)))
  (release
   (ocamlopt_flags (:standard -O3))
   (flags
-   (:standard -w -20-32-33-39))))
+   (:standard -w -20-32-33-39-67))))
 
 (library
  (name extracted)

--- a/src/ml/interpreter.ml
+++ b/src/ml/interpreter.ml
@@ -64,11 +64,11 @@ let rec pp_uvalue : Format.formatter -> DV.uvalue -> unit =
         fprintf ppf "UVALUE_Packet_struct(%a)"
           (pp_print_list ~pp_sep:pp_comma_space pp_uvalue)
           l
-    | UVALUE_Array (t, l) ->
+    | UVALUE_Array (_, l) ->
         fprintf ppf "UVALUE_Array(%a)"
           (pp_print_list ~pp_sep:pp_comma_space pp_uvalue)
           l
-    | UVALUE_Vector (t, l) ->
+    | UVALUE_Vector (_, l) ->
         fprintf ppf "UVALUE_Vector(%a)"
           (pp_print_list ~pp_sep:pp_comma_space pp_uvalue)
           l
@@ -131,20 +131,20 @@ let rec step
       output_bytes stderr str ;
       step (k (Obj.magic ()))
   (* The OOME effect *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inl1 msg), _k) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inl1 _msg), _k) ->
      Error (OutOfMemory "")
 
   (* UBE event *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 msg)), _k) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 _msg)), _k) ->
      Error (UndefinedBehavior "")
 
   (* The DebugE effect *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 msg))), k) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 _msg))), k) ->
      (debug "";
       step (k (Obj.magic DV.DVALUE_None)))
 
   (* The FailureE effect is a failure *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 msg))), _) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 _msg))), _) ->
      Error (Failed "")
 
 (* The only visible effects from LLVMIO that should propagate to the

--- a/src/ml/libvellvm/dune
+++ b/src/ml/libvellvm/dune
@@ -6,7 +6,7 @@
   (flags (:standard -w -20-32-33-39))))
 
 (menhir
- (flags --explain)
+ (explain true)
  (modules llvm_parser)
 )
 

--- a/src/ml/libvellvm/llvm_lexer.mll
+++ b/src/ml/libvellvm/llvm_lexer.mll
@@ -281,6 +281,9 @@
   ("extractvalue"   , KW_EXTRACTVALUE);
   ("insertvalue"    , KW_INSERTVALUE);
   ("landingpad"     , KW_LANDINGPAD);
+  ("catch"          , KW_CATCH);
+  ("filter"         , KW_FILTER);
+  ("cleanup"        , KW_CLEANUP);    
 
   ("dso_preemptable" , KW_DSO_PREEMPTABLE);
   ("dso_local"       , KW_DSO_LOCAL);

--- a/src/ml/libvellvm/llvm_parser.mly
+++ b/src/ml/libvellvm/llvm_parser.mly
@@ -324,6 +324,9 @@ let ann_linkage_opt (m : linkage option) : (typ annotation) option =
 %token KW_EXTRACTVALUE
 %token KW_INSERTVALUE
 %token KW_LANDINGPAD
+%token KW_CATCH
+%token KW_FILTER
+%token KW_CLEANUP
 
 %token KW_NNAN
 %token KW_NINF
@@ -717,7 +720,7 @@ declaration:
 
     midrule( { void_ctr.reset () } )   (* reset the void counter to 0 *)
 
-    LPAREN args = dc_args RPAREN
+    LPAREN args = dc_args RPAREN EOL*
 
     u = unnamed_addr?
     dc_attrs = fn_attr*
@@ -772,7 +775,7 @@ definition:
 
     midrule( { void_ctr.reset () } )   (* reset the void counter to 0 *)
 
-    LPAREN df_args = df_args RPAREN
+    LPAREN df_args = df_args RPAREN EOL*
 
     u = unnamed_addr?
     ad = addrspace?
@@ -812,11 +815,17 @@ definition:
 	  (IId (check_or_generate_id lopt), i)
       in
 
-      let process_block (lopt, (phis, instrs), blk_term) =
+      let process_block (lopt, (phis, instrs, (id_opt, blk_term))) =
 	  let blk_id   = check_or_generate_label lopt in
 	  let blk_phis = List.map process_lhs_phi phis in
 	  let blk_code = List.map process_lhs_instr instrs in
-	  { blk_id; blk_phis; blk_code; blk_term; blk_comments = None }
+	  let term_id =
+	    begin match id_opt with
+	    | None    -> None
+	    | Some id -> Some (IId (validate_bound_lexed_id id))
+	    end
+	  in
+	  { blk_id; blk_phis; blk_code; blk_term=(blk_term term_id) ; blk_comments = None }
       in
 
       let blocks = List.map process_block blks
@@ -923,21 +932,23 @@ block_label:
   | lbl=LABEL EOL*
     { Some lbl }
 
+block_phis_and_instrs_and_term:
+  | id_opt=instr_lhs p=phi EOL+ bl=block_phis_and_instrs_and_term
+    { let (phis, instrs, t) = bl in ((id_opt, p)::phis, instrs, t) }
 
-block_phis_and_instrs:
-  | /* empty */   { ([], []) }
+  | id_opt=instr_lhs inst=instr EOL+ ins=block_instrs_and_term
+    { let (instrs, t) = ins in 
+      ([], (id_opt, inst)::instrs, t) }
 
-  | id_opt=instr_lhs p=phi EOL+ bl=block_phis_and_instrs
-    { let (phis, instrs) = bl in ((id_opt, p)::phis, instrs) }
+  | t=terminator instr_metadata? EOL+
+    { ([], [], t) }
+      
+block_instrs_and_term:
+  | t=terminator instr_metadata? EOL+ { ([], t) }
 
-  | id_opt=instr_lhs inst=instr EOL+ ins=block_instrs
-    { ([], (id_opt, inst)::ins) }
-
-block_instrs:
-  | /* empty */  { [] }
-
-  | id_opt=instr_lhs inst=instr EOL+ ins=block_instrs
-    {  (id_opt, inst)::ins }
+  | id_opt=instr_lhs inst=instr EOL+ ins=block_instrs_and_term
+    { let (instrs, t) = ins in
+      ((id_opt, inst)::instrs, t) }
 
 %inline phi:
   | KW_PHI t=typ table=separated_nonempty_list(csep, phi_table_entry)
@@ -948,12 +959,12 @@ phi_table_entry:
 
 block:
   blk_id   = block_label
-  body     = block_phis_and_instrs
-  blk_term = terminator instr_metadata? EOL+
+  body     = block_phis_and_instrs_and_term
     {
-	(blk_id, body, blk_term)
+	(blk_id, body)
     }
 
+%inline
 instr_metadata:
   | COMMA list(metadata_value) { }
 
@@ -1450,7 +1461,6 @@ exp:
 
 
   | KW_VAARG tv=texp COMMA t=typ { INSTR_VAArg (tv, t)  }
-  // | KW_LANDINGPAD    { failwith"INSTR_LandingPad"    }
 
   | KW_STORE vol=KW_VOLATILE? all=texp COMMA ptr=texp anns=store_anns
     { let v = match vol with Some _ -> [ANN_volatile] | None -> [] in
@@ -1459,42 +1469,63 @@ exp:
   | KW_ATOMICCMPXCHG { failwith"INSTR_AtomicCmpXchg" }
   | KW_ATOMICRMW     { failwith"INSTR_AtomicRMW"     }
   | KW_FENCE         { failwith"INSTR_Fence"         }
+  | KW_LANDINGPAD t=typ EOL* KW_CLEANUP cs=clause* { INSTR_LandingPad (t, true, cs) }
+  | KW_LANDINGPAD t=typ EOL* cs=clause+            { INSTR_LandingPad (t, false, cs) }
 
+%inline
+clause:
+  | KW_CATCH t=typ v=expr_val EOL* { CATCH (t, v t) }
+  | KW_FILTER t=typ v=expr_val EOL* { FILTER (t, v t) }
 
 branch_label:
   KW_LABEL o=LOCAL  { lexed_id_to_raw_id o }
 
+%inline
 terminator:
   | KW_RET tv=texp
-    { TERM_Ret tv }
+    { None, fun _ -> TERM_Ret tv }
 
   | KW_RET KW_VOID
-    { TERM_Ret_void }
+    { None, fun _ -> TERM_Ret_void }
 
   | KW_BR c=texp COMMA o1=branch_label COMMA o2=branch_label
-    { TERM_Br (c, o1, o2) }
+    { None, fun _ -> TERM_Br (c, o1, o2) }
 
   | KW_BR b=branch_label
-    { TERM_Br_1 b }
+    { None, fun _ -> TERM_Br_1 b }
 
   | KW_SWITCH c=texp COMMA
     def=branch_label LSQUARE EOL? table=list(switch_table_entry) RSQUARE
-    { TERM_Switch (c, def, table) }
+    { None, fun _ -> TERM_Switch (c, def, table) }
 
   | KW_INDIRECTBR tv=texp
     COMMA LSQUARE til=separated_list(csep, branch_label)  RSQUARE
-    { TERM_IndirectBr (tv, til) }
+    { None, fun _ -> TERM_IndirectBr (tv, til) }
 
   | KW_RESUME tv=texp
-    { TERM_Resume tv }
+    { None, fun _ -> TERM_Resume tv }
 
-  | KW_INVOKE cconv? ret=tident
-    LPAREN a=separated_list(csep, call_arg) RPAREN
-    list(fn_attr) KW_TO l1=branch_label KW_UNWIND l2=branch_label
-    { TERM_Invoke (ret, a, l1, l2)  }
+  /* | l=LOCAL EQ KW_INVOKE cconv? ret=tident */
+  /*   LPAREN a=separated_list(csep, call_arg) RPAREN EOL* */
+  /*   list(fn_attr) KW_TO l1=branch_label EOL* KW_UNWIND l2=branch_label */
+  /*   { TERM_Invoke (Some (IId (validate_bound_lexed_id l)), ret, a, l1, l2)  } */
+
+  | id_opt=instr_lhs KW_INVOKE fm=list(fast_math) cc=cconv? ra=list(param_attr) addr=addrspace?
+    f=texp  a=delimited(LPAREN, separated_list(csep, call_arg), RPAREN)
+    fa=list(fn_attr) EOL*
+    KW_TO l1=branch_label EOL*
+    KW_UNWIND l2=branch_label
+    { let atts =
+	  (List.map (fun f -> ANN_fast_math_flag f) fm)
+	@ (opt_list cc)
+        @ (List.map (fun r -> ANN_ret_attribute r) ra)
+        @ (opt_list addr)
+        @ (List.map (fun f -> ANN_fun_attribute f) fa)
+      in
+      (id_opt, fun id_opt -> TERM_Invoke (id_opt, f, a, l1, l2, atts))  }
 
   | KW_UNREACHABLE
-    { TERM_Unreachable }
+    { None, fun _ -> TERM_Unreachable }
 
 align:
   | KW_ALIGN n=INTEGER { ANN_align n }

--- a/src/ml/main.ml
+++ b/src/ml/main.ml
@@ -281,7 +281,7 @@ let test_all () =
   let b3 = try test_dir !test_directory with Ran_tests b -> b in
   raise (Ran_tests (b1 && b2 && b3))
 
-let test_all' () =
+let _test_all' () =
   let _ =
     Printf.printf "============== RUNNING TEST SUITE ==============\n"
   in

--- a/src/ml/test.ml
+++ b/src/ml/test.ml
@@ -252,6 +252,11 @@ let larger_memory_tests =
 
 let c_tests = [("../tests/c/average.ll", 2)]
 
+let exception_tests =
+  [ ("../tests/ll/invoke_landingpad.ll", 5)
+  ; ("../tests/ll/invoke_landingpad_void.ll", 42)
+  ]
+
 let other_tests =
   arith_tests @ calling_convention_tests @ memory_tests @ phi_tests
   @ terminator_tests @ bitcast_tests
@@ -394,6 +399,12 @@ let suite =
           (fun (f, i) ->
             (f, fun () -> run_dvalue_test (i_test (i32_of_int i)) f) )
           c_tests )
+  ; Test
+      ( "Exception Tests"
+      , List.map
+          (fun (f, i) ->
+            (f, fun () -> run_dvalue_test (i_test (i64_of_int i)) f) )
+          exception_tests )
   ; (* Test ("Parsing-Must-fail",
      *       List.map (fun (f, p) ->
      *           (f, (fun () -> run_parsefail_test f p)))

--- a/src/ml/test.ml
+++ b/src/ml/test.ml
@@ -12,7 +12,6 @@ open Base
 open Driver
 
 open Assert
-open VellvmIntegers
 
 open InterpretationStack.InterpreterStackBigIntptr.LP.Events
 

--- a/src/rocq/QC/ReprAST.v
+++ b/src/rocq/QC/ReprAST.v
@@ -709,6 +709,16 @@ Section ReprInstances.
    Instance reprCmpxchg : Repr (cmpxchg typ) :=
     {| repr := repr_cmpxchg |}.
 
+  #[global]
+    Instance reprClause : Repr (@landingpad_clause typ) :=
+    {| repr := fun c =>
+                 match c with
+                 | CATCH t => "(CATCH " ++ repr t ++ ")"
+                 | FILTER t => "(FILTER " ++ repr t ++ ")"
+                 end
+    |}.
+                   
+  
   Definition repr_instr (i : instr typ) : string
     := match i with
        | INSTR_Comment s => "(INSTR_Comment " ++ s ++ ")"
@@ -729,8 +739,8 @@ Section ReprInstances.
            "(INSTR_AtomicRMW " ++ repr rmw ++ ")"
        | INSTR_VAArg e t =>
            "(INSTR_VAArg " ++ repr e ++ " " ++ repr t ++ ")"
-       | INSTR_LandingPad =>
-           "INSTR_LandingPad"
+       | INSTR_LandingPad t b cs =>
+           "(INSTR_LandingPad " ++ (repr t) ++ " " ++ repr b ++ " " ++ repr cs ++ ")"
        end.
 
   #[global]
@@ -767,9 +777,9 @@ Section ReprInstances.
       | TERM_IndirectBr v brs  => 
           "(TERM_IndirectBr " ++ repr v ++ " " ++ repr brs ++ ")" 
       | TERM_Resume v  => "(TERM_Resume " ++ repr v ++ ")"
-      | TERM_Invoke fnptrval args to_label unwind_label  =>
-          "(TERM_Invoke " ++ repr fnptrval ++ " " ++ repr args 
-          ++ " " ++ repr to_label ++ " " ++ repr unwind_label ++ ")"
+      | TERM_Invoke i fnptrval args to_label unwind_label anns  =>
+          "(TERM_Invoke " ++ repr i ++ repr fnptrval ++ " " ++ repr args 
+          ++ " " ++ repr to_label ++ " " ++ repr unwind_label ++ repr anns ++ ")"
       | TERM_Unreachable => "TERM_Unreachable"
        end.
 

--- a/src/rocq/QC/ShowAST.v
+++ b/src/rocq/QC/ShowAST.v
@@ -929,6 +929,13 @@ Section ShowInstances.
   Definition dshow_metadata_list (ml : list (metadata T)) := 
     concat_DString (string_to_DString " ") (map dshow_metadata ml).
     
+  Definition dnewline := string_to_DString newline.
+
+  Definition dshow_clause (c : landingpad_clause) : DString :=
+    match c with
+    | CATCH t => (string_to_DString "catch ") @@ dshow_texp t @@ dnewline
+    | FILTER t => (string_to_DString "filter ") @@ dshow_texp t @@ dnewline
+    end.
   
   Definition dshow_instr (i : instr T) : DString
     := match i with
@@ -1016,7 +1023,11 @@ Section ShowInstances.
        | INSTR_VAArg va_list_and_arg_list t  =>
            string_to_DString "va_arg " @@ dshow va_list_and_arg_list @@ string_to_DString ", " @@ dshow t
 
-       | INSTR_LandingPad => string_to_DString "skipping implementation at the moment"
+       | INSTR_LandingPad t b cs =>
+           (string_to_DString "landingpad ") @@ dshow t @@ dnewline @@
+             (if b then string_to_DString "cleanup " else DList_empty)
+             @@
+             DList_join (map dshow_clause cs)
        end.
 
   #[global] Instance dshowInstr : DShow (instr T) := { dshow := dshow_instr }.
@@ -1070,10 +1081,35 @@ Section ShowInstances.
 
        | TERM_Resume v => string_to_DString "remove " @@ dshow_texp v
 
-       | TERM_Invoke fnptrval args to_label unwind_label =>
-           string_to_DString "invoke " @@ dshow fnptrval @@
-             string_to_DString "( " @@ dshow args @@ string_to_DString "to label " @@
-             dshow to_label @@ string_to_DString "unwind label " @@ dshow unwind_label
+       | TERM_Invoke io fn args to_label unwind_label anns =>
+           let tail := find_option ann_tail anns in
+           let fast_math_flags := filter_option ann_fast_math_flag anns in
+           let cconv := find_option ann_cconv anns in
+           let ret_attrs := filter_option ann_ret_attribute anns in
+           let addrspace := find_option ann_addrspace anns in
+           let fn_attrs := filter_option ann_fun_attribute anns in
+           (match io with
+            | None => DList_empty
+            | Some i => dshow i @@ string_to_DString " = "
+            end
+           ) @@ string_to_DString "invoke "
+             @@
+             concat_DString (string_to_DString " ") (map (fun x => string_to_DString (show_fast_math x)) fast_math_flags)
+             @@
+             list_to_DString (show_opt_list cconv)
+             @@
+             DList_join (map show_param_attr ret_attrs)
+             @@
+             list_to_DString (show_opt_list addrspace) 
+             
+             @@ string_to_DString " " @@
+             dshow_texp fn @@ string_to_DString "(" @@
+             concat_DString (string_to_DString ", ") (map show_call_arg args) @@
+             string_to_DString ") " @@
+             concat_DString (string_to_DString " ") (map (fun x => string_to_DString (show_fn_attr x)) fn_attrs)
+             @@
+             string_to_DString "to label %" @@ dshow to_label @@ string_to_DString " " @@
+             string_to_DString "unwind label %" @@ dshow unwind_label
 
        | TERM_Unreachable => string_to_DString "unreachable"
        end.
@@ -1084,8 +1120,6 @@ Section ShowInstances.
     := DList_join (map (fun iid => string_to_DString indent @@  dshow_instr_id iid @@ string_to_DString newline) c).
 
   #[global] Instance dshowCode : DShow (code T) := { dshow := dshow_code "    " }.
-
-  Definition dnewline := string_to_DString newline.
 
   Definition dshow_block (indent : string) (b : block T) : DString
     :=

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -491,7 +491,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     | (_, INSTR_Fence _ _)
     | (_, INSTR_AtomicCmpXchg _)
     | (_, INSTR_AtomicRMW _)
-    | (_, INSTR_LandingPad) => raise "Unsupported VIR instruction"
+    | (_, INSTR_LandingPad _ _ _) => raise "Unsupported VIR instruction"
 
     (* Error states *)
     | (_, _) => raise "ID / Instr mismatch void/non-void"
@@ -567,7 +567,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     (* Currently unhandled VIR terminators *)
     | TERM_IndirectBr _ _
     | TERM_Resume _
-    | TERM_Invoke _ _ _ _ => raise "Unsupport itree terminator"
+    | TERM_Invoke _ _ _ _ _ _ => raise "Unsupport itree terminator"
     end.
 
   (* Denoting a list of instruction simply binds the trees together *)

--- a/src/rocq/Syntax/LLVMAst.v
+++ b/src/rocq/Syntax/LLVMAst.v
@@ -674,6 +674,10 @@ Definition ann_fun_attribute (a:annotation) : option fn_attr :=
   | _ => None
   end.
 
+Variant landingpad_clause :=
+  | CATCH (t : texp)
+  | FILTER (t : texp).
+
 Variant instr : Set :=
 | INSTR_Comment (msg:string)
 | INSTR_Op   (op:exp)                                             (* INVARIANT: op must be of the form (OP_ ...) *)
@@ -685,7 +689,7 @@ Variant instr : Set :=
 | INSTR_AtomicCmpXchg (c : cmpxchg)
 | INSTR_AtomicRMW (a :atomicrmw )
 | INSTR_VAArg (va_list_and_arg_list : texp) (t: T) (* arg_list isn't actually a list, this is just the name of the argument  *)
-| INSTR_LandingPad
+| INSTR_LandingPad (resultty:T) (cleanup:bool) (cs:list landingpad_clause)
 .
 
 Variant terminator : Set :=
@@ -698,7 +702,10 @@ Variant terminator : Set :=
 | TERM_Switch     (v:texp) (default_dest:block_id) (brs: list (tint_literal * block_id))
 | TERM_IndirectBr (v:texp) (brs:list block_id) (* address * possible addresses (labels) *)
 | TERM_Resume     (v:texp)
-| TERM_Invoke     (fnptrval:tident) (args:list (texp * (list param_attr))) (to_label:block_id) (unwind_label:block_id)
+
+  (* The `invoke` terminator, unlike the others, can optionally define an
+     instr_id for use in the "to_label" block, as with a `call` instruction.  *)                  
+| TERM_Invoke  (i:option instr_id) (fnptrval:texp) (args:list (texp * (list param_attr))) (to_label:block_id) (unwind_label:block_id) (anns:list annotation)
 | TERM_Unreachable
 .
 

--- a/src/rocq/Syntax/Scope.v
+++ b/src/rocq/Syntax/Scope.v
@@ -54,7 +54,7 @@ Section LABELS_OPERATIONS.
        | TERM_Switch v default_dest brs => default_dest :: map snd brs
        | TERM_IndirectBr v brs => brs
        | TERM_Resume v => []
-       | TERM_Invoke fnptrval args to_label unwind_label => [to_label; unwind_label]
+       | TERM_Invoke _ fnptrval args to_label unwind_label _ => [to_label; unwind_label]
        | TERM_Unreachable => []
        end.
 
@@ -268,6 +268,14 @@ Section REGISTER_OPERATIONS.
     #[global] Instance texp_use_sites {T} : Use_sites (texp T) := {| use_sites := fun x => use_sites (snd x) |}.
     #[global] Instance option_use_sites {T} `{Use_sites T} : Use_sites (option T) := {| use_sites := fun x => match x with | Some e => use_sites e | None => ∅ end |}.
 
+    #[global] Instance landingpad_clause_use_sites {T} : Use_sites (@landingpad_clause T) :=
+      {| use_sites := fun c => match c with
+                            | CATCH t => use_sites t
+                            | FILTER t => use_sites t
+                            end
+      |}.
+                                    
+    
     #[global] Instance instr_use_sites {T} : Use_sites (instr T) :=
       {| use_sites := fun i => match i with
                             | INSTR_Op e => use_sites e
@@ -277,12 +285,12 @@ Section REGISTER_OPERATIONS.
                               => use_sites e
                             | INSTR_Store e1 e2 _
                               => use_sites e1 +++ use_sites e2
+                            | INSTR_LandingPad _ _ cs => set_flat_map use_sites cs
                             | INSTR_Alloca _ _
                             | INSTR_Fence _ _
                             | INSTR_AtomicCmpXchg _
                             | INSTR_AtomicRMW _
                             | INSTR_VAArg _ _
-                            | INSTR_LandingPad
                             | INSTR_Comment _
                               => []
                             end
@@ -307,7 +315,7 @@ Section REGISTER_OPERATIONS.
                                | TERM_Unreachable
                                  => []
 
-                               | TERM_Invoke _ l _ _ =>
+                               | TERM_Invoke _ _ l _ _ _ =>
                                  set_flat_map use_sites (List.map fst l)
                                end
       |}.

--- a/src/rocq/Syntax/Traversal.v
+++ b/src/rocq/Syntax/Traversal.v
@@ -186,6 +186,16 @@ Section Endo.
     #[global] Instance Endo_tint_literal
       : Endo tint_literal | 50 := id.
 
+    #[global] Instance Endo_clause
+      `{Endo T}
+      `{Endo (exp T)}
+      : Endo landingpad_clause | 50 :=
+      fun c =>
+        match c with
+        | CATCH t => CATCH (endo t)
+        | FILTER t => FILTER (endo t)
+        end.
+    
     #[global] Instance Endo_instr
            `{Endo T}
            `{Endo (exp T)}
@@ -207,7 +217,7 @@ Section Endo.
         | INSTR_AtomicCmpXchg c => ins
         | INSTR_AtomicRMW a => ins
         | INSTR_VAArg va t => ins
-        | INSTR_LandingPad => ins
+        | INSTR_LandingPad t b cs =>  INSTR_LandingPad (endo t) b (endo cs)
         end.
 
     #[global] Instance Endo_terminator
@@ -215,6 +225,7 @@ Section Endo.
            `{Endo raw_id}
            `{Endo (exp T)}
            `{Endo param_attr}
+           `{Endo (annotation T)}           
       : Endo (terminator T) | 50 :=
       fun trm =>
         match trm with
@@ -227,8 +238,8 @@ Section Endo.
         | TERM_IndirectBr v brs =>
           TERM_IndirectBr (endo v) (endo brs)
         | TERM_Resume v => TERM_Resume (endo v)
-        | TERM_Invoke fnptrval args to_label unwind_label =>
-          TERM_Invoke (endo fnptrval) (endo args) (endo to_label) (endo unwind_label)
+        | TERM_Invoke i fnptrval args to_label unwind_label atts =>
+          TERM_Invoke (endo i) (endo fnptrval) (endo args) (endo to_label) (endo unwind_label) (endo atts)
         | TERM_Unreachable => TERM_Unreachable
         end.
 
@@ -543,6 +554,15 @@ Section TFunctor.
           (endo (a_align a))
           (f (a_type a)).
 
+    #[global] Instance TFunctor_landingpad_clause
+     `{TFunctor exp}
+      : TFunctor (@landingpad_clause) | 50 :=
+    fun U V f c =>
+      match c with
+      | CATCH v => CATCH (tfmap f v)
+      | FILTER v => FILTER (tfmap f v)
+      end.
+  
     #[global] Instance TFunctor_instr
      `{TFunctor exp}
      `{TFunctor annotation}
@@ -561,7 +581,7 @@ Section TFunctor.
         | INSTR_AtomicCmpXchg c => INSTR_AtomicCmpXchg (tfmap f c)
         | INSTR_AtomicRMW a => INSTR_AtomicRMW (tfmap f a)
         | INSTR_VAArg va t => INSTR_VAArg (tfmap f va) (f t)
-        | INSTR_LandingPad => INSTR_LandingPad
+        | INSTR_LandingPad t b cs => INSTR_LandingPad (f t) b (tfmap f cs)
         end.
 
     #[global] Instance TFunctor_tident
@@ -572,6 +592,7 @@ Section TFunctor.
            `{Endo tint_literal}
            `{Endo raw_id}
            `{TFunctor exp}
+           `{TFunctor annotation}           
       : TFunctor terminator | 50 :=
       fun U V f trm =>
         match trm with
@@ -582,10 +603,11 @@ Section TFunctor.
         | TERM_Switch v default_dest brs => TERM_Switch (tfmap f v) (endo default_dest) (endo brs)
         | TERM_IndirectBr v brs => TERM_IndirectBr (tfmap f v) (endo brs)
         | TERM_Resume v => TERM_Resume (tfmap f v)
-        | TERM_Invoke fnptrval args to_label unwind_label =>
-            TERM_Invoke (tfmap f fnptrval)
+        | TERM_Invoke i fnptrval args to_label unwind_label atts =>
+            TERM_Invoke i
+                        (tfmap f fnptrval)
                         (List.map (fun '(te, a) => (tfmap f te, a))  args)
-                        (endo to_label) (endo unwind_label)
+                        (endo to_label) (endo unwind_label) (tfmap f atts)
         | TERM_Unreachable => TERM_Unreachable
         end.
 

--- a/tests/ll/invoke_landingpad.ll
+++ b/tests/ll/invoke_landingpad.ll
@@ -1,0 +1,31 @@
+define ptr @__personality_routine (i32 %version, i32 %actions, i64 %exception_class, ptr %ext, ptr %ctxt) {
+  ret ptr null
+}  
+
+
+; doesn't actually raise any exceptions
+define i64 @test_no_exception(i64 %n) {
+  ret i64 %n
+}
+
+
+define i64 @test_invoke(i64 %n) personality i32 (i32, i32, i64, i8*, i8*)* @__personality_routine {
+  %ans = invoke i64 @test_no_exception(i64 %n) to label %continue
+            unwind label %exception
+
+continue:
+  ret i64 %ans
+
+exception:
+  %res = landingpad { ptr, i64 }
+          cleanup
+  ret i64 17	  
+}
+
+define i64 @main(i64 %argc, i8** %arcv) {
+  %1 = alloca i64
+  store i64 0, i64* %1
+  %2 = call i64 @test_invoke(i64 5)
+  ret i64 %2
+}
+

--- a/tests/ll/invoke_landingpad_void.ll
+++ b/tests/ll/invoke_landingpad_void.ll
@@ -1,0 +1,32 @@
+define ptr @__personality_routine (i32 %version, i32 %actions, i64 %exception_class, ptr %ext, ptr %ctxt) {
+  ret ptr null
+}  
+
+
+; doesn't actually raise any exceptions
+define void @test_no_exception(i64 %n) {
+  ret void
+}
+
+
+define i64 @test_invoke(i64 %n) personality i32 (i32, i32, i64, i8*, i8*)* @__personality_routine {
+  invoke void @test_no_exception(i64 %n)
+         to label %continue
+         unwind label %exception
+
+continue:
+  ret i64 42
+
+exception:
+  %res = landingpad { ptr, i64 }
+          cleanup
+  ret i64 17	  
+}
+
+define i64 @main(i64 %argc, i8** %arcv) {
+  %1 = alloca i64
+  store i64 0, i64* %1
+  %2 = call i64 @test_invoke(i64 5)
+  ret i64 %2
+}
+

--- a/tests/memory/memcasts.ll
+++ b/tests/memory/memcasts.ll
@@ -1,0 +1,21 @@
+define i32 @casts() {
+  %arr_ptr = alloca [2 x i32], align 8
+  %i64_ptr = bitcast [2 x i32]* %arr_ptr to i64*
+  store i64 4294967303, i64* %i64_ptr   ; 0x0000000100000007
+  %ind1 = getelementptr [2 x i32], [2 x i32]* %arr_ptr, i32 0, i32 0
+  %ind2 = getelementptr [2 x i32], [2 x i32]* %arr_ptr, i32 0, i32 1
+  %v1 = load i32, i32* %ind1            ; load value 7
+  %v2 = load i32, i32* %ind2            ; load value 1
+  %sum = add i32 %v1, %v2               ; sum = 8
+  %iptr = ptrtoint i64* %i64_ptr to i64 ; cast to an integer
+  %iptr2 = add i64 %iptr, 3             ; offset into bits
+  %ptr = inttoptr i64 %iptr2 to i32*    ; cast back to pointer
+  %v3 = load i32, i32* %ptr             ; load value 256, i.e. (1 >> 256)
+  %sum2 = add i32 %sum, %v3             ; sum2 = 264
+  ret i32 %sum2
+}
+
+define i32 @main(i64 %argc, i8** %arcv) {
+  %1 = call i32 @casts()
+  ret i32 %1
+}

--- a/tests/memory/opaquePtr.ll
+++ b/tests/memory/opaquePtr.ll
@@ -55,7 +55,7 @@ define i32 @foo() #0 {
   %11 = load i32, ptr %1, align 4
   %12 = add i32 %11, 1
   store i32 %12, ptr %1, align 4
-  br label %2, !llvm.loop !5
+  br label %2
 
 13:                                               ; preds = %2
   %14 = call i32 @get_a(i32 noundef 7)


### PR DESCRIPTION
Added parsing support for `invoke` instructions.  This was a bit more annoying than one might think because `invoke` is now the only "terminator" that can define a local ID.

Also added some test cases for parsing.  These compile and run with clang, but they don't throw/catch exceptions, so they currently only execute the "normal" control flow path.