### PR TITLE
Error locations

### DIFF
--- a/src/ml/IO.ml
+++ b/src/ml/IO.ml
@@ -29,8 +29,21 @@ let output_ast ast channel =
   let open Ast_printer in
   toplevel_entities channel ast
 
+
+let reset_lexbuf (filename:string) (lnum:int) lexbuf : unit =
+  lexbuf.Lexing.lex_curr_p <- {
+      pos_fname = filename;
+      pos_cnum = 0;
+      pos_bol = 0;
+      pos_lnum = lnum;
+    }
+
 let parse_file filename =
-  read_file filename |> Lexing.from_string |> Llvm_lexer.parse
+  let lexbuf = read_file filename |> 
+               Lexing.from_string
+  in
+  reset_lexbuf filename 1 lexbuf;  (* set the filename *)  
+  Llvm_lexer.parse lexbuf
 
 let ll_files_of_dir path : string list =
   let tmp_file = gen_name "." ".ll_files" ".tmp" in

--- a/src/ml/extracted/Extract.v
+++ b/src/ml/extracted/Extract.v
@@ -73,11 +73,14 @@ Extract Constant printer_object => "
       | c :: s -> Bytes.set r pos c; fill (pos + 1) s
     in Bytes.to_string (fill 0 s)
   in
-  let set_loc loc = (loc_state := loc; []) in
-  let print_msg msg =
+  let printer_set_loc loc = (loc_state := loc; []) in
+  let printer_print_msg msg =
     print_string ((camlstring_of_coqstring !loc_state) ^ "": "" ^ (camlstring_of_coqstring msg) ^ ""\n"")
   in
-  (set_loc, print_msg)
+  let printer_get_loc = fun _ -> !loc_state in
+  { printer_set_loc;
+    printer_print_msg;
+    printer_get_loc; }
   ".
 
 (* OCaml pervasive types ---------------------------------------------------- *)

--- a/src/ml/extracted/Extract.v
+++ b/src/ml/extracted/Extract.v
@@ -62,14 +62,23 @@ Extract Inlined Constant ascii_dec => "(=)".
 Extract Inductive string => "string" [ "str_nil" "str_cons" ].
 *)
 
+
 (* camlstring_of_coqstring is from Camlcoq *)
-Extract Constant print_msg => "let camlstring_of_coqstring (s: char list) =
-  let r = Bytes.create (List.length s) in
-  let rec fill pos = function
-  | [] -> r
-  | c :: s -> Bytes.set r pos c; fill (pos + 1) s
-  in Bytes.to_string (fill 0 s)
-in fun msg -> print_string (camlstring_of_coqstring msg ^ ""\n"")".
+Extract Constant printer_object => "
+  let loc_state = ref [] in
+  let camlstring_of_coqstring (s: char list) =
+    let r = Bytes.create (List.length s) in
+    let rec fill pos = function
+      | [] -> r
+      | c :: s -> Bytes.set r pos c; fill (pos + 1) s
+    in Bytes.to_string (fill 0 s)
+  in
+  let set_loc loc = (loc_state := loc; []) in
+  let print_msg msg =
+    print_string ((camlstring_of_coqstring !loc_state) ^ "": "" ^ (camlstring_of_coqstring msg) ^ ""\n"")
+  in
+  (set_loc, print_msg)
+  ".
 
 (* OCaml pervasive types ---------------------------------------------------- *)
 (* Extract Inlined Constant LLVMAst.int => "int". *)

--- a/src/ml/interpreter.ml
+++ b/src/ml/interpreter.ml
@@ -98,6 +98,9 @@ let debug (msg : string) =
     Calling `step` could either loop forever, return an error,
     or return the dvalue result returned from the itree.
  *)
+
+let current_line = ref (Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()))
+
 let rec step
     (m :
       ( 'a coq_L4
@@ -108,7 +111,15 @@ let rec step
   let open ITreeDefinition in
   match observe m with
   (* Internal steps compute as nothing *)
-  | TauF x -> step x
+  | TauF x ->
+     if !debug_flag then begin
+         let loc_str = Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()) in
+         if loc_str <> !current_line then begin 
+             Printf.printf "%s\n%!" loc_str;
+             current_line := loc_str
+           end
+     end;
+     step x
   (* SAZ: Could inspect the memory or stack here too. *)
   (* We finished the computation *)
   | RetF (_, (_, (_, (_, v)))) -> Ok v

--- a/src/ml/interpreter.ml
+++ b/src/ml/interpreter.ml
@@ -114,9 +114,12 @@ let rec step
   | RetF (_, (_, (_, (_, v)))) -> Ok v
   (* The ExternalCallE effect *)
   | VisF (Sum.Coq_inl1 (ExternalCall (t, _, dvs)), _) ->
-      Error (UninterpretedCall ("Call with return type "
-       ^ (Camlcoq.camlstring_of_coqstring (ReprAST.repr_dtyp t))
-       ^ ", " ^ (string_of_int (List.length dvs)) ^ " dvalues."))
+     let loc_str = Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()) in
+     let typ_str = Camlcoq.camlstring_of_coqstring (ReprAST.repr_dtyp t) in
+     let args_str = string_of_int (List.length dvs) in
+     Error (UninterpretedCall
+              (Printf.sprintf "%s: Call with return type %s, %s dvalues."
+                 loc_str typ_str args_str))
   (* Still TODO: Integrate 2nd argument *)
   (* The IO_stdout effect *)
   | VisF (Sum.Coq_inl1 (IO_stdout bytes), k) ->
@@ -130,24 +133,29 @@ let rec step
       step (k (Obj.magic ()))
   (* The OOME effect *)
   | VisF (Sum.Coq_inr1 (Sum.Coq_inl1 _msg), _k) ->
-     Error (OutOfMemory "")
+     let loc_str = Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()) in
+     Error (OutOfMemory loc_str)
 
   (* LLVM Exception event *)
   | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 _uv)), _k) ->
-     Error (LLVMException "")
+     let loc_str = Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()) in
+     Error (LLVMException loc_str)
 
   (* UBE event *)
   | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 _msg))), _k) ->
-     Error (UndefinedBehavior "")
+     let loc_str = Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()) in
+     Error (UndefinedBehavior loc_str)
 
   (* The DebugE effect *)
   | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inl1 _msg)))), k) ->
-     (debug "";
+     let loc_str = Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()) in
+     (debug loc_str;
       step (k (Obj.magic DV.DVALUE_None)))
 
   (* The FailureE effect is a failure *)
   | VisF (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 (Sum.Coq_inr1 _msg)))), _) ->
-     Error (Failed "")
+     let loc_str = Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()) in
+     Error (Failed loc_str)
 
 (* The only visible effects from LLVMIO that should propagate to the
    interpreter are: - Call to external functions - Debug *)

