### PR TITLE
parse (but ignore) more metadata, especially debug metadata

### DIFF
--- a/src/ml/interpreter.ml
+++ b/src/ml/interpreter.ml
@@ -10,8 +10,6 @@
 
 open InterpretationStack.InterpreterStackBigIntptr.LLVM.MEM
 
-open InterpretationStack.InterpreterStackBigIntptr.LLVM.Local
-
 open InterpretationStack.InterpreterStackBigIntptr.LLVM.Stack
 
 open InterpretationStack.InterpreterStackBigIntptr.LLVM.Global
@@ -135,20 +133,20 @@ let rec step
      Error (OutOfMemory "")
 
   (* LLVM Exception event *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 uv)), _k) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 _uv)), _k) ->
      Error (LLVMException "")
 
   (* UBE event *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 msg))), _k) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 _msg))), _k) ->
      Error (UndefinedBehavior "")
 
   (* The DebugE effect *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 msg)))), k) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 _msg)))), k) ->
      (debug "";
       step (k (Obj.magic DV.DVALUE_None)))
 
   (* The FailureE effect is a failure *)
-  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 msg)))), _) ->
+  | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 _msg)))), _) ->
      Error (Failed "")
 
 (* The only visible effects from LLVMIO that should propagate to the

--- a/src/ml/libvellvm/llvm_lexer.mll
+++ b/src/ml/libvellvm/llvm_lexer.mll
@@ -220,6 +220,14 @@
   ("musttail"                     , KW_MUSTTAIL);
   ("notail"                       , KW_NOTAIL);
   ("volatile"                     , KW_VOLATILE);
+  ("memory"                       , KW_MEMORY);
+  ("read"                         , KW_READ);
+  ("write"                        , KW_WRITE);
+  ("none"                         , KW_NONE);
+  ("readwrite"                    , KW_READWRITE);
+  ("argmem"                       , KW_ARGMEM);
+  ("inaccessiblemem"              , KW_INACCESSIBLEMEM);
+  ("errnomem"                     , KW_ERRNOMEM);
 
   (* instrs *)
   ("add"            , KW_ADD);
@@ -376,7 +384,7 @@
       let token = Hashtbl.find symbol_table str in
       let _ = Histogram.record histogram str in
       token
-    with _ -> failwith ("Unknown or unsupported keyword: " ^ str)
+    with _ -> KW_UNKNOWN str
 
   type ident_type = Named | NamedString | Unnamed
 
@@ -402,9 +410,9 @@ let upletter = ['A'-'Z']
 let lowletter = ['a'-'z']
 let letter = upletter | lowletter
 let alphanum = digit | letter
-let ident_fst  = letter   | ['-' '$' '.' '_']
-let ident_nxt  = alphanum | ['-' '$' '.' '_']
-let label_char = alphanum | ['-' '$' '.' '_']
+let ident_fst  = letter   | ['-' '$' '.' '_' ':']
+let ident_nxt  = alphanum | ['-' '$' '.' '_' ':']
+let label_char = alphanum | ['-' '$' '.' '_' ':'] 
 let kwletter   = alphanum | ['_']
 
 rule token = parse
@@ -425,6 +433,7 @@ rule token = parse
   | ']'  { RSQUARE }
   | '<'  { LT }
   | '>'  { GT }
+  | ':'  { COLON }
   | "..." { DOTDOTDOT }
 
   (* labels *)
@@ -436,6 +445,7 @@ rule token = parse
 
   (* FIXME: support metadata strings and struct. Parsed as identifier here. *)
   | "!{" { BANGLCURLY }
+  | "!DI" kwletter* '(' { gobble_metadata_debug 1 lexbuf } (* ignore input until next closing paren; produce METADATA_DEBUG after *)
   | '!'  { let rid = lexed_id lexbuf in
            begin match rid with
            | ParseUtil.Named id ->
@@ -448,6 +458,8 @@ rule token = parse
          }
 
   | '#' (digit+ as i) { ATTR_GRP_ID (coq_of_int (int_of_string i)) }
+
+  | "#dbg" kwletter* '(' { gobble_debug 1 lexbuf } (* ignore input until next closing paren *)
 
   (* constants *)
   | ('-'? digit+) as d            { INTEGER (z_of_ocaml_Z (Z.of_string d)) }
@@ -462,6 +474,19 @@ rule token = parse
 
   (* keywords *)
   | kwletter+ as a { create_token a }
+
+and gobble_debug depth = parse
+  | '(' { gobble_debug (depth+1) lexbuf }
+  | ')' { if depth = 1 then token lexbuf else gobble_debug (depth - 1) lexbuf }
+  | eol { Lexing.new_line lexbuf; gobble_debug depth lexbuf }
+  | _   { gobble_debug depth lexbuf }
+
+and gobble_metadata_debug depth = parse
+  | '(' { gobble_metadata_debug (depth+1) lexbuf }
+  | ')' { if depth = 1 then METADATA_DEBUG else gobble_metadata_debug (depth - 1) lexbuf }
+  | eol { Lexing.new_line lexbuf; gobble_metadata_debug depth lexbuf }
+  | _   { gobble_metadata_debug depth lexbuf }
+
 
 and comment = parse
   | eol { Lexing.new_line lexbuf; token lexbuf }

--- a/src/ml/libvellvm/llvm_parser.mly
+++ b/src/ml/libvellvm/llvm_parser.mly
@@ -976,7 +976,7 @@ block_instrs_and_term:
       ((id_opt, inst)::instrs, t) }
 
 %inline phi:
-  | KW_PHI t=typ table=comma_path_with_instr_metadata(phi_table_entry)
+  | KW_PHI t=typ table=separated_nonempty_list(csep, phi_table_entry)
     { Phi (t, List.map (fun (l,v) -> (l, v t)) table)}
 
 phi_table_entry:

--- a/src/ml/libvellvm/llvm_parser.mly
+++ b/src/ml/libvellvm/llvm_parser.mly
@@ -67,7 +67,7 @@ let ann_linkage_opt (m : linkage option) : (typ annotation) option =
 %}
 
 %token<ParseUtil.lexed_id> GLOBAL LOCAL
