### PR TITLE
add support for parsing range annotations

### DIFF
--- a/src/ml/libvellvm/llvm_lexer.mll
+++ b/src/ml/libvellvm/llvm_lexer.mll
@@ -404,6 +404,7 @@
   ("poison", KW_POISON);
   ("zeroinitializer" , KW_ZEROINITIALIZER);
   ("c" , KW_C);
+  ("range", KW_RANGE);
 
   (* metadata *)
 (*  

--- a/src/ml/libvellvm/llvm_parser.mly
+++ b/src/ml/libvellvm/llvm_parser.mly
@@ -462,6 +462,8 @@ let mk_metadata (m : ('a metadata list option)) : 'a metadata list =
 %token KW_ACQ_REL
 %token KW_SEQ_CST
 
+%token KW_RANGE
+
 %token<string> KW_UNKNOWN
 
 (* METADATA constants *)
@@ -525,6 +527,7 @@ metadata_id:
   | KW_NONNULL                   { METADATA_Id (Name (str "nonnull")) }
   | KW_NOUNDEF                   { METADATA_Id (Name (str "noundef")) }
   | KW_ALIGN                     { METADATA_Id (Name (str "align")) }
+  | KW_RANGE                     { METADATA_Id (Name (str "range")) }
   | s=STRING                     { METADATA_Id (Name (str ("\"" ^ s ^ "\""))) } (* preserve quotes *)
   | mid=INTEGER                  { METADATA_Id (Anon mid) }
   | mid=KW_UNKNOWN               { METADATA_Id (Name (str mid)) }
@@ -1188,6 +1191,7 @@ param_attr:
   | KW_WRITEONLY                         { PARAMATTR_Writeonly                 }
   | KW_WRITABLE                          { PARAMATTR_Writable                  }
   | KW_DEADONUNWIND                      { PARAMATTR_Dead_on_unwind            }
+  | KW_RANGE LPAREN t=typ a=INTEGER COMMA b=INTEGER RPAREN { PARAMATTR_Range(t, a, b) }
 
  (* TODO: This loses information when metadata is used as an argument *)
 call_arg:

--- a/src/rocq/QC/ReprAST.v
+++ b/src/rocq/QC/ReprAST.v
@@ -417,6 +417,7 @@ Section ReprInstances.
     | PARAMATTR_Writeonly => "PARAMATTR_Writeonly"
     | PARAMATTR_Writable => "PARAMATTR_Writable"
     | PARAMATTR_Dead_on_unwind => "PARAMATTR_Dead_on_unwind"
+    | PARAMATTR_Range t a b => "(PARAMATTR_Range " ++ repr t ++ " " ++ repr a ++ " " ++ repr b ++ ")"
     end.
 
   #[global]

--- a/src/rocq/QC/ShowAST.v
+++ b/src/rocq/QC/ShowAST.v
@@ -281,6 +281,10 @@ Section ShowInstances.
     | PARAMATTR_Writeonly => sd "writeonly"
     | PARAMATTR_Writable => sd "writable"
     | PARAMATTR_Dead_on_unwind => sd "dead_on_unwind"
+    | PARAMATTR_Range t a b => sd "range(" @@ sd (show t)
+                                          @@ sd " "
+                                          @@ sd (show a) @@ sd ", " 
+                                          @@ sd (show b) @@ sd ")"
     end.
 
   #[global] Instance dshowParamAttr : DShow param_attr

--- a/src/rocq/Syntax/LLVMAst.v
+++ b/src/rocq/Syntax/LLVMAst.v
@@ -172,7 +172,7 @@ Variant param_attr : Set :=
 | PARAMATTR_Writeonly
 | PARAMATTR_Writable
 | PARAMATTR_Dead_on_unwind      
-(* | PARAMATTR_Range (t : typ) a b (* MISSING: range qualifiers *) *)    
+| PARAMATTR_Range (t : typ) (a b : int_ast)
 .
 
 Variant frame_pointer_val : Set :=

--- a/tests/ll/range.ll
+++ b/tests/ll/range.ll
@@ -1,0 +1,12 @@
+define i64 @foo(i64 noundef range(i64 1, 50) %x) {
+  ret i64 %x
+}
+
+define i64 @main(i64 %argc, i8** %arcv) {
+  %1 = call i64 @foo(i64 noundef range(i64 1, 10) 8)
+  ret i64 %1
+}
+
+; ASSERT EQ: i64 6 = call i64 @foo(i64 6)
+; ASSERT POISON: call i64 @foo(i64 0)
+; ASSERT POISON: call i64 @foo(i64 500)


### PR DESCRIPTION
This is parsing-only support of the range annotations.  We would have to adapt the call semantics to implement the desired poison behavior.