--- a/src/ml/libvellvm/llvm_lexer.mll
+++ b/src/ml/libvellvm/llvm_lexer.mll
@@ -23,7 +23,22 @@
 (*  ------------------------------------------------------------------------- *)
 
 {
+  open Lexing
   open Llvm_parser
+
+  let reset_lexbuf (filename:string) (lnum:int) lexbuf : unit =
+    lexbuf.lex_curr_p <- {
+      pos_fname = filename;
+      pos_cnum = 0;
+      pos_bol = 0;
+      pos_lnum = lnum;
+    }
+
+  let newline lexbuf =
+    lexbuf.lex_curr_p <- { (lexeme_end_p lexbuf) with
+      pos_lnum = (lexeme_end_p lexbuf).pos_lnum + 1;
+      pos_bol = (lexeme_end lexbuf) }
+
   let str = Camlcoq.coqstring_of_camlstring
   let of_str = Camlcoq.camlstring_of_coqstring
   let coq_N_of_int = Camlcoq.N.of_int

--- a/src/ml/libvellvm/llvm_parser.mly
+++ b/src/ml/libvellvm/llvm_parser.mly
@@ -24,10 +24,29 @@
 (*  ------------------------------------------------------------------------- *)
 
 
-
+open Lexing
 open LLVMAst
 open ParserHelper
 open ParseUtil
+
+(* Compute a METADATA_File_info value from the current parser state. *)
+let pos_of_lexpos (p : position) =
+  (p.pos_lnum,  (p.pos_cnum - p.pos_bol))
+
+let metadata_file_info (startpos:Lexing.position) (endpos:Lexing.position) =
+  let filename = str startpos.pos_fname in
+  let start_line = coq_of_int startpos.pos_lnum in
+  let start_col = coq_of_int (startpos.pos_cnum - startpos.pos_bol) in
+  let end_line = coq_of_int endpos.pos_lnum in
+  let end_col = coq_of_int (endpos.pos_cnum - endpos.pos_bol) in
+  METADATA_File_info {
+      filename ;
+      start_line ;
+      start_col ;
+      end_line ;
+      end_col ;
+      }
+      
 
 (* normalize_float_size :
    - LLVM floating point literals need different interpretations depending
@@ -1057,8 +1076,9 @@ block_instrs_and_term:
 
 phi:
   | KW_PHI t=typ ps=phi_suffix
-    { let (table, md) = ps in 
-      (Phi (t, List.map (fun (l,v) -> (l, v t)) table), md) }
+    { let (table, md) = ps in
+      let f_info = metadata_file_info $startpos $endpos in
+      (Phi (t, List.map (fun (l,v) -> (l, v t)) table), f_info::md) }
 
 phi_suffix:
   | te=phi_table_entry COMMA ps=phi_suffix
@@ -1479,17 +1499,20 @@ expr_op:
 
 instr_path:
   | KW_EXTRACTVALUE tv=texp im=comma_path_with_instr_metadata(INTEGER)
-    { let (idx, md) = im in 
-      (INSTR_Op (OP_ExtractValue (tv, idx)), md) }
+    { let f_info = metadata_file_info $startpos $endpos in
+      let (idx, md) = im in 
+      (INSTR_Op (OP_ExtractValue (tv, idx)), f_info::md) }
 
   | KW_INSERTVALUE agg=texp COMMA new_val=texp im=comma_path_with_instr_metadata(INTEGER)
-    { let (idx, md) = im in
-      (INSTR_Op (OP_InsertValue (agg, new_val, idx)), md) }
+    { let f_info = metadata_file_info $startpos $endpos in
+      let (idx, md) = im in
+      (INSTR_Op (OP_InsertValue (agg, new_val, idx)), f_info::md) }
 
     (* SAZ: TODO - record the inbounds, nuw, nusw flags, also allow inrange(S,E) *) 
   | KW_GETELEMENTPTR KW_INBOUNDS? KW_NUSW? KW_NUW? t=typ COMMA ptr=texp im=comma_path_with_instr_metadata(texp)
-    { let (idx, md) = im in
-      (INSTR_Op(OP_GetElementPtr (t, ptr, idx)), md) }
+    { let f_info = metadata_file_info $startpos $endpos in
+      let (idx, md) = im in
+      (INSTR_Op(OP_GetElementPtr (t, ptr, idx)), f_info::md) }
 
 
 expr_val:
@@ -1569,7 +1592,9 @@ operand_bundles:
 
 instr:
   | eo=instr_op md=instr_metadata
-     { (INSTR_Op eo, md)  }
+    { 
+      let f_info = metadata_file_info $startpos $endpos in
+      (INSTR_Op eo, f_info::md)  }
 
   | ep=instr_path
      { ep }
@@ -1577,7 +1602,9 @@ instr:
   | t=tailcall? KW_CALL fm=list(fast_math) cc=cconv? ra=list(param_attr) addr=addrspace?
     f=call_exp  a=delimited(LPAREN, separated_list(csep, call_arg), RPAREN)
     fa=list(fn_attr) ops=operand_bundles? md=instr_metadata
-    { let atts =
+    {
+      let f_info = metadata_file_info $startpos $endpos in
+      let atts =
 	(opt_list t)
 	@ (List.map (fun f -> ANN_fast_math_flag f) fm)
 	@ (opt_list cc)
@@ -1590,36 +1617,44 @@ instr:
 		| Some ops -> ops
 		end
       in
-      (INSTR_Call (f, a, atts, ops), md) }
+      (INSTR_Call (f, a, atts, ops), f_info::md) }
 
   | KW_ALLOCA ia=KW_INALLOCA? t=typ am=alloca_anns
-    { let a = ann_opt ia ANN_inalloca in
+    {
+      let f_info = metadata_file_info $startpos $endpos in     
+      let a = ann_opt ia ANN_inalloca in
       let (anns, md) = am in
-      (INSTR_Alloca (t, a@anns), md) }
+      (INSTR_Alloca (t, a@anns), f_info::md) }
 
   | KW_LOAD at=KW_ATOMIC? vol=KW_VOLATILE? t=typ COMMA tv=texp ss=syncscope? o=ordering? am=ls_anns
-    { let at_ann = ann_opt at ANN_atomic in
+    { let f_info = metadata_file_info $startpos $endpos in     
+      let at_ann = ann_opt at ANN_atomic in
       let v = ann_opt vol ANN_volatile in
       let (a, md) = am in
       let (ss_ann : typ annotation list) = opt_list ss in
       let ord_ann = List.map (fun x -> ANN_ordering x) (opt_list o) in
-      (INSTR_Load (t, tv, at_ann@v@ss_ann@ord_ann@a), md) } 
+      (INSTR_Load (t, tv, at_ann@v@ss_ann@ord_ann@a), f_info::md) } 
 
 
-  | KW_VAARG tv=texp COMMA t=typ md=instr_metadata { (INSTR_VAArg (tv, t), md)  }
+  | KW_VAARG tv=texp COMMA t=typ md=instr_metadata
+    { let f_info = metadata_file_info $startpos $endpos in     
+      (INSTR_VAArg (tv, t), f_info::md)
+    }
 
   | KW_STORE at=KW_ATOMIC? vol=KW_VOLATILE? all=texp COMMA ptr=texp ss=syncscope? o=ordering? am=ls_anns
-    { let at_ann = ann_opt at ANN_atomic in
+    { let f_info = metadata_file_info $startpos $endpos in     
+      let at_ann = ann_opt at ANN_atomic in
       let v = ann_opt vol ANN_volatile in
       let (a, md) = am in
       let (ss_ann : typ annotation list) = opt_list ss in
       let ord_ann = List.map (fun x -> ANN_ordering x) (opt_list o) in
-      (INSTR_Store (all, ptr, at_ann@v@ss_ann@ord_ann@a), md) }
+      (INSTR_Store (all, ptr, at_ann@v@ss_ann@ord_ann@a), f_info::md) }
 
   | KW_ATOMICCMPXCHG c_weak=KW_WEAK? c_volatile=KW_VOLATILE?
     c_ptr=texp COMMA c_cmp=texp COMMA c_new=texp ss=syncscope?
     c_success_ordering=ordering c_failure_ordering=ordering c_align=comma_align?
-    { let c_syncscope =
+    { let f_info = metadata_file_info $startpos $endpos in     
+      let c_syncscope =
 	       begin match ss with
                | Some (ANN_syncscope s) -> Some s
 	       | Some _ -> failwith "impossible: syncscope not found"
@@ -1638,12 +1673,13 @@ instr:
 	   c_failure_ordering;	   
 	   c_align;
 	 }
-      , [])
+      , [f_info])
     }
       
   | KW_ATOMICRMW a_volatile=KW_VOLATILE? a_operation=atomicrmw_op
     a_ptr=texp COMMA a_val=texp ss=syncscope? a_ordering=ordering a_align=comma_align?
-    { let a_syncscope = begin match ss with
+    { let f_info = metadata_file_info $startpos $endpos in     
+      let a_syncscope = begin match ss with
                | Some (ANN_syncscope s) -> Some s
 	       | Some _ -> failwith "impossible: syncscope not found"
 	       | _ -> None
@@ -1658,23 +1694,26 @@ instr:
 	  a_ordering;
 	  a_align;
 	}
-      , [])
+      , [f_info])
     }
 
   | KW_FENCE ss=syncscope? a_ordering=ordering