-%token LPAREN RPAREN LCURLY RCURLY LTLCURLY RCURLYGT LSQUARE RSQUARE LT GT EQ COMMA EOF STAR DOTDOTDOT
+%token LPAREN RPAREN LCURLY RCURLY LTLCURLY RCURLYGT LSQUARE RSQUARE LT GT EQ COMMA EOF STAR COLON DOTDOTDOT
 
 %token<string> STRING
 %token<Camlcoq.Z.t> INTEGER
@@ -255,6 +255,15 @@ let ann_linkage_opt (m : linkage option) : (typ annotation) option =
 (* %token KW_WARN_STACK_SIZE (* quoted "warn-stack-size" *) *)
 %token KW_VSCALE_RANGE
 (* %token KW_MIN_LEGAL_VECTOR_WIDTH (* quoted "min-legal-vector-width" *) *)
+%token KW_MEMORY
+%token KW_READ
+%token KW_WRITE
+%token KW_NONE
+%token KW_READWRITE
+%token KW_ARGMEM
+%token KW_INACCESSIBLEMEM
+%token KW_ERRNOMEM
+
 
 %token KW_DSO_PREEMPTABLE
 %token KW_DSO_LOCAL
@@ -390,6 +399,8 @@ let ann_linkage_opt (m : linkage option) : (typ annotation) option =
 %token KW_ACQ_REL
 %token KW_SEQ_CST
 
+%token<string> KW_UNKNOWN
+
 (* METADATA constants *)
 
 (* for load instructions *)
@@ -401,6 +412,8 @@ let ann_linkage_opt (m : linkage option) : (typ annotation) option =
 %token META_DEREFERENCEABLE_OR_NULL
 %token META_ALIGN
 %token META_NOUNDEF
+
+%token METADATA_DEBUG
 
 %token<LLVMAst.raw_id> METADATA_ID
 %token<string> METADATA_STRING
@@ -432,14 +445,16 @@ toplevel_entity:
    *)
   | i=lident EQ KW_TYPE t=typ           { TLE_Type_decl (ID_Local i, t)  }
   | g=global_decl                       { TLE_Global g                   }
-  | i=METADATA_ID EQ KW_DISTINCT? m=tle_metadata     { TLE_Metadata (i, m)            }
+  | i=METADATA_ID EQ KW_DISTINCT? m=tle_metadata
+                                        { TLE_Metadata (i, m)            }
   | KW_ATTRIBUTES i=ATTR_GRP_ID EQ LCURLY a=fn_attr* RCURLY
                                         { TLE_Attribute_group (i, a)     }
 
 (* metadata are not implemented yet, but are at least (partially) parsed *)
 tle_metadata:
-  | BANGLCURLY m=separated_list(csep, metadata_value) RCURLY
-   { METADATA_Node m }
+  | BANGLCURLY m=separated_list(csep, tconst_or_metadata_value) RCURLY
+    { METADATA_Node m }
+  | METADATA_DEBUG { METADATA_Debug_info_elided }
   | KW_METADATA m=metadata_node
     { m }
 
@@ -456,11 +471,14 @@ metadata_id:
   | mid=METADATA_ID              { METADATA_Id mid }
 
 metadata_node:
-  | BANGLCURLY m=separated_list(csep, metadata_value) RCURLY
+  | BANGLCURLY m=separated_list(csep, tconst_or_metadata_value) RCURLY
     { METADATA_Node m }
 
+tconst_or_metadata_value:
+  | tconst                      { METADATA_Const $1  } 
+  | m=metadata_value            { m } 
+
 metadata_value:
-  | tconst                      { METADATA_Const $1  }
   | KW_NULL                     { METADATA_Null      } (* null with no type *)
   | ms=METADATA_STRING          { METADATA_String (str ms) }
   | mid=METADATA_ID             { METADATA_Id mid     }
@@ -764,6 +782,7 @@ df_arg:
 %inline
 definition:
   | KW_DEFINE
+    (* begin LLParser::parseFunctionHeader from https://github.com/llvm/llvm-project/blob/main/llvm/lib/AsmParser/LLParser.cpp *)
     l = linkage?
     p = preemption_specifier?
     v = visibility?
@@ -789,7 +808,13 @@ definition:
     pre = prefix?
     pro = prologue?
     per = personality?
+    (* end LLParser::parseFunctionHeader *)
+
+    (* begin LLParser::parseOptionalFunctionMetadata *)
     meta = global_metadata
+    (* end LLParser::parseOptionalFunctionMetadata *)
+
+    (* begin LLParser::parseFunctionBody *)
     LCURLY 
     blks=df_blocks
     RCURLY
@@ -951,7 +976,7 @@ block_instrs_and_term:
       ((id_opt, inst)::instrs, t) }
 
 %inline phi:
-  | KW_PHI t=typ table=separated_nonempty_list(csep, phi_table_entry)
+  | KW_PHI t=typ table=comma_path_with_instr_metadata(phi_table_entry)
     { Phi (t, List.map (fun (l,v) -> (l, v t)) table)}
 
 phi_table_entry:
@@ -966,7 +991,7 @@ block:
 
 %inline
 instr_metadata:
-  | COMMA list(metadata_value) { }
+  | COMMA metadata_value+ { }
 
 
 df_blocks:
@@ -1138,7 +1163,24 @@ fn_attr:
   | s=STRING                              { FNATTR_String (str s)   }
   | k=STRING EQ v=STRING                  { FNATTR_Key_value (str k, str v) }
   | i=ATTR_GRP_ID                         { FNATTR_Attr_grp i       }
+  | s=KW_UNKNOWN                          { FNATTR_UNKNOWN (str s)  }
+  | KW_MEMORY LPAREN l=separated_nonempty_list (csep, mem_attr) RPAREN   { FNATTR_Memory l }
 
+mem_attr:
+  | k=mem_access_kind { (LOC_Default, k) }
+  | l=mem_loc COLON k=mem_access_kind { (l, k) }
+
+mem_access_kind:
+  | KW_NONE  { ACC_None }
+  | KW_READ  { ACC_Read }
+  | KW_WRITE { ACC_Write }
+  | KW_READWRITE { ACC_Readwrite }
+
+mem_loc:
+  | KW_DEFAULT         { LOC_Default }
+  | KW_ARGMEM          { LOC_Argmem }
+  | KW_INACCESSIBLEMEM { LOC_Inaccessiblemem }
+  | KW_ERRNOMEM        { LOC_Errnomem }
 
 %inline
 ibinop_nuw_nsw_opt: (* may appear with `nuw`/`nsw` keywords *)
