### PR TITLE
mark fence as a void instr

### DIFF
--- a/src/rocq/Syntax/AstLib.v
+++ b/src/rocq/Syntax/AstLib.v
@@ -829,6 +829,7 @@ Definition is_void_instr (i:instr typ) : bool :=
   match i with
   | INSTR_Comment _ => true
   | INSTR_Call (t,_) _ _ _ => is_void_typ t
+  | INSTR_Fence _ _ => true
   | INSTR_Store _ _ _ => true
   | _ => false
   end.


### PR DESCRIPTION
I was running into an issue where the following code:
```
  %0 = atomicrmw sub ptr %_6.i.i.i, i64 1 release, align 8, !noalias !1903
  %1 = icmp eq i64 %0, 1
  br i1 %1, label %bb2.i.i.i, label %bb4.i

bb2.i.i.i:                                        ; preds = %start
  fence acquire
; invoke alloc::sync::Arc<T,A>::drop_slow
  invoke void @"_ZN5alloc4sync16Arc$LT$T$C$A$GT$9drop_slow17h67b164422b71dee0E"(ptr noalias noundef nonnull align 8 dereferenceable(40) %_1)
          to label %bb4.i unwind label %cleanup.i

cleanup.i:                                        ; preds = %bb2.i.i.i
  %2 = landingpad { ptr, i32 }
          cleanup
```

was raising an error:
```
Fatal error: exception ParseUtil.InvalidAnonymousId("Unexpected sequential id: expected >= 3 but found 2")
```

After some investigation, it seems the problem was the fence instruction incorrectly claiming `%2`, since it was not marked as a "void instr".

The above code is accepted with this change.