-    { let a_syncscope = begin match ss with
+    { let f_info = metadata_file_info $startpos $endpos in     
+      let a_syncscope = begin match ss with
                | Some (ANN_syncscope s) -> Some s
 	       | Some _ -> failwith "impossible: syncscope not found"
 	       | _ -> None
 	       end
       in
-      (INSTR_Fence(a_syncscope, a_ordering), [])
+      (INSTR_Fence(a_syncscope, a_ordering), [f_info])
     }
   | KW_LANDINGPAD t=typ KW_CLEANUP cs=clause* md=instr_metadata
-    { (INSTR_LandingPad (t, true, cs), md) }
+    { let f_info = metadata_file_info $startpos $endpos in     
+      (INSTR_LandingPad (t, true, cs), f_info::md) }
 
   | KW_LANDINGPAD t=typ cs=clause+ md=instr_metadata
-    { (INSTR_LandingPad (t, false, cs), md) }
+    { let f_info = metadata_file_info $startpos $endpos in     
+      (INSTR_LandingPad (t, false, cs), f_info::md) }
 
 syncscope:
   KW_SYNCSCOPE LPAREN s=STRING RPAREN
@@ -1725,27 +1764,34 @@ branch_label:
 %inline
 terminator:
   | KW_RET tv=texp md=instr_metadata
-    { ((TERM_Ret tv), md) }
+    { let f_info = metadata_file_info $startpos $endpos in     
+      ((TERM_Ret tv), f_info::md) }
 
   | KW_RET KW_VOID md=instr_metadata
-    { (TERM_Ret_void, md) }
+    { let f_info = metadata_file_info $startpos $endpos in     
+      (TERM_Ret_void, f_info::md) }
 
   | KW_BR c=texp COMMA o1=branch_label COMMA o2=branch_label md=instr_metadata
-    { (TERM_Br (c, o1, o2), md) }
+    { let f_info = metadata_file_info $startpos $endpos in     
+      (TERM_Br (c, o1, o2), f_info::md) }
 
   | KW_BR b=branch_label md=instr_metadata
-    { (TERM_Br_1 b, md) }
+    { let f_info = metadata_file_info $startpos $endpos in     
+      (TERM_Br_1 b, f_info::md) }
 
   | KW_SWITCH c=texp COMMA
     def=branch_label LSQUARE table=list(switch_table_entry) RSQUARE md=instr_metadata
-    { (TERM_Switch (c, def, table), md) }
+    { let f_info = metadata_file_info $startpos $endpos in     
+      (TERM_Switch (c, def, table), f_info::md) }
 
   | KW_INDIRECTBR tv=texp
     COMMA LSQUARE til=separated_list(csep, branch_label)  RSQUARE md=instr_metadata
-    { (TERM_IndirectBr (tv, til), md) }
+    { let f_info = metadata_file_info $startpos $endpos in     
+      (TERM_IndirectBr (tv, til), f_info::md) }
 
   | KW_RESUME tv=texp md=instr_metadata
-    { (TERM_Resume tv, md) }
+    { let f_info = metadata_file_info $startpos $endpos in
+      (TERM_Resume tv, f_info::md) }
 
   | KW_INVOKE fm=list(fast_math) cc=cconv? ra=list(param_attr) addr=addrspace?
     f=call_exp  a=delimited(LPAREN, separated_list(csep, call_arg), RPAREN)
@@ -1755,7 +1801,8 @@ terminator:
     KW_UNWIND l2=branch_label
     md=instr_metadata
 
-    { let atts =
+    { let f_info = metadata_file_info $startpos $endpos in
+      let atts =
 	  (List.map (fun f -> ANN_fast_math_flag f) fm)
 	@ (opt_list cc)
         @ (List.map (fun r -> ANN_ret_attribute r) ra)
@@ -1767,10 +1814,11 @@ terminator:
 		| Some ops -> ops
 		end
       in
-      (TERM_Invoke(f, a, l1, l2, atts, ops), md)  }
+      (TERM_Invoke(f, a, l1, l2, atts, ops), f_info::md)  }
 
   | KW_UNREACHABLE md=instr_metadata
-    { (TERM_Unreachable, md) }
+    { let f_info = metadata_file_info $startpos $endpos in
+      (TERM_Unreachable, f_info::md) }
 
 comma_align:
   | COMMA KW_ALIGN n=INTEGER { n }

--- a/src/rocq/Handlers/Concretization.v
+++ b/src/rocq/Handlers/Concretization.v
@@ -28,7 +28,8 @@ From Vellvm Require Import
      Semantics.LLVMEvents
      Semantics.LLVMParams
      Semantics.StoreId
-     Handlers.MemoryModel.
+     Handlers.MemoryModel
+     QC.ShowAST.
 
 From ExtLib Require Import
      Structures.Monads
@@ -113,7 +114,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_I sz_to =>
               if Pos.eqb sz_t sz_from && (sz_to <? sz_from)%positive
               then Conv_Pure (@DVALUE_I sz_to (repr (unsigned i1)))
-              else Conv_Illegal "ill-typed Trunc"
+              else Conv_Illegal "i-to-i ill-typed Trunc"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
               Conv_Pure (DVALUE_Poison t)
@@ -126,7 +127,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_I sz_to =>
               if Pos.eqb sz_t sz_from && (sz_from <? sz_to)%positive
               then Conv_Pure (@DVALUE_I sz_to (repr (unsigned i1)))
-              else Conv_Illegal "ill-typed Zext"
+              else Conv_Illegal "i-to-i ill-typed Zext"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
               Conv_Pure (DVALUE_Poison t)
@@ -139,7 +140,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_I sz_to =>
               if Pos.eqb sz_t sz_from && (sz_from <? sz_to)%positive
               then Conv_Pure (@DVALUE_I sz_to (repr (signed i1)))
-              else Conv_Illegal "ill-typed Sext"
+              else Conv_Illegal "i-to-i ill-typed Sext"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
               Conv_Pure (DVALUE_Poison t)
@@ -171,12 +172,12 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_Float =>
               if Pos.eqb sz_t sz_from
               then Conv_Pure (DVALUE_Float (Float32.of_intu (repr (unsigned i1))))
-              else Conv_Illegal "ill-typed Uitofp"
+              else Conv_Illegal "i-to-float ill-typed Uitofp"
 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_Double =>
               if Pos.eqb sz_t sz_from
               then Conv_Pure (DVALUE_Double (Float.of_longu (repr (unsigned i1))))
-              else Conv_Illegal "ill-typed Uitofp"
+              else Conv_Illegal "i-to-double ill-typed Uitofp"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_Float
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_Double =>
@@ -190,12 +191,12 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_Float =>
               if Pos.eqb sz_t sz_from
               then Conv_Pure (DVALUE_Float (Float32.of_intu (repr (signed i1))))
-              else Conv_Illegal "ill-typed Sitofp"
+              else Conv_Illegal "i-to-float ill-typed Sitofp"
 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_Double =>
               if Pos.eqb sz_t sz_from
               then Conv_Pure (DVALUE_Double (Float.of_longu (repr (signed i1))))
-              else Conv_Illegal "ill-typed Sitofp"
+              else Conv_Illegal "i-to-double ill-typed Sitofp"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_Float
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_Double =>
@@ -243,7 +244,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
                                (@DVALUE_I sz_to
                                   (@repr (@bit_int sz_to) (VInt_Bounded sz_to)
                                      (@unsigned (@bit_int sz_from) (VInt_Bounded sz_from) i1)))
-                           else Conv_Illegal "ill-typed Trunc"
+                           else Conv_Illegal "i-to-i ill-typed Trunc"
                        | _ => Conv_Illegal "ill-typed Trunc"
                        end
                    | @DVALUE_Poison t =>
@@ -268,7 +269,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
                                (@DVALUE_I sz_to
                                   (@repr (@bit_int sz_to) (VInt_Bounded sz_to)
                                      (@unsigned (@bit_int sz_from) (VInt_Bounded sz_from) i1)))
-                           else Conv_Illegal "ill-typed Zext"
+                           else Conv_Illegal "i-to-i ill-typed Zext"
                        | _ => Conv_Illegal "ill-typed Zext"
                        end
                    | @DVALUE_Poison t =>
@@ -293,7 +294,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
                                (@DVALUE_I sz_to
                                   (@repr (@bit_int sz_to) (VInt_Bounded sz_to)
                                      (@signed (@bit_int sz_from) (VInt_Bounded sz_from) i1)))
-                           else Conv_Illegal "ill-typed Sext"
+                           else Conv_Illegal "i-to-i ill-typed Sext"
                        | _ => Conv_Illegal "ill-typed Sext"
                        end
                    | @DVALUE_Poison t =>
@@ -320,7 +321,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
                                      (@repr (@bit_int 32) (VInt_Bounded 32)
                                         (@unsigned (@bit_int sz_from)
                                            (VInt_Bounded sz_from) i1))))