@@ -1192,6 +1234,12 @@ fcmp:
   | KW_UNE   { FUne   }
   | KW_TRUE  { FTrue  }
 
+
+(* TODO:
+- zext and uitofp support the nneg modifier
+- trunc supports the nuw and nsw modifiers
+- fptrunc and fpext support the fastmath flag(s)
+*)
 conversion:
   | KW_TRUNC    { Trunc    }
   | KW_ZEXT     { Zext     }
@@ -1232,51 +1280,53 @@ fast_math:
   | KW_REASSOC { Reassoc }
   | KW_FAST { Fast }
 
+comma_path_with_instr_metadata(X):
+  | COMMA x=X l=comma_path_with_instr_metadata(X)    { x::l }
+  | instr_metadata? { [] }
+
 instr_op:
-  | op=ibinop t=typ o1=exp COMMA o2=exp
+  | op=ibinop t=typ o1=exp COMMA o2=exp instr_metadata?
     { OP_IBinop (op, t, o1 t, o2 t) }
 
-  | KW_ICMP op=icmp t=typ o1=exp COMMA o2=exp
+  | KW_ICMP op=icmp t=typ o1=exp COMMA o2=exp instr_metadata?
     { OP_ICmp (op, t, o1 t, o2 t) }
 
-  | op=fbinop f=fast_math* t=typ o1=exp COMMA o2=exp
+  | op=fbinop f=fast_math* t=typ o1=exp COMMA o2=exp instr_metadata?
     { OP_FBinop (op, f, t, o1 t, o2 t) }
 
     // special case, coerced to fsub
-  | KW_FNEG f=fast_math* t=typ o=exp
+  | KW_FNEG f=fast_math* t=typ o=exp instr_metadata?
      { OP_FBinop (FSub, f, t, EXP_Double Floats.Float32.zero, o t) }
 
-  | KW_FCMP op=fcmp t=typ o1=exp COMMA o2=exp
+  | KW_FCMP op=fcmp t=typ o1=exp COMMA o2=exp instr_metadata?
     { OP_FCmp (op, t, o1 t, o2 t) }
 
-  | c=conversion t1=typ v=exp KW_TO t2=typ
+  | c=conversion t1=typ v=exp KW_TO t2=typ instr_metadata?
     { OP_Conversion (c, t1, v t1, t2) }
 
-  | KW_GETELEMENTPTR KW_INBOUNDS? t=typ COMMA ptr=texp idx=preceded(COMMA, texp)*
+  | KW_GETELEMENTPTR KW_INBOUNDS? t=typ COMMA ptr=texp idx=comma_path_with_instr_metadata(texp)
     { OP_GetElementPtr (t, ptr, idx) }
 
-  | KW_SELECT if_=texp COMMA then_=texp COMMA else_= texp
+  | KW_SELECT if_=texp COMMA then_=texp COMMA else_= texp instr_metadata?
     { OP_Select (if_, then_, else_) }
 
-  | KW_FREEZE v=texp
+  | KW_FREEZE v=texp instr_metadata?
     { OP_Freeze v }
 
-  | KW_EXTRACTELEMENT vec=texp COMMA idx=texp
+  | KW_EXTRACTELEMENT vec=texp COMMA idx=texp instr_metadata?
     { OP_ExtractElement (vec, idx) }
 
-  | KW_INSERTELEMENT vec=texp
-    COMMA new_el=texp COMMA idx=texp
+  | KW_INSERTELEMENT vec=texp 
+    COMMA new_el=texp COMMA idx=texp instr_metadata?
     { OP_InsertElement (vec, new_el, idx)  }
 
-  | KW_EXTRACTVALUE tv=texp COMMA
-    idx=separated_nonempty_list (csep, INTEGER)
+  | KW_EXTRACTVALUE tv=texp idx=comma_path_with_instr_metadata(INTEGER)
     { OP_ExtractValue (tv, idx) }
 
-  | KW_INSERTVALUE agg=texp COMMA new_val=texp COMMA
-    idx=separated_nonempty_list (csep, INTEGER)
+  | KW_INSERTVALUE agg=texp COMMA new_val=texp idx=comma_path_with_instr_metadata(INTEGER)
     { OP_InsertValue (agg, new_val, idx) }
 
-  | KW_SHUFFLEVECTOR v1=texp COMMA v2=texp COMMA mask=texp
+  | KW_SHUFFLEVECTOR v1=texp COMMA v2=texp COMMA mask=texp instr_metadata?
     { OP_ShuffleVector (v1, v2, mask)  }
 
 expr_op:
@@ -1353,7 +1403,7 @@ a_align:
 
 a_addrspace:
   | csep a=addrspace { [a] }
-  | (* empty *) { [] }
+  | instr_metadata? (* empty *) { [] }
 
 alloca_anns:
   anns=a_num_elts { anns }
@@ -1442,7 +1492,7 @@ exp:
   | csep md=global_metadata { md }
 
 %inline instr:
-  | eo=instr_op { INSTR_Op eo }
+  | eo=instr_op  { INSTR_Op eo }
 
   | t=tailcall? KW_CALL fm=list(fast_math) cc=cconv? ra=list(param_attr) addr=addrspace?
     f=call_exp  a=delimited(LPAREN, separated_list(csep, call_arg), RPAREN)

--- a/src/ml/main.ml
+++ b/src/ml/main.ml
@@ -18,6 +18,14 @@ open ShowAST
 
 module DV = InterpretationStack.InterpreterStackBigIntptr.LP.Events.DV
 
+let string_of_function_id id : string =
+  LLVMAst.( match id with
+  | Name n -> "@" ^ (Camlcoq.camlstring_of_coqstring n)
+  | Anon z -> "@" ^ (Camlcoq.Z.to_string z)
+  | Raw z ->  "_RAW_" ^  (Camlcoq.Z.to_string z)
+  )
+
+
 (* test harness
    ------------------------------------------------------------- *)
 exception Ran_tests of bool
