### PR TITLE
implement cmpxchg for sequential memory

### DIFF
--- a/src/ml/libvellvm/llvm_lexer.mll
+++ b/src/ml/libvellvm/llvm_lexer.mll
@@ -344,6 +344,22 @@
   ("acq_rel"        , KW_ACQ_REL);
   ("seq_cst"        , KW_SEQ_CST);
 
+  (* atomicrmw ops *)
+  ("max"      	    , KW_MAX);
+  ("min"	    , KW_MIN);
+  ("xchg"           , KW_XCHG);
+  ("fmax"           , KW_FMAX);
+  ("fmin"	    , KW_FMIN);
+  ("umin"	    , KW_UMIN);
+  ("umax"	    , KW_UMAX);
+  ("nand"	    , KW_NAND);
+  ("fmaximum"	    , KW_FMAXIMUM);
+  ("fminimum"	    , KW_FMINIMUM); 
+  ("uinc_wrap"	    , KW_UINC_WRAP);
+  ("udec_wrap"	    , KW_UDEC_WRAP);
+  ("usub_cond"	    , KW_USUB_COND);
+  ("usub_sat"	    , KW_USUB_SAT);
+
   (*types*)
   ("iptr"      , KW_IPTR);
   ("ptr"       , KW_PTR);

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -435,6 +435,122 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
   Definition catch_llvm_exc_L0' : itree L0' ~> eitherT uvalue (itree L0')
       := interp_either catch_llvm_exc_L0'_h.
 
+  Definition denote_cmpxchg id cpx : itree instr_E unit :=
+    (* SAZ: This will have to be revisited when we have a truly concurrent semantics. *)
+    let '(ptr_ty, ptr_val) := cpx.(c_ptr) in
+    let '(cmp_ty, cmp_val) := cpx.(c_cmp) in
+    let '(new_ty, new_val) := cpx.(c_new) in
+
+    (* Check whether the comparison types agree.  LLVM IR requires them to be integer
+           or pointer types (otherwise the IR is not well formed).  Vellvm checks that
+           the types are the same, but doesn't check their specific type.
+     *)
+    if (dtyp_eq_dec cmp_ty new_ty) then
+      
+      (* evaluate the arguments to the instruction *)
+      ptr_uv <- translate exp_to_instr (denote_exp (Some ptr_ty) ptr_val) ;;
+      cmp_uv <- translate exp_to_instr (denote_exp' (Some cmp_ty) cmp_val) ;;
+      new_uv <- translate exp_to_instr (denote_exp' (Some cmp_ty) new_val) ;;
+      
+      (* Perform the load - load addresses must be unique *)
+      ptr_dv <- concretize_or_pick_unique ptr_uv;;
+      loaded_uv <- trigger (Load cmp_ty ptr_dv);;
+
+      (* Perform the comparison - again we have to concretize the results *)
+      dv <- concretize_or_pick_unique (UVALUE_ICmp Eq loaded_uv cmp_uv);;
+      match dv with
+      | @DVALUE_I 1 comparison_bit =>
+          if equ comparison_bit one then
+            
+            (* They compared as equal: perform the write to memory *)
+            trigger (Store cmp_ty ptr_dv new_uv) ;;
+            (* return a struct with the loaded value and "true" *)
+            let ret_uv := UVALUE_Struct [loaded_uv; @UVALUE_I 1 one] in
+            trigger (LocalWrite id ret_uv);;
+            ret tt
+          else
+            (* They compared as distinct: do not perform the write to memory *)
+            (* return a struct with the loaded value and "false" *)                
+            let ret_uv := UVALUE_Struct [loaded_uv; @UVALUE_I 1 zero] in
+            trigger (LocalWrite id ret_uv);;
+            ret tt
+      | DVALUE_Poison dt => raiseUB "comparing poison in atomiccmpxchg."
+      | _ => raise "Br got non-bool value"
+      end
+    else 
+      raise "Ill-typed atomiccmpxchg".
+
+
+  (* Implement the atomic modify operations in terms of Vellvm uvalues.
+     Note: Langref doesn' seem to specifiy whether the arithmetic operations should be treated
+           as having (or not) the signed/wrapping flags activated.  Here we (arbitrarily?)
+           set them to false.
+  *)
+  Definition denote_atomic_rmw_operation a_op (pv : uvalue) (val : uvalue) : itree instr_E uvalue :=
+    match a_op with      
+    | Axchg =>
+        (* xchg: *ptr = val *)
+        ret val   
+    | Aadd =>
+        (* add: *ptr = *ptr + val *)
+        ret (UVALUE_IBinop (Add false false) pv val)
+    | Asub =>
+        (* sub: *ptr = *ptr - val *)
+        ret (UVALUE_IBinop (Sub false false) pv val)
+    | Aand =>
+        (* and: *ptr = *ptr - val *)
+        ret (UVALUE_IBinop And pv val)
+    | Aor =>
+        (* or: *ptr = *ptr | val *)
+        ret (UVALUE_IBinop Or pv val)
+    | Axor =>
+        (* xor: *ptr = *ptr ^ val *)
+        ret (UVALUE_IBinop Xor pv val)
+    | Afadd =>
+        (* fadd: *ptr = *ptr + val (using floating point arithmetic) *)
+        ret (UVALUE_FBinop FAdd [] pv val)
+    | Afsub =>
+        (* fsub: *ptr = *ptr - val (using floating point arithmetic) *)
+        ret (UVALUE_FBinop FSub [] pv val)
+    | Amax
+    | Amin
+    | Aumax
+    | Aumin
+    | Afmax
+    | Afmin
+    | Anand
+    | Afmaximum
+    | Afminimum
+    | Auinc_wrap
+    | Audec_wrap
+    | Ausub_cond
+    | Ausub_sat => raise "Unsupported atomicrwm operation"
+    end.
+    
+  
+  Definition denote_atomicrmw id armw : itree instr_E unit :=
+    let '(ptr_ty, ptr_val) := armw.(a_ptr) in
+    let '(a_ty, a_val) := armw.(a_val) in
+    let a_op := armw.(a_operation) in
+
+    (* evaluate the arguments to the instruction *)
+    ptr_uv <- translate exp_to_instr (denote_exp (Some ptr_ty) ptr_val) ;;
+    a_uv <- translate exp_to_instr (denote_exp' (Some a_ty) a_val) ;;
+    
+    (* Perform the load - load addresses must be unique *)
+    ptr_dv <- concretize_or_pick_unique ptr_uv;;
+    loaded_uv <- trigger (Load a_ty ptr_dv);;
+
+    stored_uv <- denote_atomic_rmw_operation a_op loaded_uv a_uv ;;
+
+    (* Perform the store *)
+    trigger (Store a_ty ptr_dv stored_uv) ;;
+    
+    (* The result is the original value loaded from ptr before the modification *)
+    trigger (LocalWrite id loaded_uv);;
+    ret tt.
+
+  
   (* An instruction has only side-effects, it therefore returns [unit] *)
   Definition denote_instr
     (i: (instr_id * instr dtyp * list (metadata dtyp))) (varargs : option ADDR.addr) : itree instr_E unit :=
@@ -576,60 +692,18 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
         | IId id  => trigger (LocalWrite id retv);;
                      ret tt
         end
-
           
     | (IId id, INSTR_AtomicCmpXchg cpx) =>
-        (* SAZ: This will have to be revisited when we have a truly concurrent semantics. *)
-        let '(ptr_ty, ptr_val) := cpx.(c_ptr) in
-        let '(cmp_ty, cmp_val) := cpx.(c_cmp) in
-        let '(new_ty, new_val) := cpx.(c_new) in
+        denote_cmpxchg id cpx
 
-        (* Check whether the comparison types agree.  LLVM IR requires them to be integer
-           or pointer types (otherwise the IR is not well formed).  Vellvm checks that
-           the types are the same, but doesn't check their specific type.
-         *)
-        if (dtyp_eq_dec cmp_ty new_ty) then
-          
-          (* evaluate the arguments to the instruction *)
-          ptr_uv <- translate exp_to_instr (denote_exp (Some ptr_ty) ptr_val) ;;
-          cmp_uv <- translate exp_to_instr (denote_exp' (Some cmp_ty) cmp_val) ;;
-          new_uv <- translate exp_to_instr (denote_exp' (Some cmp_ty) new_val) ;;
-          
-          (* Perform the load - load addresses must be unique *)
-          ptr_dv <- concretize_or_pick_unique ptr_uv;;
-          loaded_uv <- trigger (Load cmp_ty ptr_dv);;
-
-          (* Perform the comparison - again we have to concretize the results *)
-          dv <- concretize_or_pick_unique (UVALUE_ICmp Eq loaded_uv cmp_uv);;
-          match dv with
-          | @DVALUE_I 1 comparison_bit =>
-              if equ comparison_bit one then
-                
-                (* They compared as equal: perform the write to memory *)
-                trigger (Store cmp_ty ptr_dv new_uv) ;;
-                (* return a struct with the loaded value and "true" *)
-                let ret_uv := UVALUE_Struct [loaded_uv; @UVALUE_I 1 one] in
-                trigger (LocalWrite id ret_uv);;
-                ret tt
-              else
-                (* They compared as distinct: do not perform the write to memory *)
-                (* return a struct with the loaded value and "false" *)                
-                let ret_uv := UVALUE_Struct [loaded_uv; @UVALUE_I 1 zero] in
-                trigger (LocalWrite id ret_uv);;
-                ret tt
-          | DVALUE_Poison dt => raiseUB "comparing poison in atomiccmpxchg."
-          | _ => raise "Br got non-bool value"
-          end
-        else 
-          raise "Ill-typed atomiccmpxchg"
-
+    | (IId id, INSTR_AtomicRMW armw) =>
+        denote_atomicrmw id armw
+                       
     (* Currently unhandled itree instructions *)
-    | (_, INSTR_LandingPad _ _ _) => raise "todo landingpad"
-    | (_, INSTR_Fence _ _)
-    | (_, INSTR_AtomicRMW _) => raise "Unsupported VIR instruction"
-
+    | (_, INSTR_LandingPad _ _ _) => raise "Unsupported INSTR_Landingpad"
+    | (_, INSTR_Fence _ _) => raise "Unsupported INSTR_Fence"
     (* Error states *)
-    | (_, _) => raise "ID / Instr mismatch void/non-void"
+    | (_, _) => raise "ID / Instr mismatch void / non-void"
     end.
 
   (* Computes the label to be returned by a switch terminator, after evaluation of values

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -576,10 +576,56 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
         | IId id  => trigger (LocalWrite id retv);;
                      ret tt
         end
-    | (_, INSTR_LandingPad _ _ _) => raise "todo landingpad"
+
+          
+    | (IId id, INSTR_AtomicCmpXchg cpx) =>
+        (* SAZ: This will have to be revisited when we have a truly concurrent semantics. *)
+        let '(ptr_ty, ptr_val) := cpx.(c_ptr) in
+        let '(cmp_ty, cmp_val) := cpx.(c_cmp) in
+        let '(new_ty, new_val) := cpx.(c_new) in
+
+        (* Check whether the comparison types agree.  LLVM IR requires them to be integer
+           or pointer types (otherwise the IR is not well formed).  Vellvm checks that
+           the types are the same, but doesn't check their specific type.
+         *)
+        if (dtyp_eq_dec cmp_ty new_ty) then
+          
+          (* evaluate the arguments to the instruction *)
+          ptr_uv <- translate exp_to_instr (denote_exp (Some ptr_ty) ptr_val) ;;
+          cmp_uv <- translate exp_to_instr (denote_exp' (Some cmp_ty) cmp_val) ;;
+          new_uv <- translate exp_to_instr (denote_exp' (Some cmp_ty) new_val) ;;
+          
+          (* Perform the load - load addresses must be unique *)
+          ptr_dv <- concretize_or_pick_unique ptr_uv;;
+          loaded_uv <- trigger (Load cmp_ty ptr_dv);;
+
+          (* Perform the comparison - again we have to concretize the results *)
+          dv <- concretize_or_pick_unique (UVALUE_ICmp Eq loaded_uv cmp_uv);;
+          match dv with
+          | @DVALUE_I 1 comparison_bit =>
+              if equ comparison_bit one then
+                
+                (* They compared as equal: perform the write to memory *)
+                trigger (Store cmp_ty ptr_dv new_uv) ;;
+                (* return a struct with the loaded value and "true" *)
+                let ret_uv := UVALUE_Struct [loaded_uv; @UVALUE_I 1 one] in
+                trigger (LocalWrite id ret_uv);;
+                ret tt
+              else
+                (* They compared as distinct: do not perform the write to memory *)
+                (* return a struct with the loaded value and "false" *)                
+                let ret_uv := UVALUE_Struct [loaded_uv; @UVALUE_I 1 zero] in
+                trigger (LocalWrite id ret_uv);;
+                ret tt
+          | DVALUE_Poison dt => raiseUB "comparing poison in atomiccmpxchg."
+          | _ => raise "Br got non-bool value"
+          end
+        else 
+          raise "Ill-typed atomiccmpxchg"
+
     (* Currently unhandled itree instructions *)
+    | (_, INSTR_LandingPad _ _ _) => raise "todo landingpad"
     | (_, INSTR_Fence _ _)
-    | (_, INSTR_AtomicCmpXchg _)
     | (_, INSTR_AtomicRMW _) => raise "Unsupported VIR instruction"
 
     (* Error states *)

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -482,7 +482,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
 
   (* Implement the atomic modify operations in terms of Vellvm uvalues.
-     Note: Langref doesn' seem to specifiy whether the arithmetic operations should be treated
+     Note: Langref doesn't seem to specifiy whether the arithmetic operations should be treated
            as having (or not) the signed/wrapping flags activated.  Here we (arbitrarily?)
            set them to false.
   *)
@@ -506,6 +506,16 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     | Axor =>
         (* xor: *ptr = *ptr ^ val *)
         ret (UVALUE_IBinop Xor pv val)
+    | Anand =>
+        (* nand: *ptr = ~( *ptr & val ) *)
+        match val with
+        | UVALUE_I sz _ =>
+            (* SAZ: Is this the best way to get a UValue with 0xFFFF..FFFF bit pattern? *)
+            ret (UVALUE_IBinop (Sub false false)
+                   (@UVALUE_I sz (@repr (@bit_int sz) _ (@max_unsigned (@bit_int sz) _)))
+                   (UVALUE_IBinop And pv val))            
+        | _ => raise "atomicrmw nand of non-integer value"
+        end
     | Afadd =>
         (* fadd: *ptr = *ptr + val (using floating point arithmetic) *)
         ret (UVALUE_FBinop FAdd [] pv val)
@@ -518,7 +528,6 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     | Aumin
     | Afmax
     | Afmin
-    | Anand
     | Afmaximum
     | Afminimum
     | Auinc_wrap

--- a/src/rocq/Semantics/InfiniteToFinite/LangRefine.v
+++ b/src/rocq/Semantics/InfiniteToFinite/LangRefine.v
@@ -20817,6 +20817,247 @@ Qed.
     dvalue_refine_strict_dvalue_to_uvalue
     : REF.
 
+  Lemma denote_cmpxchg_orutt_strict :
+    forall id c,
+      orutt instr_E_refine_strict instr_E_res_refine_strict eq
+        (IS1.LLVM.D.denote_cmpxchg id c) (denote_cmpxchg id c) (OOM:=OOME).
+  Proof.
+    intros id c.
+    destruct c, c_ptr, c_cmp, c_new.
+    cbn.
+    break_match_goal; eauto with ORUTT.
+    2: {
+      apply orutt_raise; cbn; eauto.
+      intros ? ? CONTRA.
+      inv CONTRA.
+    }
+
+    cbn.
+    apply orutt_bind with (RR:=uvalue_refine_strict).
+    { apply translate_exp_to_instr_E1E2_orutt_strict.
+      apply orutt_bind with (RR:=uvalue_refine_strict).
+      apply denote_exp'_E1E2_orutt.
+      apply orutt_denote_exp_concretize_if_no_undef_or_poison.
+    }
+
+    intros r1 r2 H.
+    subst.
+    apply orutt_bind with (RR:=uvalue_refine_strict).
+    { apply translate_exp_to_instr_E1E2_orutt_strict.
+      apply denote_exp'_E1E2_orutt.
+    }
+
+    intros r0 r3 H0.
+    apply orutt_bind with (RR:=uvalue_refine_strict).
+    { apply translate_exp_to_instr_E1E2_orutt_strict.
+      apply denote_exp'_E1E2_orutt.
+    }
+
+    intros r4 r5 H1.
+    apply orutt_bind with (RR:=dvalue_refine_strict).
+    apply concretize_or_pick_unique_instr_E_orutt_strict; auto.
+
+    intros r6 r7 H2.
+    apply orutt_bind with (RR:=uvalue_refine_strict).
+    { apply orutt_trigger; cbn; auto.
+      tauto.
+      intros o CONTRA.
+      unfold_subevents.
+      inv CONTRA.
+    }
+
+    intros r8 r9 H3.
+    repeat rewrite bind_bind.
+    setoid_rewrite bind_ret_l.
+
+    apply orutt_bind with (RR:=fun a b => dvalue_refine_strict (proj1_sig a) (proj1_sig b)).
+    { apply orutt_trigger; cbn; auto.
+      - unfold uvalue_refine_strict.
+        cbn.
+        rewrite H3, H0.
+        reflexivity.
+      - intros [t1 ?] [t2 ?].
+        intros H4.
+        tauto.
+      - intros o CONTRA.
+        unfold_subevents.
+        inv CONTRA.
+    }
+
+    intros r10 r11 H4.
+    destruct r10, r11; cbn in *.
+    destruct x, x0; try solve [first [apply orutt_raise
+                                     | apply orutt_raiseUB
+                                     | apply orutt_raiseOOM
+                                     | apply orutt_raiseLLVM
+                                 ]; [ intros * CONTRA; unfold_subevents; inv CONTRA | cbn; auto]
+                              | unfold dvalue_refine_strict in *; cbn in *;
+                                break_match_hyp_inv
+                              | unfold dvalue_refine_strict in *; cbn in *; inv H4
+                      ].
+    unfold dvalue_refine_strict in *; cbn in *; inv H4.
+    subst_existT.
+
+    destruct sz0; try solve [first [apply orutt_raise
+                                     | apply orutt_raiseUB
+                                     | apply orutt_raiseOOM
+                                     | apply orutt_raiseLLVM
+                                 ]; [ intros * CONTRA; unfold_subevents; inv CONTRA | cbn; auto]
+                              | unfold dvalue_refine_strict in *; cbn in *;
+                                break_match_hyp_inv
+                              | unfold dvalue_refine_strict in *; cbn in *; inv H4
+                    ].
+    break_match_goal.
+    { apply orutt_bind with (RR:=eq).
+      { apply orutt_trigger; cbn; auto.
+        intros [] [] ?; auto.
+        intros o CONTRA.
+        unfold_subevents.
+        inv CONTRA.
+      }
+
+      intros [] [] ?.
+      apply orutt_bind with (RR:=eq).
+      { apply orutt_trigger; cbn; unfold uvalue_refine_strict;
+          repeat setoid_rewrite H3; cbn; auto.
+        split; auto.
+        rewrite H3.
+        reflexivity.
+
+        intros [] [] ?; auto.
+
+        intros o CONTRA.
+        unfold_subevents.
+        inv CONTRA.
+      }
+
+      intros [] [] ?.
+      eauto with ORUTT.
+    }
+
+    apply orutt_bind with (RR:=eq).
+    { apply orutt_trigger; cbn; unfold uvalue_refine_strict;
+        repeat setoid_rewrite H3; cbn; auto.
+      split; auto.
+      rewrite H3.
+      reflexivity.
+
+      intros [] [] ?; auto.
+
+      intros o CONTRA.
+      unfold_subevents.
+      inv CONTRA.
+    }
+
+    intros [] [] ?.
+    eauto with ORUTT.
+  Qed.
+
+  Lemma denote_atomic_rmw_operation_orutt_strict :
+    forall r0 r8 r3 r9 a_operation,
+      uvalue_refine_strict r0 r3 ->
+      uvalue_refine_strict r8 r9 ->
+      orutt instr_E_refine_strict instr_E_res_refine_strict uvalue_refine_strict
+        (IS1.LLVM.D.denote_atomic_rmw_operation a_operation r8 r0)
+        (denote_atomic_rmw_operation a_operation r9 r3)
+        (OOM:=OOME).
+  Proof.
+    intros r0 r8 r3 r9 a_operation REF1 REF2.
+    destruct a_operation; cbn;
+      try solve
+        [ apply orutt_Ret; unfold_uvalue_refine_strict; try rewrite REF1; try rewrite REF2; auto
+        | first [apply orutt_raise
+                | apply orutt_raiseUB
+                | apply orutt_raiseOOM
+                | apply orutt_raiseLLVM
+            ]; [ intros * CONTRA; unfold_subevents; inv CONTRA | cbn; auto]].
+    unfold_uvalue_refine_strict.
+    (* TODO: this match is huge, we should be smarter about this *)
+    destruct r0, r3;
+      try solve
+        [ first [apply orutt_raise
+                | apply orutt_raiseUB
+                | apply orutt_raiseOOM
+                | apply orutt_raiseLLVM
+            ]; [ intros * CONTRA; unfold_subevents; inv CONTRA | cbn; auto]
+        | cbn in *; repeat break_match_hyp_inv
+        | inv REF1
+        | inv REF2
+        | inv REF1; subst_existT;
+          inv REF2; subst_existT;
+          apply orutt_Ret; cbn;
+          unfold_uvalue_refine_strict;
+          repeat match goal with
+            | H: uvalue_convert_strict _ = _ |- _ =>
+                setoid_rewrite H
+            end; auto
+        ].
+  Qed.
+
+  Lemma denote_atomicrmw_orutt_strict :
+    forall id a,
+      orutt instr_E_refine_strict instr_E_res_refine_strict eq (IS1.LLVM.D.denote_atomicrmw id a)
+        (denote_atomicrmw id a) (OOM:=OOME).
+  Proof.
+    intros id a.
+    destruct a, a_ptr, a_val.
+    cbn.
+
+    apply orutt_bind with (RR:=uvalue_refine_strict).
+    { apply translate_exp_to_instr_E1E2_orutt_strict.
+      apply orutt_bind with (RR:=uvalue_refine_strict).
+      apply denote_exp'_E1E2_orutt.
+      apply orutt_denote_exp_concretize_if_no_undef_or_poison.
+    }
+
+    intros r1 r2 H.
+    subst.
+    apply orutt_bind with (RR:=uvalue_refine_strict).
+    { apply translate_exp_to_instr_E1E2_orutt_strict.
+      apply denote_exp'_E1E2_orutt.
+    }
+
+    intros r0 r3 H0.
+    apply orutt_bind with (RR:=dvalue_refine_strict).
+    apply concretize_or_pick_unique_instr_E_orutt_strict; auto.
+
+    intros r6 r7 H2.
+    apply orutt_bind with (RR:=uvalue_refine_strict).
+    { apply orutt_trigger; cbn; auto.
+      tauto.
+      intros o CONTRA.
+      unfold_subevents.
+      inv CONTRA.
+    }
+
+    intros r8 r9 H3.
+    apply orutt_bind with (RR:=uvalue_refine_strict).
+    { apply denote_atomic_rmw_operation_orutt_strict; auto.
+    }
+
+    intros r10 r11 H4.
+    apply orutt_bind with (RR:=eq).
+    { apply orutt_trigger; cbn; auto.
+      intros [] [] ?; auto.
+      intros o CONTRA.
+      unfold_subevents.
+      inv CONTRA.
+    }
+
+    intros [] [] ?.
+    apply orutt_bind with (RR:=eq).
+    { apply orutt_trigger; cbn; unfold uvalue_refine_strict;
+        repeat setoid_rewrite H3; cbn; auto.
+      intros [] [] ?; auto.
+      intros o CONTRA.
+      unfold_subevents.
+      inv CONTRA.
+    }
+
+    intros [] [] ?.
+    eauto with ORUTT.
+  Qed.
+
   Lemma denote_instr_orutt_strict :
     forall instr varg1 varg2,
       OptionUtil.option_rel2 addr_refine varg1 varg2 ->
@@ -21153,6 +21394,10 @@ Qed.
         intros o CONTRA; inv CONTRA.
       - apply orutt_raise; cbn; auto.
         intros msg o0 CONTRA; inv CONTRA.
+      - (* cmpxchg *)
+        apply denote_cmpxchg_orutt_strict.
+      - (* atomicrmw *)
+        apply denote_atomicrmw_orutt_strict.
       - (* va_arg *)
         break_match_goal; subst.
         eapply orutt_bind with (RR:=uvalue_refine_strict).

--- a/tests/ll/atomicrmw.ll
+++ b/tests/ll/atomicrmw.ll
@@ -1,0 +1,77 @@
+;; Compare and swap when the values stored/compared are i32s
+define i32 @atomicrmw_i32_add(i32 %x, i32 %y) {
+   %ptr = alloca i32
+   store i32 %x, ptr %ptr
+   %ans = atomicrmw add ptr %ptr, i32 %y acq_rel
+   %res = load i32, ptr %ptr
+   ret i32 %res
+}
+
+; ASSERT EQ: i32 42 = call i32 @atomicrmw_i32_add(i32 17, i32 25)
+; ASSERT EQ: i32 100 = call i32 @atomicrmw_i32_add(i32 10, i32 90)
+
+
+;; Compare and swap when the values stored/compared are i32s
+define i32 @atomicrmw_i32_sub(i32 %x, i32 %y) {
+   %ptr = alloca i32
+   store i32 %x, ptr %ptr
+   %ans = atomicrmw sub ptr %ptr, i32 %y acq_rel
+   %res = load i32, ptr %ptr
+   ret i32 %res
+}
+
+; ASSERT EQ: i32 8 = call i32 @atomicrmw_i32_sub(i32 25, i32 17)
+; ASSERT EQ: i32 80 = call i32 @atomicrmw_i32_sub(i32 90, i32 10)
+
+
+;; Compare and swap when the values stored/compared are i32s
+define i32 @atomicrmw_i32_xchg(i32 %x, i32 %y) {
+   %ptr = alloca i32
+   store i32 %x, ptr %ptr
+   %ans = atomicrmw xchg ptr %ptr, i32 %y acq_rel
+   %res = load i32, ptr %ptr
+   ret i32 %res
+}
+
+; ASSERT EQ: i32 17 = call i32 @atomicrmw_i32_xchg(i32 25, i32 17)
+; ASSERT EQ: i32 10 = call i32 @atomicrmw_i32_xchg(i32 90, i32 10)
+
+
+;; Compare and swap when the values stored/compared are i32s
+define i32 @atomicrmw_i32_and(i32 %x, i32 %y) {
+   %ptr = alloca i32
+   store i32 %x, ptr %ptr
+   %ans = atomicrmw and ptr %ptr, i32 %y acq_rel
+   %res = load i32, ptr %ptr
+   ret i32 %res
+}
+
+; ASSERT EQ: i32 17 = call i32 @atomicrmw_i32_and(i32 25, i32 17)
+; ASSERT EQ: i32 16 = call i32 @atomicrmw_i32_and(i32 25, i32 16)
+
+
+;; Compare and swap when the values stored/compared are i32s
+define i32 @atomicrmw_i32_or(i32 %x, i32 %y) {
+   %ptr = alloca i32
+   store i32 %x, ptr %ptr
+   %ans = atomicrmw or ptr %ptr, i32 %y acq_rel
+   %res = load i32, ptr %ptr
+   ret i32 %res
+}
+
+; ASSERT EQ: i32 27 = call i32 @atomicrmw_i32_or(i32 24, i32 11)
+; ASSERT EQ: i32 25 = call i32 @atomicrmw_i32_or(i32 25, i32 16)
+
+;; Compare and swap when the values stored/compared are i32s
+define i32 @atomicrmw_i32_xor(i32 %x, i32 %y) {
+   %ptr = alloca i32
+   store i32 %x, ptr %ptr
+   %ans = atomicrmw xor ptr %ptr, i32 %y acq_rel
+   %res = load i32, ptr %ptr
+   ret i32 %res
+}
+
+; ASSERT EQ: i32 19 = call i32 @atomicrmw_i32_xor(i32 24, i32 11)
+; ASSERT EQ: i32 9 = call i32 @atomicrmw_i32_xor(i32 25, i32 16)
+
+

--- a/tests/ll/atomicrmw.ll
+++ b/tests/ll/atomicrmw.ll
@@ -75,3 +75,30 @@ define i32 @atomicrmw_i32_xor(i32 %x, i32 %y) {
 ; ASSERT EQ: i32 9 = call i32 @atomicrmw_i32_xor(i32 25, i32 16)
 
 
+
+;; Compare and swap when the values stored/compared are i5s
+define i5 @atomicrmw_i5_nand(i5 %x, i5 %y) {
+   %ptr = alloca i5
+   store i5 %x, ptr %ptr
+   %ans = atomicrmw nand ptr %ptr, i5 %y acq_rel
+   %res = load i5, ptr %ptr
+   ret i5 %res
+}
+
+; ASSERT EQ: i5 23 = call i5 @atomicrmw_i5_nand(i5 24, i5 11)
+; ASSERT EQ: i5 22 = call i5 @atomicrmw_i5_nand(i5 15, i5 9)
+
+
+;; Compare and swap when the values stored/compared are i8s
+define i8 @atomicrmw_i8_nand(i8 %x, i8 %y) {
+   %ptr = alloca i8
+   store i8 %x, ptr %ptr
+   %ans = atomicrmw nand ptr %ptr, i8 %y acq_rel
+   %res = load i8, ptr %ptr
+   ret i8 %res
+}
+
+; ASSERT EQ: i8 127 = call i8 @atomicrmw_i8_nand(i8 255, i8 128)
+
+
+

--- a/tests/ll/cmpxchg.ll
+++ b/tests/ll/cmpxchg.ll
@@ -1,0 +1,81 @@
+;; Compare and swap when the values stored/compared are i32s
+define i32 @cmpxchg_i32(i32 %x) {
+   %ptr = alloca i32
+   store i32 17, ptr %ptr
+   %ans = cmpxchg ptr %ptr, i32 %x, i32 42 acq_rel monotonic
+   %value_loaded = extractvalue { i32, i1 } %ans, 0
+   %success = extractvalue { i32, i1 } %ans, 1   
+   br i1 %success, label %true, label %false
+
+true:
+  %loaded_value = load i32, ptr %ptr
+  ret i32 %loaded_value
+
+false:
+  %other_value = load i32, ptr %ptr
+  ret i32 %other_value
+}
+
+;; Compare and swap when the values stored/compared are i64s
+define i64 @cmpxchg_i64(i64 %x) {
+   %ptr = alloca i64
+   store i64 17, ptr %ptr
+   %ans = cmpxchg ptr %ptr, i64 %x, i64 42 acq_rel monotonic
+   %value_loaded = extractvalue { i64, i1 } %ans, 0
+   %success = extractvalue { i64, i1 } %ans, 1   
+   br i1 %success, label %true, label %false
+
+true:
+  %loaded_value = load i64, ptr %ptr
+  ret i64 %loaded_value
+
+false:
+  %other_value = load i64, ptr %ptr
+  ret i64 %other_value
+}
+
+;; Compare and swap when the values stored are pointers
+define i32 @cmpxchg_ptr(i32 %x) {
+   %ptr = alloca ptr
+   %ptr_i = alloca i32
+   %ptr_j = alloca i32
+   
+   store i32 %x, ptr %ptr_i
+   store i32 17, ptr %ptr_j
+   store ptr %ptr_i, ptr %ptr
+
+   ;; if %x is 42 then the compare and swap succeeds
+   %cmp = icmp eq i32 %x, 42
+   br i1 %cmp, label %true, label %false
+
+true:
+   %ans = cmpxchg ptr %ptr, ptr %ptr_i, ptr %ptr_j acq_rel monotonic
+   %value_loaded = extractvalue { ptr, i1 } %ans, 0
+   %success = extractvalue { ptr, i1 } %ans, 1
+   br i1 %success, label %load_success, label %load_fail
+
+load_success:
+   %ptr_loaded = load i32*, ptr %ptr
+   %ans_s = load i32, ptr %ptr_loaded
+   ret i32 %ans_s
+
+false:
+  %ans_f = cmpxchg ptr %ptr, ptr %ptr_j, ptr %ptr_i acq_rel monotonic
+  %vl = extractvalue { ptr, i1 } %ans_f, 0
+  %sl = extractvalue { ptr, i1 } %ans_f, 1
+  br i1 %sl, label %load_success, label %load_fail
+
+load_fail:
+  ret i32 0
+}
+
+
+
+; ASSERT EQ: i32 42 = call i32 @cmpxchg_i32(i32 17)
+; ASSERT EQ: i32 17 = call i32 @cmpxchg_i32(i32 55)
+
+; ASSERT EQ: i64 42 = call i64 @cmpxchg_i64(i64 17)
+; ASSERT EQ: i64 17 = call i64 @cmpxchg_i64(i64 55)
+
+; ASSERT EQ: i32 0 = call i32 @cmpxchg_ptr(i32 17)
+; ASSERT EQ: i32 17 = call i32 @cmpxchg_ptr(i32 42)


### PR DESCRIPTION
This is a first stab at adding interpreter support for the `cmpxchg` and `atomicrmw` instructions.  I have (lightly) tested the interpreter using the test cases in this pull request, but haven't pushed through any of the proofs.

- I'm not 100% sure that this does the right thing in the presence of `undef` and `poison`
- `LangRefine.v` will have to be patched up to account for the new instruction