-                           else Conv_Illegal "ill-typed Uitofp"
+                           else Conv_Illegal "i-to-float ill-typed Uitofp"
                        | @DTYPE_Double =>
                            if (sz_t =? sz_from)%positive
                            then
@@ -330,7 +331,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
                                      (@repr (@bit_int 64) (VInt_Bounded 64)
                                         (@unsigned (@bit_int sz_from)
                                            (VInt_Bounded sz_from) i1))))
-                           else Conv_Illegal "ill-typed Uitofp"
+                           else Conv_Illegal "i-to-double ill-typed Uitofp"
                        | _ => Conv_Illegal "ill-typed Uitofp"
                        end
                    | @DVALUE_Poison t =>
@@ -356,7 +357,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
                                   (Float32.of_intu
                                      (@repr (@bit_int 32) (VInt_Bounded 32)
                                         (@signed (@bit_int sz_from) (VInt_Bounded sz_from) i1))))
-                           else Conv_Illegal "ill-typed Sitofp"
+                           else Conv_Illegal "i-to-float ill-typed Sitofp"
                        | @DTYPE_Double =>
                            if (sz_t =? sz_from)%positive
                            then
@@ -365,7 +366,7 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
                                   (Float.of_longu
                                      (@repr (@bit_int 64) (VInt_Bounded 64)
                                         (@signed (@bit_int sz_from) (VInt_Bounded sz_from) i1))))
-                           else Conv_Illegal "ill-typed Sitofp"
+                           else Conv_Illegal "i-to-double ill-typed Sitofp"
                        | _ => Conv_Illegal "ill-typed Sitofp"
                        end
                    | @DVALUE_Poison t =>
@@ -971,14 +972,14 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
       the composition of a huge case analysis that builds a value of [conv_case], and a function
       with only four cases to actually build the tree.
      *)
-    Definition get_conv_case (conv : conversion_type) (t1:dtyp) (x:dvalue) (t2:dtyp) : conv_case :=
+        Definition get_conv_case (conv : conversion_type) (t1:dtyp) (x:dvalue) (t2:dtyp) : conv_case :=
       match conv with
-      | Trunc nuw nsb  => (* TODO: update to support the nuw and nsb flags *)
+      | Trunc nuw nsb => (* TODO: handle the nuw and nsb flags *)
           match t1, x, t2 with
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_I sz_to =>
               if Pos.eqb sz_t sz_from && (sz_to <? sz_from)%positive
               then Conv_Pure (@DVALUE_I sz_to (repr (unsigned i1)))
-              else Conv_Illegal "ill-typed Trunc"
+              else Conv_Illegal "i-to-i ill-typed Trunc"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
               Conv_Pure (DVALUE_Poison t)
@@ -986,12 +987,12 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
           | _, _, _ => Conv_Illegal "ill-typed Trunc"
           end
 
-      | Zext nneg => (* TODO: handle the nneg flag correctly *)
+      | Zext nneg => (* TODO: handle the nneg flag *)
           match t1, x, t2 with
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_I sz_to =>
               if Pos.eqb sz_t sz_from && (sz_from <? sz_to)%positive
               then Conv_Pure (@DVALUE_I sz_to (repr (unsigned i1)))
-              else Conv_Illegal "ill-typed Zext"
+              else Conv_Illegal "i-to-i ill-typed Zext"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
               Conv_Pure (DVALUE_Poison t)
@@ -1004,7 +1005,7 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_I sz_to =>
               if Pos.eqb sz_t sz_from && (sz_from <? sz_to)%positive
               then Conv_Pure (@DVALUE_I sz_to (repr (signed i1)))
-              else Conv_Illegal "ill-typed Sext"
+              else Conv_Illegal "i-to-i ill-typed Sext"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
               Conv_Pure (DVALUE_Poison t)
@@ -1031,17 +1032,17 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
                  end
                else Conv_Illegal "unequal bitsize in cast"
 
-      | Uitofp nneg => (* TODO: nneg flag *)
+      | Uitofp nneg => (* TODO: handle the nneg flag *)
           match t1, x, t2 with
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_Float =>
               if Pos.eqb sz_t sz_from
               then Conv_Pure (DVALUE_Float (Float32.of_intu (repr (unsigned i1))))
-              else Conv_Illegal "ill-typed Uitofp"
+              else Conv_Illegal "i-to-float ill-typed Uitofp"
 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_Double =>
               if Pos.eqb sz_t sz_from
               then Conv_Pure (DVALUE_Double (Float.of_longu (repr (unsigned i1))))
-              else Conv_Illegal "ill-typed Uitofp"
+              else Conv_Illegal "i-to-double ill-typed Uitofp"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_Float
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_Double =>
@@ -1055,12 +1056,12 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_Float =>
               if Pos.eqb sz_t sz_from
               then Conv_Pure (DVALUE_Float (Float32.of_intu (repr (signed i1))))
-              else Conv_Illegal "ill-typed Sitofp"
+              else Conv_Illegal "i-to-float ill-typed Sitofp"
 
           | DTYPE_I sz_t, @DVALUE_I sz_from i1, DTYPE_Double =>
               if Pos.eqb sz_t sz_from
               then Conv_Pure (DVALUE_Double (Float.of_longu (repr (signed i1))))
-              else Conv_Illegal "ill-typed Sitofp"
+              else Conv_Illegal "i-to-double ill-typed Sitofp"
 
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_Float
           | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_Double =>
@@ -1108,7 +1109,7 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
                                (@DVALUE_I sz_to
                                   (@repr (@bit_int sz_to) (VInt_Bounded sz_to)
                                      (@unsigned (@bit_int sz_from) (VInt_Bounded sz_from) i1)))
-                           else Conv_Illegal "ill-typed Trunc"
+                           else Conv_Illegal "i-to-i ill-typed Trunc"
                        | _ => Conv_Illegal "ill-typed Trunc"
                        end
                    | @DVALUE_Poison t =>
@@ -1133,7 +1134,7 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
                                (@DVALUE_I sz_to
                                   (@repr (@bit_int sz_to) (VInt_Bounded sz_to)
                                      (@unsigned (@bit_int sz_from) (VInt_Bounded sz_from) i1)))
-                           else Conv_Illegal "ill-typed Zext"
+                           else Conv_Illegal "i-to-i ill-typed Zext"
                        | _ => Conv_Illegal "ill-typed Zext"
                        end
                    | @DVALUE_Poison t =>
@@ -1158,7 +1159,7 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
                                (@DVALUE_I sz_to
                                   (@repr (@bit_int sz_to) (VInt_Bounded sz_to)
                                      (@signed (@bit_int sz_from) (VInt_Bounded sz_from) i1)))
-                           else Conv_Illegal "ill-typed Sext"
+                           else Conv_Illegal "i-to-i ill-typed Sext"
                        | _ => Conv_Illegal "ill-typed Sext"
                        end
                    | @DVALUE_Poison t =>
@@ -1185,7 +1186,7 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
                                      (@repr (@bit_int 32) (VInt_Bounded 32)
                                         (@unsigned (@bit_int sz_from)
                                            (VInt_Bounded sz_from) i1))))
-                           else Conv_Illegal "ill-typed Uitofp"
+                           else Conv_Illegal "i-to-float ill-typed Uitofp"
                        | @DTYPE_Double =>
                            if (sz_t =? sz_from)%positive
                            then
@@ -1195,7 +1196,7 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
                                      (@repr (@bit_int 64) (VInt_Bounded 64)
                                         (@unsigned (@bit_int sz_from)
                                            (VInt_Bounded sz_from) i1))))
-                           else Conv_Illegal "ill-typed Uitofp"
+                           else Conv_Illegal "i-to-double ill-typed Uitofp"
                        | _ => Conv_Illegal "ill-typed Uitofp"
                        end
                    | @DVALUE_Poison t =>
@@ -1221,7 +1222,7 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
                                   (Float32.of_intu
                                      (@repr (@bit_int 32) (VInt_Bounded 32)
                                         (@signed (@bit_int sz_from) (VInt_Bounded sz_from) i1))))