@@ -74,7 +82,7 @@ let make_test name ll_ast t : (string * assertion) option =
   let run dtyp entry args ll_ast =
     Interpreter.step
       (TopLevel.TopLevelBigIntptr.interpreter_gen dtyp
-         (Camlcoq.coqstring_of_camlstring entry)
+         entry
          (Monad.ret (Obj.magic ITreeDefinition.coq_Monad_itree) args) ll_ast )
   in
   let run_to_value dtyp entry args ll_ast () : DV.dvalue =
@@ -93,7 +101,7 @@ let make_test name ll_ast t : (string * assertion) option =
             Interpreter.pp_uvalue str_formatter args ;
           flush_str_formatter ()
         in
-        Printf.sprintf "%s = %s(%s)" expected_str entry args_str
+        Printf.sprintf "%s = %s(%s)" expected_str (string_of_function_id entry) args_str
       in
       let result = run_to_value dtyp entry args ll_ast in
       Some (str, dvalue_eq_assertion name result (fun () -> expected))
@@ -113,7 +121,7 @@ let make_test name ll_ast t : (string * assertion) option =
              Interpreter.pp_uvalue str_formatter args ;
            flush_str_formatter ()
          in
-         Printf.sprintf "%s = %s(%s)" expected_str entry args_str
+         Printf.sprintf "%s = %s(%s)" expected_str (string_of_function_id entry) args_str
        in
        let result = run_to_value dtyp entry args ll_ast in
        Some (str, dvalue_eq_assertion name result (fun () -> expected))
@@ -131,8 +139,10 @@ let make_test name ll_ast t : (string * assertion) option =
       let assertion () =
         (* let buf = Buffer.create 16 in List.iter (Buffer.add_char buf)
            (showProg sum_ast); Printf.printf "%s\n" (Buffer.contents buf); *)
-        let res_tgt = run expected_rett tgt_fn_str v_args sum_ast in
-        let res_src = run expected_rett src_fn_str v_args sum_ast in
+        let tgt_fn_id = LLVMAst.Name (Camlcoq.coqstring_of_camlstring tgt_fn_str) in
+        let src_fn_id = LLVMAst.Name (Camlcoq.coqstring_of_camlstring src_fn_str) in      
+        let res_tgt = run expected_rett tgt_fn_id v_args sum_ast in
+        let res_src = run expected_rett src_fn_id v_args sum_ast in
         match res_tgt with
         | Error (UndefinedBehavior _) ->
             () (* If the target is UB then the src can be anything! *)

--- a/src/ml/tester.ml
+++ b/src/ml/tester.ml
@@ -62,10 +62,17 @@ let compare_tgt_for_poison src tgt : (string, unit) Either.t =
            "TargetMorePoisonous: expected tgt to be poison but got %s"
            (string_of_dvalue tgt) )
 
+let string_of_function_id id : string =
+  LLVMAst.( match id with
+  | Name n -> "@" ^ (Camlcoq.camlstring_of_coqstring n)
+  | Anon z -> "@" ^ (Camlcoq.Z.to_string z)
+  | Raw z ->  "_RAW_" ^  (Camlcoq.Z.to_string z)
+  )
+
 let run dtyp entry args ll_ast =
   Interpreter.step
     (TopLevel.TopLevelBigIntptr.interpreter_gen dtyp
-       (Camlcoq.coqstring_of_camlstring entry)
+       entry
        (Monad.ret (Obj.magic ITreeDefinition.coq_Monad_itree) args) ll_ast )
 
 (* This function takes in a name, a got and expected function, and the left
@@ -91,7 +98,7 @@ let eval_POISONTest (name : string) (got : unit -> DV.dvalue)
    src_tgt_error_side * string -> test_result*)
 
 let eval_SRCTGTTest (name : string) (expected_rett : DynamicTypes.dtyp)
-    (tgt_fn_str : string) (src_fn_str : string) (v_args : DV.uvalue list)
+    (tgt_fn_str : LLVMAst.function_id) (src_fn_str : LLVMAst.function_id) (v_args : DV.uvalue list)
     (mode : Assertion.src_tgt_mode) (sum_ast : Result.ast) () : result_sum =
   let res_tgt = run expected_rett tgt_fn_str v_args sum_ast in
   let res_src = run expected_rett src_fn_str v_args sum_ast in
@@ -131,6 +138,7 @@ let eval_SRCTGTTest (name : string) (expected_rett : DynamicTypes.dtyp)
   | Error e ->
       Result.make_singleton (STErr Tgt) name (AST_TEST_ERR (sum_ast, e))
 