-                           else Conv_Illegal "ill-typed Sitofp"
+                           else Conv_Illegal "i-to-float ill-typed Sitofp"
                        | @DTYPE_Double =>
                            if (sz_t =? sz_from)%positive
                            then
@@ -1230,7 +1231,7 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
                                   (Float.of_longu
                                      (@repr (@bit_int 64) (VInt_Bounded 64)
                                         (@signed (@bit_int sz_from) (VInt_Bounded sz_from) i1))))
-                           else Conv_Illegal "ill-typed Sitofp"
+                           else Conv_Illegal "i-to-double ill-typed Sitofp"
                        | _ => Conv_Illegal "ill-typed Sitofp"
                        end
                    | @DVALUE_Poison t =>

--- a/src/rocq/QC/ReprAST.v
+++ b/src/rocq/QC/ReprAST.v
@@ -88,6 +88,16 @@ Section ReprInstances.
 
   Local Open Scope string.
 
+  Definition repr_file_info (f : file_info) : string :=
+    "(mk_file_info " ++ """" ++ f.(filename) ++ """ "
+                     ++ (repr f.(start_line)) ++ " "
+                     ++ (repr f.(start_col))  ++ " "
+                     ++ (repr f.(end_line)) ++ " "
+                     ++ (repr f.(end_col)) ++ ")".
+  
+  #[global]
+   Instance reprFile_info : Repr file_info := {| repr := repr_file_info |}.
+  
   Fixpoint repr_dtyp (t : dtyp) : string :=
     match t with
     | DTYPE_I sz => "(DTYPE_I " ++ repr sz ++ ")"
@@ -343,6 +353,7 @@ Section ReprInstances.
     | METADATA_Node mds => "(METADATA_Node [" ++ (contents id (List.map repr_metadata mds)) ++ "])"
     | METADATA_Pair md1 md2 => "(METADATA_Pair " ++ (repr_metadata md1) ++ " " ++ (repr_metadata md2) ++ ")"
     | METADATA_Debug s1 s2 => "(METADATA_Debug " ++ repr s1 ++ ", " ++ repr s2 ++ ")"
+    | METADATA_File_info f => "(METADATA_File_info " ++ (repr f) ++ ")"
     end.
 
   #[global]

--- a/src/rocq/QC/ShowAST.v
+++ b/src/rocq/QC/ShowAST.v
@@ -726,6 +726,8 @@ Section ShowInstances.
                             @@ sd "}"
     | METADATA_Pair md1 md2 => dshow_metadata md1 @@ sd " " @@ dshow_metadata md2
     | METADATA_Debug ds s => sd ("!DI" ++ ds ++ "(" ++ s ++ ")")
+    (* File info never gets printed *)                                    
+    | METADATA_File_info _ => DList_empty
     end.
   
   #[global] Instance dshowExp : DShow (exp T) :=
@@ -1082,11 +1084,19 @@ tag ::= string constant
 
   #[global] Instance dshowInstrId : DShow instr_id
     := {| dshow := dshow_instr_id |}.
+
+  Fixpoint remove_file_info (md : list (metadata T)) : list (metadata T) :=
+    match md with
+    | [] => []
+    | m::rest => if is_METADATA_File_info m then remove_file_info rest else
+                 m::(remove_file_info rest)
+    end.
   
   Definition dshow_metadata_suffix (md : list (metadata T)) : DString :=
-    match md with
+    let md' := remove_file_info md in
+    match md' with
     | [] => DList_empty
-    | _ => DList_join (map (fun m => sd ", " @@ (dshow_metadata m)) md)
+    | _ => DList_join (map (fun m => sd ", " @@ (dshow_metadata m)) md')
     end.
   
   Definition dshow_id_instr_metadata (inst : instr_id * instr T * list (metadata T)) : DString :=

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -194,7 +194,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
      Expressions are denoted as itrees that return a [uvalue].
    *)
 
-  Fixpoint denote_exp'
+  Fixpoint denote_exp' 
            (top:option dtyp) (o:exp dtyp) {struct o} : itree exp_E uvalue :=
     let eval_texp '(dt,ex) := denote_exp' (Some dt) ex
     in
@@ -206,7 +206,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
     | EXP_Integer x =>
       match top with
-      | None                => raise "denote_exp given untyped EXP_Integer"
+      | None                => raise ("denote_exp given untyped EXP_Integer")
       | Some (DTYPE_I bits) => fmap dvalue_to_uvalue (coerce_integer_to_int (Some bits) x)
       | Some DTYPE_IPTR     => fmap dvalue_to_uvalue (coerce_integer_to_int None x)
       | Some typ            => raise ("bad type for constant int: " ++ to_string typ)
@@ -214,24 +214,24 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
     | EXP_Float x =>
       match top with
-      | None              => raise "denote_exp given untyped EXP_Float"
+      | None              => raise ("denote_exp given untyped EXP_Float")
       | Some DTYPE_Float  => ret (UVALUE_Float x)
-      | _                 => raise "bad type for constant float"
+      | _                 => raise ("bad type for constant float")
       end
 
     | EXP_Double x =>
       match top with
-      | None              => raise "denote_exp given untyped EXP_Double"
+      | None              => raise ("denote_exp given untyped EXP_Double")
       | Some DTYPE_Double => ret (UVALUE_Double x)
-      | _                 => raise "bad type for constant double"
+      | _                 => raise ("bad type for constant double")
       end
 
     | EXP_Hex x =>
       match top with
-      | None              => raise "denote_exp given untyped EXP_Hex"
+      | None              => raise ("denote_exp given untyped EXP_Hex")
       | Some DTYPE_Float  => ret (UVALUE_Float (Float32.of_double x))
       | Some DTYPE_Double => ret (UVALUE_Double x)
-      | _                 => raise "bad type for constant hex float"
+      | _                 => raise ("bad type for constant hex float")
       end
 
     | EXP_Bool b =>
@@ -244,7 +244,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
     | EXP_Zero_initializer =>
       match top with
-      | None   => raise "denote_exp given untyped EXP_Zero_initializer"
+      | None   => raise ("denote_exp given untyped EXP_Zero_initializer")
       | Some t => lift_err ret (fmap dvalue_to_uvalue (dv_zero_initializer t))
       end
 
@@ -254,13 +254,13 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
     | EXP_Undef =>
       match top with
-      | None   => raise "denote_exp given untyped EXP_Undef"
+      | None   => raise ("denote_exp given untyped EXP_Undef")
       | Some t => ret (UVALUE_Undef t)
       end
 
     | EXP_Poison =>
       match top with
-      | None   => raise "denote_exp given untyped EXP_Poison"
+      | None   => raise ("denote_exp given untyped EXP_Poison")
       | Some t => ret (UVALUE_Poison t)
       end
 
@@ -273,11 +273,11 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     (* Option 2: do a little bit of typechecking *)
     | EXP_Packed_struct es =>
       match top with
-      | None => raise "denote_exp given untyped EXP_Struct"
+      | None => raise ("denote_exp given untyped EXP_Struct")
       | Some (DTYPE_Packed_struct _) =>
         vs <- map_monad eval_texp es ;;
         ret (UVALUE_Packed_struct vs)
-      | _ => raise "bad type for VALUE_Packed_struct"
+      | _ => raise ("bad type for VALUE_Packed_struct")
       end
 
     | EXP_Array t es =>
@@ -371,6 +371,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
         | METADATA_Node _ => ret UVALUE_None
         | METADATA_Pair _ _ => ret UVALUE_None
         | METADATA_Debug _ _ => ret UVALUE_None
+        | METADATA_File_info _ => ret UVALUE_None
         end
     end.
 
@@ -378,7 +379,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     := uv <- denote_exp' top o;;
        concretize_if_no_undef_or_poison uv.
 
-  Arguments denote_exp _ : simpl nomatch.
+  Arguments denote_exp _ _ : simpl nomatch.
 
   Definition denote_op (o:exp dtyp) : itree exp_E uvalue :=
     denote_exp None o.
@@ -474,11 +475,11 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
             let ret_uv := UVALUE_Struct [loaded_uv; @UVALUE_I 1 zero] in
             trigger (LocalWrite id ret_uv);;
             ret tt
-      | DVALUE_Poison dt => raiseUB "comparing poison in atomiccmpxchg."
-      | _ => raise "Br got non-bool value"
+      | DVALUE_Poison dt => raiseUB ("comparing poison in atomiccmpxchg.")
+      | _ => raise ("Br got non-bool value")
       end
     else 
-      raise "Ill-typed atomiccmpxchg".
+      raise ("Ill-typed atomiccmpxchg").
 
 
   (* Implement the atomic modify operations in terms of Vellvm uvalues.
@@ -514,7 +515,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
             ret (UVALUE_IBinop (Sub false false)
                    (@UVALUE_I sz (@repr (@bit_int sz) _ (@max_unsigned (@bit_int sz) _)))
                    (UVALUE_IBinop And pv val))            
-        | _ => raise "atomicrmw nand of non-integer value"
+        | _ => raise ("atomicrmw nand of non-integer value")
         end
     | Afadd =>
         (* fadd: *ptr = *ptr + val (using floating point arithmetic) *)
@@ -533,7 +534,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     | Auinc_wrap
     | Audec_wrap
     | Ausub_cond
-    | Ausub_sat => raise "Unsupported atomicrwm operation"
+    | Ausub_sat => raise ("Unsupported atomicrwm operation")
     end.
     
   
@@ -564,6 +565,14 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
   Definition denote_instr
     (i: (instr_id * instr dtyp * list (metadata dtyp))) (varargs : option ADDR.addr) : itree instr_E unit :=
     let '(i, md) := i in
+    (* The following two lines set up file location information. *)
+    (* extract it from the metadata: *)
+    let err_loc := location_error_string md in
+    (* imperatively set the flag for printing of exceptions
+       [set_loc] extracts in such a way as to change the behavior of [print_msg]
+     *)
+    let bogus := set_loc err_loc in
+    let err_loc := (bogus ++ err_loc) in
     match i with
     (* Pure operations *)
 
@@ -617,12 +626,12 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
       (* Store addresses must be unique *)
       da <- concretize_or_pick_unique ua ;;
       match da with
-      | DVALUE_Poison dt => raiseUB "Store to poisoned address."
+      | DVALUE_Poison dt => raiseUB (err_loc ++ ": Store to poisoned address.")
       | _ => trigger (Store dt da uv)
       end;;
       ret tt
 
-    | (_, INSTR_Store _ _ _) => raise "ILL-FORMED itree ERROR: Store to non-void ID"
+    | (_, INSTR_Store _ _ _) => raise (err_loc ++ ": ILL-FORMED itree ERROR: Store to non-void ID")
 
     (* Call *)
     (* TODO: technically operand bundles can affect semantics *)                                     
@@ -639,11 +648,11 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
                 ua <- translate exp_to_instr (denote_exp (Some t) e);;
                 da <- concretize_or_pick_unique ua;;
                 match da with
-                | DVALUE_Poison dt => raiseUB "Store to poisoned address."
+                | DVALUE_Poison dt => raiseUB ("Store to poisoned address.")
                 | _ => trigger (Store DTYPE_Pointer da (UVALUE_Addr varargs));;
                       ret UVALUE_None
                 end
-            | _, _ => raise "va_start invalid arguments"
+            | _, _ => raise (err_loc ++ ": va_start invalid arguments")
             end
           else
             if String.eqb s "llvm.va_copy"
@@ -657,7 +666,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
                   vargs <- trigger (Load DTYPE_Pointer dsrc);;
                   trigger (Store DTYPE_Pointer ddest vargs);;
                   ret UVALUE_None
-              | _ => raise "va_copy invalid arguments"
+              | _ => raise (err_loc ++ ": va_copy invalid arguments")
               end
             else
               if String.eqb s "llvm.va_end"
@@ -712,9 +721,9 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     | (_, INSTR_Fence _ _) => ret tt
                        
     (* Currently unhandled itree instructions *)
-    | (_, INSTR_LandingPad _ _ _) => raise "Unsupported INSTR_Landingpad"
+    | (_, INSTR_LandingPad _ _ _) => raise (err_loc ++ ": Unsupported INSTR_Landingpad")
     (* Error states *)
-    | (_, _) => raise "ID / Instr mismatch void / non-void"
+    | (_, _) => raise (err_loc ++ ": ID / Instr mismatch void / non-void")
     end.
 
   (* Computes the label to be returned by a switch terminator, after evaluation of values
@@ -744,7 +753,10 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
          or jumps to a new [block_id]. *)
 
   Definition denote_terminator (trm: (instr_id * terminator dtyp * list (metadata dtyp))): itree instr_E (block_id + uvalue) :=
-    let '(iid, t, _) := trm in
+    let '(iid, t, md) := trm in
+    let err_loc := location_error_string md in
+    let bogus := set_loc err_loc in
+    let err_loc := (bogus ++ err_loc) in
     match t with
 
     | TERM_Ret (dt, op) =>
@@ -763,8 +775,8 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
           ret (inl br1)
         else
           ret (inl br2)
-      | DVALUE_Poison dt => raiseUB "Branching on poison."
-      | _ => raise "Br got non-bool value"
+      | DVALUE_Poison dt => raiseUB (err_loc ++ ": Branching on poison.")
+      | _ => raise (err_loc ++ ": Br got non-bool value")
       end
 
     | TERM_Br_1 br => ret (inl br)
@@ -774,7 +786,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
       (* Selection on [undef] is UB *)
       selector <- concretize_or_pick_unique uselector;;
       if dvalue_is_poison selector
-      then raiseUB "Switching on poison."
+      then raiseUB (err_loc ++ ": Switching on poison.")
       else (* We evaluate all the selectors. Note that they are enforced to be constants, we could reflect this in the syntax and avoid this step *)
         switches <- map_monad
                      (fun '((TInt_Literal sz x),id) =>
@@ -783,7 +795,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
                      dests;;
         lift_err (fun b => ret (inl b)) (select_switch selector default_br switches)
 
-    | TERM_Unreachable => raiseUB "IMPOSSIBLE: unreachable in reachable position"
+    | TERM_Unreachable => raiseUB (err_loc ++ ": IMPOSSIBLE: unreachable in reachable position")
 
       (* TODO: technically operand bundles can affect the semantics of invoke *)
     | TERM_Invoke (dt, fnptrval) args to_label unwind_label anns _ =>
@@ -809,7 +821,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
       raiseLLVM exn
 
     (* Currently unhandled VIR terminators *)
-    | TERM_IndirectBr _ _ => raise "Unsupport itree terminator"
+    | TERM_IndirectBr _ _ => raise (err_loc ++ ": Unsupport itree terminator")
     end.
 
   (* Denoting a list of instruction simply binds the trees together *)
@@ -817,12 +829,15 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     map_monad_ (fun i => denote_instr i varargs) c.
 
   Definition denote_phi (bid_from : block_id) (id_p : local_id * phi dtyp * (list (metadata dtyp))) : itree exp_E (local_id * uvalue) :=
-    let '(id, Phi dt args, _) := id_p in
+    let '(id, Phi dt args, md) := id_p in
+    let err_loc := location_error_string md in
+    let bogus := set_loc err_loc in
+    let err_loc := (bogus ++ err_loc) in
     match assoc bid_from args with
     | Some op =>
       uv <- denote_exp (Some dt) op ;;
       ret (id,uv)
-    | None => raise ("jump: phi node doesn't include block ")
+    | None => raise (err_loc ++ ": jump: phi node doesn't include block ")
     end.
 
   Definition denote_phis (bid_from: block_id) (phis: list (local_id * phi dtyp * (list (metadata dtyp)))): itree instr_E unit :=

--- a/src/rocq/Semantics/InfiniteToFinite.v
+++ b/src/rocq/Semantics/InfiniteToFinite.v
@@ -26933,11 +26933,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
               2: {
                 pstep; red; cbn.
-                change ((VisF (subevent void (ThrowOOM (print_msg "")))
+                change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
                                 (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
-                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
                                                                                     (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
@@ -27092,11 +27092,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
               2: {
                 pstep; red; cbn.
-                change ((VisF (subevent void (ThrowOOM (print_msg "")))
+                change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
                                 (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
-                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
                                                                                     (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
@@ -27310,11 +27310,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
               2: {
                 pstep; red; cbn.
-                change ((VisF (subevent void (ThrowOOM (print_msg "")))
+                change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
                                 (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
-                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
                                                                                     (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
@@ -27511,11 +27511,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
               2: {
                 pstep; red; cbn.
-                change ((VisF (subevent void (ThrowOOM (print_msg "")))
+                change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
                                 (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
-                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
                                                                                     (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
@@ -27858,11 +27858,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
               2: {
                 pstep; red; cbn.
-                change ((VisF (subevent void (ThrowOOM (print_msg "")))
+                change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
                                 (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
-                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
                                                                                     (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
@@ -28054,18 +28054,18 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                            (fun x : void =>
                               ITree.subst
                                 (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
-                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
                                                                                     (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
                                                                                                   end) (Ret x)))).
-              change (VisF (subevent void (Throw (print_msg "")))
+              change (VisF (subevent void (Throw tt))
        (fun x : void =>
         ITree.subst
           (fun v1 : void => match v1 return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
                          end) (Ret x)))
                 with
-                (observe (Vis (subevent void (Throw (print_msg "")))
+                (observe (Vis (subevent void (Throw tt))
        (fun x : void =>
         ITree.subst
           (fun v1 : void => match v1 return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
@@ -28209,11 +28209,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
               2: {
                 pstep; red; cbn.
-                change ((VisF (subevent void (ThrowOOM (print_msg "")))
+                change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
                                 (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
-                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+                                              end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
                                                                                     (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
@@ -29233,11 +29233,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           }
           2: {
             pstep; red; cbn.
-            change ((VisF (subevent void (ThrowOOM (print_msg "")))
+            change ((VisF (subevent void (ThrowOOM tt))
                        (fun x : void =>
                           ITree.subst
                             (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
-                                          end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+                                          end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                            (fun x : void =>
                                                                               ITree.subst
                                                                                 (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with

--- a/src/rocq/Semantics/InfiniteToFinite/LangRefine.v
+++ b/src/rocq/Semantics/InfiniteToFinite/LangRefine.v
@@ -20078,7 +20078,8 @@ Qed.
               | LLVMAst.METADATA_Id _ 
               | LLVMAst.METADATA_Node _
               | LLVMAst.METADATA_Pair _ _
-              | LLVMAst.METADATA_Debug _ _ => True
+              | LLVMAst.METADATA_Debug _ _
+              | LLVMAst.METADATA_File_info _ => True
               | LLVMAst.METADATA_Const (t, v) =>
                   orutt exp_E_refine_strict
                     exp_E_res_refine_strict uvalue_refine_strict
@@ -20531,6 +20532,7 @@ Qed.
     - destruct te.
       simpl in IHe.
       apply IHe.
+    - auto.
     - auto.
     - auto.
     - auto.

--- a/src/rocq/Semantics/InterpretationStack.v
+++ b/src/rocq/Semantics/InterpretationStack.v
@@ -26,7 +26,8 @@ From Vellvm.Handlers Require Export
      UndefinedBehaviour.
 
 From Stdlib Require Import
-  Morphisms.
+  Morphisms
+  String.
 
 (* end hide *)
 

--- a/src/rocq/Semantics/LLVMEvents.v
+++ b/src/rocq/Semantics/LLVMEvents.v
@@ -89,9 +89,19 @@ Set Contextual Implicit.
   Definition raiseLLVM {E EXC} {A} `{LLVMExcE EXC -< E} (e : EXC) : itree E A :=
     v <- trigger (LLVMExc e);; match v: void with end.
 
-  (* This function can be replaced with print_string during extraction
-     to print the error messages of Throw and (indirectly) ThrowUB. *)
-  Definition print_msg (msg : string) : unit := tt.
+  (* See src/ml/Extract.v for the special handling of these operation. *)
+  (* This function can be replaced with print operations  during extraction
+     to print the error messages of Throw and (indirectly) ThrowUB.
+      - set_loc imperatively sets a string that will be prefixed onto the msg
+        it returns the empty string, but we need to use its result to
+        force extraction 
+      - print_msg call `print_string`
+   *)
+  Definition printer_object : (string -> string) * (string -> unit) :=
+    (fun (_:string) => "", fun (_:string) => tt).
+
+  Definition set_loc : string -> string := (fst printer_object).
+  Definition print_msg : string -> unit := (snd printer_object).
 
   (* Undefined behaviour carries a string. *)
   Variant UBE : Type -> Type :=
@@ -112,7 +122,7 @@ Set Contextual Implicit.
   Variant OOME : Type -> Type :=
   | ThrowOOM : unit -> OOME void.
 
-  (** Since the output type of [ThrowUB] is [void], we can make it an action
+  (** Since the output type of [ThrowOOM] is [void], we can make it an action
     with any return type. *)
   Definition raiseOOM {E : Type -> Type} `{OOME -< E} {X}
              (e : string)

--- a/src/rocq/Semantics/LLVMEvents.v
+++ b/src/rocq/Semantics/LLVMEvents.v
@@ -97,11 +97,18 @@ Set Contextual Implicit.
         force extraction 
       - print_msg call `print_string`
    *)
-  Definition printer_object : (string -> string) * (string -> unit) :=
-    (fun (_:string) => "", fun (_:string) => tt).
-
-  Definition set_loc : string -> string := (fst printer_object).
-  Definition print_msg : string -> unit := (snd printer_object).
+  Record printer := mk_printer {
+      printer_set_loc : string -> string ;
+      printer_print_msg : string -> unit ;
+      printer_get_loc : unit -> string ;
+    }.
+  
+  Definition printer_object : printer :=
+    mk_printer (fun (_:string) => "") (fun (_:string) => tt) (fun (_:unit) => "").
+  
+  Definition set_loc : string -> string := printer_object.(printer_set_loc).
+  Definition print_msg : string -> unit := printer_object.(printer_print_msg).
+  Definition get_loc : unit -> string := printer_object.(printer_get_loc).
 
   (* Undefined behaviour carries a string. *)
   Variant UBE : Type -> Type :=

--- a/src/rocq/Syntax/AstLib.v
+++ b/src/rocq/Syntax/AstLib.v
@@ -379,7 +379,8 @@ Section ExpInd.
   Hypothesis IH_METADATA_Node : forall (ms:list (metadata T)), (forall m, In m ms -> Q m) -> Q (METADATA_Node ms).
   Hypothesis IH_METADATA_Pair : forall (m1 m2:metadata T), Q m1 -> Q m2 -> Q (METADATA_Pair m1 m2).
   Hypothesis IH_METADATA_Debug : forall (s t:string), Q (METADATA_Debug s t).
-
+  Hypothesis IH_METADATA_File_info : forall (f:file_info), Q (METADATA_File_info f).
+  
   Lemma exp_ind : forall (v:exp T), P v.
 Proof.    
 refine(  
@@ -425,7 +426,8 @@ with F0 (m : metadata T) : Q m :=
   | METADATA_Node mds => _
   | METADATA_Pair md1 md2 => IH_METADATA_Pair md1 md2 (F0 md1) (F0 md2)
   | METADATA_Debug DIstr contents => IH_METADATA_Debug DIstr contents
-  end
+  | METADATA_File_info f => IH_METADATA_File_info f
+    end
 for
 F).
 - apply IH_Cstring.
@@ -510,6 +512,7 @@ with F0 (m : metadata T) : Q m :=
   | METADATA_Node mds => _
   | METADATA_Pair md1 md2 => IH_METADATA_Pair md1 md2 (F0 md1) (F0 md2)                          
   | METADATA_Debug DIstr contents => IH_METADATA_Debug DIstr contents
+  | METADATA_File_info f => IH_METADATA_File_info f
   end
 for
 F0).
@@ -837,3 +840,33 @@ Proof using.
   intros * EQ; inv EQ; auto.
 Qed.
 
+(* File information - line numbers and error messages.
+   The parser associates a METADATA_File_info value with every instruction of the AST.
+ *)
+
+Definition is_METADATA_File_info {T} (m:metadata T) : option file_info :=
+  match m with
+  | METADATA_File_info f => Some f
+  | _ => None
+  end.
+
+Fixpoint get_file_info {T} (l : list (metadata T)) : option file_info :=
+  match l with
+  | [] => None
+  | m::rest => match is_METADATA_File_info m with
+             | Some f => Some f
+             | None => get_file_info rest
+             end
+  end.
+
+Definition no_loc_string : string := "[??:??.??-??.??]".
+
+Definition location_string (fo : option file_info) : string :=
+  match fo with
+  | None => no_loc_string
+  | Some f => "[" ++ f.(filename) ++ ":" ++ (show f.(start_line)) ++ "." ++ (show f.(start_col))
+                 ++ "-" ++ (show f.(end_line)) ++ "." ++ (show f.(end_col)) ++ "]"                 
+  end.
+
+Definition location_error_string {T} (l : list (metadata T)) : string :=
+  location_string (get_file_info l).

--- a/src/rocq/Syntax/DynamicTypes.v
+++ b/src/rocq/Syntax/DynamicTypes.v
@@ -323,6 +323,32 @@ Section hiding_notation.
   #[global] Instance serialize_dtyp : Serialize dtyp := serialize_dtyp'.
 End hiding_notation.
 
+  Fixpoint dtyp_to_string (dt:dtyp) : string :=
+    match dt with
+    | DTYPE_I sz     => ("i" ++ to_string (Npos sz))%string
+    | DTYPE_IPTR     => ("iptr")%string
+    | DTYPE_Pointer  => "ptr"
+    | DTYPE_Void     => "dvoid"
+    | DTYPE_Half     => "half"
+    | DTYPE_Float    => "float"
+    | DTYPE_Double   => "double"
+    | DTYPE_X86_fp80 => "x86_fp80"
+    | DTYPE_Fp128    => "fp128"
+    | DTYPE_Ppc_fp128 => "ppc_fp128"
+    | DTYPE_Metadata  => "metadata"
+    | DTYPE_X86_mmx   => "x86_mmx"
+    | DTYPE_Array sz t
+      => "[" ++ to_string sz ++ " x " ++  dtyp_to_string t ++ "]"%string
+    | DTYPE_Struct fields
+      => "{ [Struct Field Types Elided] }"
+    | DTYPE_Packed_struct fields
+      => "packed{ [Struct Field Types Elided] }"
+    | DTYPE_Opaque => "opaque"
+    | DTYPE_Vector sz t
+      => "<" ++ to_string sz ++ " x " ++  dtyp_to_string t ++ ">"%string                   
+    end.
+
+
 (* TODO: This probably should live somewhere else... *)
 #[refine]#[local] Instance Decidable_eq_N : forall (x y : N), Decidable (eq x y) := {
     Decidable_witness := N.eqb x y

--- a/src/rocq/Syntax/LLVMAst.v
+++ b/src/rocq/Syntax/LLVMAst.v
@@ -34,6 +34,24 @@ Definition int_ast := Z.
 Definition float := Floats.float.  (* 64-bit floating point value *)
 Definition float32 := Floats.float32.
 
+(* File Information - this is used by the Vellvm-only 
+   METADATA_File_info "virtual" metadata value to record source information.
+   Every phi, instr, and terminator is annotated with a file_info value provided
+   by the parser.
+   - These are never pretty printed via "show"
+   - They *are* reflected via "repr"
+   - They can be used to generate error messages: see examples in Denotation.v
+   - See AstLib for some utility functions (especially [location_error_string])
+ *)
+Record file_info : Set :=
+  mk_file_info {
+      filename : string ;
+      start_line : int_ast ;
+      start_col  : int_ast ;
+      end_line   : int_ast ;
+      end_col    : int_ast ;
+    }.
+
 
 Variant raw_id : Set :=
 | Name (s:string)     (* Named identifiers are strings: %argc, %val, %x, @foo, @bar etc. *)
@@ -427,6 +445,11 @@ with metadata : Set :=
  *)
 | METADATA_Debug (DIstr:string) (contents:string)
 
+(* SAZ: hijack the metadata to add Vellvm line numbers - this will be added by the parser but
+   elided in the prettyprinter.
+   We can use this to improve the error messages by providing more context.
+ *)
+| METADATA_File_info (finfo:file_info)
 .
 Set Elimination Schemes.
 

--- a/src/rocq/Syntax/Traversal.v
+++ b/src/rocq/Syntax/Traversal.v
@@ -171,6 +171,7 @@ Section Endo.
         | METADATA_Node mds => METADATA_Node (List.map endo_metadata mds)
         | METADATA_Pair md1 md2 => METADATA_Pair (endo_metadata md1) (endo_metadata md2)                                            
         | METADATA_Debug sd d => METADATA_Debug (endo sd) (endo d)
+        | METADATA_File_info f => METADATA_File_info f
         end.
 
     
@@ -570,6 +571,7 @@ Section TFunctor.
         | METADATA_Node mds => METADATA_Node (map (ft_metadata U V f) mds)
         | METADATA_Pair md1 md2 => METADATA_Pair (ft_metadata U V f md1) (ft_metadata U V f md2)         
         | METADATA_Debug ds s => METADATA_Debug ds s
+        | METADATA_File_info f => METADATA_File_info f
         end.
           
                

--- a/src/rocq/Theory/OOMRefinementExamples.v
+++ b/src/rocq/Theory/OOMRefinementExamples.v
@@ -667,7 +667,7 @@ Module Infinite.
           * pstep; red; cbn.
 
             change
-              (VisF (subevent void (ThrowOOM (print_msg "")))
+              (VisF (subevent void (ThrowOOM tt))
                  (fun x : void =>
                     match
                       x
@@ -833,7 +833,7 @@ Module Infinite.
           * reflexivity.
           * pstep; red; cbn.
             change
-              (VisF (subevent void (ThrowOOM (print_msg "")))
+              (VisF (subevent void (ThrowOOM tt))
                  (fun x : void =>
                     match
                       x
@@ -843,7 +843,7 @@ Module Infinite.
                          (MMEP.MMSP.MemState * (store_id * (stack_frame uvalue * Stack.stack uvalue * res_L1))))
                     with
                     end)) with
-              (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+              (observe (Vis (subevent void (ThrowOOM tt))
                           (fun x : void =>
                              match
                                x
@@ -1049,11 +1049,11 @@ Module Infinite.
     red in H0. cbn in *. rewrite itree_eta, (itree_eta t3).
     do 2 red.
     punfold H0. red in H0; cbn in H0.
-    remember (VisF (subevent void (ThrowOOM (print_msg oom_msg)))
+    remember (VisF (subevent void (ThrowOOM tt))
             (fun x : void =>
              ITree.bind match x return (itree _ R) with
                         end (fun x0 : R => k1 x0))).
-    remember (VisF (subevent void (ThrowOOM (print_msg oom_msg)))
+    remember (VisF (subevent void (ThrowOOM tt))
            (fun x : void =>
             match
               x
@@ -1173,7 +1173,7 @@ Module Infinite.
           * reflexivity.
           * pstep; red; cbn.
             change
-              (VisF (subevent void (ThrowOOM (print_msg "")))
+              (VisF (subevent void (ThrowOOM tt))
                  (fun x0 : void =>
                     match
                       x0
@@ -1183,7 +1183,7 @@ Module Infinite.
                          (MMEP.MMSP.MemState * (store_id * (stack_frame uvalue * Stack.stack uvalue * res_L1))))
                     with
                     end)) with
-              (observe (Vis (subevent void (ThrowOOM (print_msg "")))
+              (observe (Vis (subevent void (ThrowOOM tt))
                           (fun x0 : void =>
                              match
                                x0
@@ -1619,11 +1619,11 @@ Module Finite.
     red in H0. cbn in *. rewrite itree_eta, (itree_eta t3).
     do 2 red.
     punfold H0. red in H0; cbn in H0.
-    remember (VisF (subevent void (ThrowOOM (print_msg oom_msg)))
+    remember (VisF (subevent void (ThrowOOM tt))
             (fun x : void =>
              ITree.bind match x return (itree _ R) with
                         end (fun x0 : R => k1 x0))).
-    remember (VisF (subevent void (ThrowOOM (print_msg oom_msg)))
+    remember (VisF (subevent void (ThrowOOM tt))
            (fun x : void =>
             match
               x


### PR DESCRIPTION
One more tweak: this makes `-debug` also print the locations of each instruction as it is executed.  Very helpful for debugging infinite loops.