+
 let make_test name ll_ast t : string * (unit -> result_sum) =
   let open Format in
   (* TODO: ll_ast is of type list (toplevel_entity typ (block typ * list
@@ -155,7 +163,7 @@ let make_test name ll_ast t : string * (unit -> result_sum) =
           flush_str_formatter ()
         in
         let lhs = expected_str in
-        let rhs = Printf.sprintf "%s(%s)" entry args_str in
+        let rhs = Printf.sprintf "%s(%s)" (string_of_function_id entry) args_str in
         (lhs, rhs)
       in
       let result = run_to_value dtyp entry args ll_ast in
@@ -177,7 +185,7 @@ let make_test name ll_ast t : string * (unit -> result_sum) =
           flush_str_formatter ()
         in
         let lhs = expected_str in
-        let rhs = Printf.sprintf "%s(%s)" entry args_str in
+        let rhs = Printf.sprintf "%s(%s)" (string_of_function_id entry) args_str in
         (lhs, rhs)
       in
       let result = run_to_value dtyp entry args ll_ast in
@@ -201,8 +209,10 @@ let make_test name ll_ast t : string * (unit -> result_sum) =
         in
         Printf.sprintf "src = tgt on generated input (%s)" args_str
       in
+      let tgt_fn_id = LLVMAst.Name (Camlcoq.coqstring_of_camlstring tgt_fn_str) in
+      let src_fn_id = LLVMAst.Name (Camlcoq.coqstring_of_camlstring src_fn_str) in      
       ( str
-      , eval_SRCTGTTest name expected_rett tgt_fn_str src_fn_str v_args mode
+      , eval_SRCTGTTest name expected_rett tgt_fn_id src_fn_id v_args mode
           sum_ast )
 
 let print_stats (rs : result_sum) () : unit =

--- a/src/ml/testing/assertion.ml
+++ b/src/ml/testing/assertion.ml
@@ -61,9 +61,9 @@ let show_src_tgt_mode = function
 
 type test =
   (* expected dvalue, dynamic type, entry, arguments *)
-  | EQTest of DV.dvalue * DynamicTypes.dtyp * string * DV.uvalue list
+  | EQTest of DV.dvalue * DynamicTypes.dtyp * function_id * DV.uvalue list
   (* dynamic type, entry, arguments *)
-  | POISONTest of DynamicTypes.dtyp * string * DV.uvalue list
+  | POISONTest of DynamicTypes.dtyp * function_id * DV.uvalue list
   (* Find a better name for this *)
   (* retty, args for src, (t, args) for arguments to source and test *)
   (* Source target mode, dynamic type, Left is arguments and right is AST*)
@@ -164,27 +164,23 @@ let rec texp_to_uvalue ((typ, exp) : LLVMAst.typ * LLVMAst.typ LLVMAst.exp) :
         (Printf.sprintf "Assertion includes unsupported expression:\n\t%s %s"
            (string_of_typ typ) (string_of_exp exp) )
 
-let texp_to_function_name (_, exp) : string =
+let texp_to_function_id (_, exp) : function_id =
   match exp with
-  | EXP_Ident (ID_Global (Name x)) -> Camlcoq.camlstring_of_coqstring x
+  | EXP_Ident (ID_Global id) -> id
   | _ -> failwith "found non-function name"
 
 (* | INSTR_Call of 't texp * 't texp list *)
 let instr_to_call_data instr =
   match instr with
   | INSTR_Call (fn, args, _) ->
-      ( texp_to_function_name fn
+      ( texp_to_function_id fn
       , List.map (fun x -> texp_to_uvalue (fst x)) args )
   | _ ->
       failwith "Assertion includes unsupported instruction (must be a call)"
 
-let texp_to_name_retty (texp : LLVMAst.typ texp) : DynamicTypes.dtyp * string
-    =
-  let t, exp = texp in
-  match exp with
-  | EXP_Ident (ID_Global (Name x)) ->
-      (typ_to_dtyp t, Camlcoq.camlstring_of_coqstring x)
-  | _ -> failwith "found non-function name"
+let texp_to_name_retty (texp : LLVMAst.typ texp) : DynamicTypes.dtyp * function_id =
+  let t, _ = texp in
+  (typ_to_dtyp t, texp_to_function_id texp)
 
 let instr_to_call_data' instr =
   match instr with

--- a/src/rocq/QC/ReprAST.v
+++ b/src/rocq/QC/ReprAST.v
@@ -440,6 +440,31 @@ Section ReprInstances.
    Instance reprCconv : Repr cconv :=
     {| repr := repr_cconv |}.
 
+  Definition repr_mem_loc loc : string :=
+    match loc with
+    | LOC_Default => "LOC_Default"
+    | LOC_Argmem => "LOC_Armem"
+    | LOC_Inaccessiblemem  => "LOC_Inaccessiblemem"
+    | LOC_Errnomem => "LOC_Errnomem"
+    end.
+
+  #[global]
+    Instance reprMemLoc : Repr mem_loc :=
+    {| repr := repr_mem_loc |}.
+
+  Definition repr_mem_access_kind k : string :=
+    match k with
+    | ACC_None => "ACC_None"
+    | ACC_Read => "ACC_Read"
+    | ACC_Write => "ACC_Write"
+    | ACC_Readwrite => "ACC_Readwrite"
+    end.
+
+  #[global]
+    Instance reprMemAccessKind : Repr mem_access_kind :=
+    {| repr := repr_mem_access_kind |}.
+
+  
   Definition repr_fn_attr (fa : fn_attr) : string :=
     match fa with
     | FNATTR_Alignstack a => "(FNATTR_Alignstack " ++ repr a ++ ")"
@@ -540,6 +565,8 @@ Section ReprInstances.
     | FNATTR_String s => "(FNATTR_String " ++ repr s ++ ")"
     | FNATTR_Key_value kv => "(FNATTR_Key_value " ++ repr kv ++ ")"
     | FNATTR_Attr_grp g => "(FNATTR_Attr_grp " ++ repr g ++ ")"
+    | FNATTR_Memory l => "(FNATTR_Memory " ++ repr l ++ ")"
+    | FNATTR_UNKNOWN s => "(FNATTR_UNKNOWN " ++ repr s ++ ")"
     end.
 
   #[global]
@@ -574,6 +601,7 @@ Section ReprInstances.
     | METADATA_String str => "(METADATA_String " ++ repr str ++ ")"
     | METADATA_Named strs => "(METADATA_Named " ++ repr strs ++ ")"
     | METADATA_Node mds => "(METADATA_Node [" ++ (contents id (List.map repr_metadata mds)) ++ "])"
+    | METADATA_Debug_info_elided => "METADATA_Debug_info_elided"
     end.
 
   #[global]

--- a/src/rocq/QC/ShowAST.v
+++ b/src/rocq/QC/ShowAST.v
@@ -899,7 +899,7 @@ Section ShowInstances.
     | METADATA_Node mds => string_to_DString "!{"
                             @@ concat_DString (string_to_DString " , ") (map dshow_metadata mds)
                             @@ string_to_DString "}"
-    | METADATA_Debug_info_elided => string_to_DString "!DI(debug info elided)"
+    | METADATA_Debug_info_elided => string_to_DString "!{!""debug info elided""}"
     end.
 
   #[global] Instance dshowMetadata (md : metadata T) : DShow (metadata T) :=

--- a/src/rocq/QC/ShowAST.v
+++ b/src/rocq/QC/ShowAST.v
@@ -30,6 +30,14 @@ Fixpoint concatStr (l : list string) : string :=
   | nil => ""
   | (h :: t) => h ++ concatStr t
   end.
+
+Fixpoint concat_str_sep (sep:string) (l : list string) : string :=
+  match l with
+  | nil => ""
+  | (h::nil) => h          
+  | (h :: t) => h ++ sep ++ (concat_str_sep sep t)
+  end.
+
 (*  ------------------------------------------------------------------------- *)
 
 #[global] Instance Show_Pos : Show positive.
@@ -253,6 +261,20 @@ Section ShowInstances.
   #[global] Instance dshowParamAttr : DShow param_attr
     := { dshow := show_param_attr }.
 
+  Definition show_eff '(loc, k) :=
+    match loc with
+    | LOC_Default => ""
+    | LOC_Argmem => "argmem: "
+    | LOC_Inaccessiblemem  => "inaccessiblemem: "
+    | LOC_Errnomem => "errnomem: "
+    end ++
+    match k with
+    | ACC_None => "none"
+    | ACC_Read => "read"
+    | ACC_Write => "write"
+    | ACC_Readwrite => "readwrite"
+    end.
+  
   Definition show_fn_attr (f : fn_attr) : string :=
     match f with
     | FNATTR_Alignstack a => "alignstack(" ++ show a ++ ")"
@@ -344,6 +366,8 @@ Section ShowInstances.
     | FNATTR_String s => """" ++ s ++ """"  (* "no-see" *)
     | FNATTR_Key_value kv => """" ++ fst kv ++ """=" ++ """" ++ snd kv ++ """" (* "unsafe-fp-math"="false" *)
     | FNATTR_Attr_grp g => "#" ++ show g
+    | FNATTR_Memory l => "memory(" ++ concat_str_sep ", " (map show_eff l ) ++ ")"
+    | FNATTR_UNKNOWN s => s
     end.
 
   #[global] Instance showFnAttr : Show fn_attr
@@ -875,6 +899,7 @@ Section ShowInstances.
     | METADATA_Node mds => string_to_DString "!{"
                             @@ concat_DString (string_to_DString " , ") (map dshow_metadata mds)
                             @@ string_to_DString "}"
+    | METADATA_Debug_info_elided => string_to_DString "!DI(debug info elided)"
     end.
 
   #[global] Instance dshowMetadata (md : metadata T) : DShow (metadata T) :=

--- a/src/rocq/Semantics/InfiniteToFinite/LangRefine.v
+++ b/src/rocq/Semantics/InfiniteToFinite/LangRefine.v
@@ -2331,8 +2331,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
   Definition model_E1E2_L0_orutt_strict args1 args2 p1 p2 :=
     L0_E1E2_orutt_strict
-      (LLVM1.denote_vellvm (DTYPE_I 32%positive) "main" args1 (convert_types (mcfg_of_tle p1)))
-      (LLVM2.denote_vellvm (DTYPE_I 32%positive) "main" args2 (convert_types (mcfg_of_tle p2))).
+      (LLVM1.denote_vellvm (DTYPE_I 32%positive) (LLVMAst.Name "main") args1 (convert_types (mcfg_of_tle p1)))
+      (LLVM2.denote_vellvm (DTYPE_I 32%positive) (LLVMAst.Name "main") args2 (convert_types (mcfg_of_tle p2))).
 
   Definition model_E1E2_L1_orutt_strict args1 args2 p1 p2 :=
     L1_E1E2_orutt_strict

--- a/src/rocq/Semantics/TopLevel.v
+++ b/src/rocq/Semantics/TopLevel.v
@@ -526,13 +526,13 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
      *)
   Definition denote_vellvm
              (ret_typ : dtyp)
-             (entry : string)
+             (entry : function_id)
              (args : list uvalue)
              (mcfg : CFG.mcfg dtyp) : itree L0 dvalue :=
     build_global_environment mcfg ;;
     'defns <- map_monad address_one_function (m_definitions mcfg) ;;
     'builtins <- map_monad address_one_builtin_function (built_in_functions (m_declarations mcfg));;
-    'addr <- trigger (GlobalRead (Name entry)) ;;
+    'addr <- trigger (GlobalRead entry) ;;
     'rv <- denote_mcfg (IP.of_list (defns ++ builtins)) ret_typ (dvalue_to_uvalue addr) args;;
     match rv with
     | inl exc => raiseLLVM exc
@@ -565,7 +565,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
    *)
   Definition interpreter_gen
     (ret_typ : dtyp)
-    (entry : string)
+    (entry : function_id)
     (arg_gen : itree L0 (list uvalue))
     (prog: ll_toplevel_entities)
     : itree L4 res_L4 :=
@@ -584,7 +584,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
              (prog : ll_toplevel_entities)
               : itree L4 res_L4
     :=
-    interpreter_gen (DTYPE_I 32%positive) "main" (build_main_args args) prog.
+    interpreter_gen (DTYPE_I 32%positive) (Name "main") (build_main_args args) prog.
 
   (**
      We now turn to the definition of our _model_ of vellvm's semantics. The
@@ -599,7 +599,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
    *)
   Definition model_gen
              (ret_typ : dtyp)
-             (entry : string)
+             (entry : function_id)
              (arg_gen : itree L0 (list uvalue))
              (prog: ll_toplevel_entities)
     : PropT L4 res_L4 :=
@@ -611,7 +611,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
 
   Definition model_gen_oom
              (ret_typ : dtyp)
-             (entry : string)
+             (entry : function_id)
              (arg_gen : itree L0 (list uvalue))
              (prog: ll_toplevel_entities)
     : PropT L4 res_L4 :=
@@ -623,7 +623,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
 
   Definition model_gen_oom_L1
              (ret_typ : dtyp)
-             (entry : string)
+             (entry : function_id)
              (arg_gen : itree L0 (list uvalue))
              (prog: ll_toplevel_entities)
     : itree L1 res_L1 :=
@@ -635,7 +635,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
 
   Definition model_gen_oom_L2
              (ret_typ : dtyp)
-             (entry : string)
+             (entry : function_id)
              (arg_gen : itree L0 (list uvalue))
              (prog: ll_toplevel_entities)
     : itree L2 res_L2 :=
@@ -648,7 +648,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   Definition model_gen_oom_L3
     (RR : relation res_L2)
     (ret_typ : dtyp)
-    (entry : string)
+    (entry : function_id)
     (arg_gen : itree L0 (list uvalue))
     (prog: ll_toplevel_entities)
     : PropT L3 res_L3 :=
@@ -662,7 +662,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
     RR_mem
     RR_pick
     (ret_typ : dtyp)
-    (entry : string)
+    (entry : function_id)
     (arg_gen : itree L0 (list uvalue))
     (prog: ll_toplevel_entities)
     : PropT L4 res_L4 :=
@@ -676,7 +676,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
     RR_mem
     RR_pick
     (ret_typ : dtyp)
-    (entry : string)
+    (entry : function_id)
     (arg_gen : itree L0 (list uvalue))
     (prog: ll_toplevel_entities)
     : PropT L5 res_L5 :=
@@ -691,7 +691,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
     RR_pick
     RR_oom
     (ret_typ : dtyp)
-    (entry : string)
+    (entry : function_id)
     (arg_gen : itree L0 (list uvalue))
     (prog: ll_toplevel_entities)
     : PropT L6 res_L6 :=
@@ -704,14 +704,14 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   (**
      Finally, the official model assumes no user-defined intrinsics.
    *)
-  Definition model args := model_gen (DTYPE_I 32%positive) "main" (build_main_args args).
-  Definition model_oom args := model_gen_oom (DTYPE_I 32%positive) "main" (build_main_args args).
-  Definition model_oom_L1 args := model_gen_oom_L1 (DTYPE_I 32%positive) "main" (build_main_args args).
-  Definition model_oom_L2 args := model_gen_oom_L2 (DTYPE_I 32%positive) "main" (build_main_args args).
-  Definition model_oom_L3 RR_mem args := model_gen_oom_L3 RR_mem (DTYPE_I 32%positive) "main" (build_main_args args).
-  Definition model_oom_L4 RR_mem RR_pick args := model_gen_oom_L4 RR_mem RR_pick (DTYPE_I 32%positive) "main" (build_main_args args).
-  Definition model_oom_L5 RR_mem RR_pick args := model_gen_oom_L5 RR_mem RR_pick (DTYPE_I 32%positive) "main" (build_main_args args).
-  Definition model_oom_L6 RR_mem RR_pick RR_oom args := model_gen_oom_L6 RR_mem RR_pick RR_oom (DTYPE_I 32%positive) "main" (build_main_args args).
+  Definition model args := model_gen (DTYPE_I 32%positive) (Name "main") (build_main_args args).
+  Definition model_oom args := model_gen_oom (DTYPE_I 32%positive) (Name "main") (build_main_args args).
+  Definition model_oom_L1 args := model_gen_oom_L1 (DTYPE_I 32%positive) (Name "main") (build_main_args args).
+  Definition model_oom_L2 args := model_gen_oom_L2 (DTYPE_I 32%positive) (Name "main") (build_main_args args).
+  Definition model_oom_L3 RR_mem args := model_gen_oom_L3 RR_mem (DTYPE_I 32%positive) (Name "main") (build_main_args args).
+  Definition model_oom_L4 RR_mem RR_pick args := model_gen_oom_L4 RR_mem RR_pick (DTYPE_I 32%positive) (Name "main") (build_main_args args).
+  Definition model_oom_L5 RR_mem RR_pick args := model_gen_oom_L5 RR_mem RR_pick (DTYPE_I 32%positive) (Name "main") (build_main_args args).
+  Definition model_oom_L6 RR_mem RR_pick RR_oom args := model_gen_oom_L6 RR_mem RR_pick RR_oom (DTYPE_I 32%positive) (Name "main") (build_main_args args).
 End LLVMTopLevel.
 
 Module Make (IS : InterpreterStack) : LLVMTopLevel IS.

--- a/src/rocq/Syntax/LLVMAst.v
+++ b/src/rocq/Syntax/LLVMAst.v
@@ -163,6 +163,20 @@ Variant frame_pointer_val : Set :=
 | FRAMEPTR_All
 .
 
+Variant mem_loc : Set :=
+| LOC_Default
+| LOC_Argmem
+| LOC_Inaccessiblemem
+| LOC_Errnomem
+.
+
+Variant mem_access_kind : Set :=
+| ACC_None
+| ACC_Read      
+| ACC_Write
+| ACC_Readwrite
+.
+    
 Variant fn_attr : Set :=
 | FNATTR_Alignstack (a:int_ast)
 (* | FNATTR_Alloc_family (fam : string) - FNATTR_KeyValue *)
@@ -242,6 +256,9 @@ Variant fn_attr : Set :=
 | FNATTR_String (s:string)   (* See the comments above for cases covered by FNATTR_String *)
 | FNATTR_Key_value (kv : string * string) (* See the comments above for cases covered by FNATTR_KeyValue *)
 | FNATTR_Attr_grp (g:int_ast)
+(* This memory attribute is just a syntactic representation of the constraints. *)                    
+| FNATTR_Memory (effs: list (mem_loc * mem_access_kind))
+| FNATTR_UNKNOWN (s:string)
 .
 
 Variant thread_local_storage : Set :=
@@ -387,6 +404,7 @@ Inductive metadata : Set :=
 | METADATA_String (str:string)
 | METADATA_Named  (strs:list string)
 | METADATA_Node   (mds:list metadata)
+| METADATA_Debug_info_elided  (* represents a !DI.(_) metadata node *)
 .
 
 

--- a/src/rocq/Syntax/Traversal.v
+++ b/src/rocq/Syntax/Traversal.v
@@ -181,6 +181,7 @@ Section Endo.
         | METADATA_String str => METADATA_String (endo str)
         | METADATA_Named strs => METADATA_Named (endo strs)
         | METADATA_Node mds => METADATA_Node (List.map endo_metadata mds)
+        | METADATA_Debug_info_elided => METADATA_Debug_info_elided
         end.
 
     #[global] Instance Endo_tint_literal
@@ -658,6 +659,7 @@ Section TFunctor.
         | METADATA_String str => METADATA_String (endo str)
         | METADATA_Named strs => METADATA_Named (endo strs)
         | METADATA_Node mds => METADATA_Node (tfmap endo_metadata mds)
+        | METADATA_Debug_info_elided => METADATA_Debug_info_elided
         end.
 
 

--- a/src/rocq/Theory/TopLevelRefinements.v
+++ b/src/rocq/Theory/TopLevelRefinements.v
@@ -222,7 +222,7 @@ Module Type TopLevelRefinements (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
     Hint Resolve refine_12 refine_23 refine_34 refine_45 refine_56 : refine_xx.
 
     Variable ret_typ : dtyp.
-    Variable entry : string.
+    Variable entry : function_id.
     Variable args : list uvalue.
 
     Definition denote_vellvm_init := denote_vellvm ret_typ entry args.

--- a/src/rocq/Transformations/EquivExpr.v
+++ b/src/rocq/Transformations/EquivExpr.v
@@ -70,6 +70,7 @@ Module Type EquivExpr (IS : InterpreterStack) (TOP : LLVMTopLevel IS) (DT : Deno
     Hypothesis IH_METADATA_Id    : forall id, P (METADATA_Id id).
     Hypothesis IH_METADATA_String : forall str, P (METADATA_String str).
     Hypothesis IH_METADATA_Named : forall strs, P (METADATA_Named strs).
+    Hypothesis IH_METADATA_Debug_info_elided : P (METADATA_Debug_info_elided).
     Hypothesis IH_METADATA_Node : forall (mds : list (metadata T)),
         (forall md, In md mds -> P md) ->
         P (METADATA_Node mds).

--- a/tests/parsing/metadatatests.ll
+++ b/tests/parsing/metadatatests.ll
@@ -1,0 +1,9 @@
+define i32 @square(i32 %num) unnamed_addr #0 !dbg !1 {
+start:
+  %num.dbg.spill = alloca [4 x i8], align 4, !dbg !1
+  ret i32 4
+}
+
+
+!1 = !DILocation(line: 11, column: 5, scope: !7)
+!7 = !{}

--- a/tests/parsing/rustc-genererated1.ll
+++ b/tests/parsing/rustc-genererated1.ll
@@ -1,0 +1,63 @@
+; ModuleID = 'example.81b56bf8d265fdf5-cgu.0'
+source_filename = "example.81b56bf8d265fdf5-cgu.0"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@alloc_9be5c135c0f7c91e35e471f025924b11 = private unnamed_addr constant [15 x i8] c"/app/example.rs", align 1
+@alloc_da5cf958710295b96b156e93b9bd4d46 = private unnamed_addr constant <{ ptr, [16 x i8] }> <{ ptr @alloc_9be5c135c0f7c91e35e471f025924b11, [16 x i8] c"\0F\00\00\00\00\00\00\00\0B\00\00\00\05\00\00\00" }>, align 8
+
+; Function Attrs: nonlazybind uwtable
+define i32 @square(i32 %num) unnamed_addr #0 !dbg !7 {
+start:
+  %num.dbg.spill = alloca [4 x i8], align 4
+  store i32 %num, ptr %num.dbg.spill, align 4
+    #dbg_declare(ptr %num.dbg.spill, !14, !DIExpression(), !16)
+  %0 = call { i32, i1 } @llvm.smul.with.overflow.i32(i32 %num, i32 %num), !dbg !17
+  %_2.0 = extractvalue { i32, i1 } %0, 0, !dbg !17
+  %_2.1 = extractvalue { i32, i1 } %0, 1, !dbg !17
+  br i1 %_2.1, label %panic, label %bb1, !dbg !17
+
+bb1:                                              ; preds = %start
+  ret i32 %_2.0, !dbg !18
+
+panic:                                            ; preds = %start
+; call core::panicking::panic_const::panic_const_mul_overflow
+  call void @core::panicking::panic_const::panic_const_mul_overflow::h0c89a1ab8bb38613(ptr align 8 @alloc_da5cf958710295b96b156e93b9bd4d46) #3, !dbg !17
+  unreachable, !dbg !17
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare { i32, i1 } @llvm.smul.with.overflow.i32(i32, i32) #1
+
+; core::panicking::panic_const::panic_const_mul_overflow
+; Function Attrs: cold noinline noreturn nonlazybind uwtable
+declare void @core::panicking::panic_const::panic_const_mul_overflow::h0c89a1ab8bb38613(ptr align 8) unnamed_addr #2
+
+attributes #0 = { nonlazybind uwtable "probe-stack"="inline-asm" "target-cpu"="x86-64" }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { cold noinline noreturn nonlazybind uwtable "probe-stack"="inline-asm" "target-cpu"="x86-64" }
+attributes #3 = { noreturn }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+!llvm.dbg.cu = !{!5}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 2, !"RtLibUseGOT", i32 1}
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{!"rustc version 1.88.0 (6b00bc388 2025-06-23)"}
+!5 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !6, producer: "clang LLVM (rustc version 1.88.0 (6b00bc388 2025-06-23))", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!6 = !DIFile(filename: "/app/example.rs/@/example.81b56bf8d265fdf5-cgu.0", directory: "/app")
+!7 = distinct !DISubprogram(name: "square", scope: !9, file: !8, line: 10, type: !10, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !5, templateParams: !15, retainedNodes: !13)
+!8 = !DIFile(filename: "example.rs", directory: "/app", checksumkind: CSK_MD5, checksum: "ceda14a2d889d95f49e3fe2ba48e9536")
+!9 = !DINamespace(name: "example", scope: null)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12, !12}
+!12 = !DIBasicType(name: "i32", size: 32, encoding: DW_ATE_signed)
+!13 = !{!14}
+!14 = !DILocalVariable(name: "num", arg: 1, scope: !7, file: !8, line: 10, type: !12)
+!15 = !{}
+!16 = !DILocation(line: 10, column: 15, scope: !7)
+!17 = !DILocation(line: 11, column: 5, scope: !7)
+!18 = !DILocation(line: 12, column: 2, scope: !7)


### PR DESCRIPTION
Working toward supporting rustc-generated LLVM IR code "out of the box".  This extends the frontend with better handling for metadata generated by rustc.  This just ignores the contents of metadata nodes for the various `!DI????` tags.  

We might want to do a bit more testing before merging with the dev branch.