### PR TITLE
Module refactor

### DIFF
--- a/src/fix-extraction.sh
+++ b/src/fix-extraction.sh
@@ -18,41 +18,41 @@ function replace () {
 for f in "${FILENAMES[@]}"
 do
     # BigIntptr mismatches
-    replace "s/MemoryModelImplementation.LLVMParamsBigIntptr.Events.DV/LP.Events.DV/g" $f
-    replace "s/LLVMParamsBigIntptr.Events.DV/LP.Events.DV/g" $f
+    replace "s/MemoryModelImplementation.LLVMParamsBigIntptr.DV/LP.DV/g" $f
+    replace "s/LLVMParamsBigIntptr.DV/LP.DV/g" $f
     replace "s/MemoryModelImplementation.LLVMParamsBigIntptr.ADDR.addr/LP.ADDR.addr/g" $f
     replace "s/LLVMParamsBigIntptr.ADDR.addr/LP.ADDR.addr/g" $f
     replace "s/MemoryModelImplementation.LLVMParamsBigIntptr.IP/LP.IP/g" $f
     replace "s/LLVMParamsBigIntptr.IP/LP.IP/g" $f
     replace "s/MemoryModelImplementation.LLVMParamsBigIntptr.PROV/LP.PROV/g" $f
     replace "s/LLVMParamsBigIntptr.PROV/LP.PROV/g" $f
-    replace "s/MemoryModelImplementation.LLVMParamsBigIntptr.Events/LP.Events/g" $f
-    replace "s/LLVMParamsBigIntptr.Events/LP.Events/g" $f
-    replace "s/^(\s*)type dvalue_byte = MemoryBigIntptr.CP.CONCBASE.dvalue_byte =\n(\s*)\| DVALUE_ExtractByte of LP.Events.DV.dvalue/\1type dvalue_byte = MemoryBigIntptr.CP.CONCBASE.dvalue_byte =\n\2\| DVALUE_ExtractByte of LLVMParamsBigIntptr.Events.DV.dvalue/gm" $f
+    # replace "s/MemoryModelImplementation.LLVMParamsBigIntptr.Events/LP.Events/g" $f
+    # replace "s/LLVMParamsBigIntptr.Events/LP.Events/g" $f
+    # replace "s/^(\s*)type dvalue_byte = MemoryBigIntptr.CP.CONCBASE.dvalue_byte =\n(\s*)\| DVALUE_ExtractByte of LP.Events.DV.dvalue/\1type dvalue_byte = MemoryBigIntptr.CP.CONCBASE.dvalue_byte =\n\2\| DVALUE_ExtractByte of LLVMParamsBigIntptr.Events.DV.dvalue/gm" $f
 
     # 64BitIntptr mismatches
-    replace "s/MemoryModelImplementation.LLVMParams64BitIntptr.Events.DV/LP.Events.DV/g" $f
-    replace "s/LLVMParams64BitIntptr.Events.DV/LP.Events.DV/g" $f
+    replace "s/MemoryModelImplementation.LLVMParams64BitIntptr.DV/LP.DV/g" $f
+    replace "s/LLVMParams64BitIntptr.DV/LP.DV/g" $f
     replace "s/MemoryModelImplementation.LLVMParams64BitIntptr.ADDR.addr/LP.ADDR.addr/g" $f
     replace "s/LLVMParams64BitIntptr.ADDR.addr/LP.ADDR.addr/g" $f
     replace "s/MemoryModelImplementation.LLVMParams64BitIntptr.IP/LP.IP/g" $f
     replace "s/LLVMParams64BitIntptr.IP/LP.IP/g" $f
     replace "s/MemoryModelImplementation.LLVMParams64BitIntptr.PROV/LP.PROV/g" $f
     replace "s/LLVMParams64BitIntptr.PROV/LP.PROV/g" $f
-    replace "s/MemoryModelImplementation.LLVMParams64BitIntptr.Events/LP.Events/g" $f
-    replace "s/LLVMParams64BitIntptr.Events/LP.Events/g" $f
-    replace "s/^(\s*)type dvalue_byte = Memory64BitIntptr.CP.CONCBASE.dvalue_byte =\n(\s*)\| DVALUE_ExtractByte of LP.Events.DV.dvalue/\1type dvalue_byte = Memory64BitIntptr.CP.CONCBASE.dvalue_byte =\n\2\| DVALUE_ExtractByte of LLVMParams64BitIntptr.Events.DV.dvalue/gm" $f
+    # replace "s/MemoryModelImplementation.LLVMParams64BitIntptr.Events/LP.Events/g" $f
+    # replace "s/LLVMParams64BitIntptr.Events/LP.Events/g" $f
+    # replace "s/^(\s*)type dvalue_byte = Memory64BitIntptr.CP.CONCBASE.dvalue_byte =\n(\s*)\| DVALUE_ExtractByte of LP.Events.DV.dvalue/\1type dvalue_byte = Memory64BitIntptr.CP.CONCBASE.dvalue_byte =\n\2\| DVALUE_ExtractByte of LLVMParams64BitIntptr.Events.DV.dvalue/gm" $f
 
     # Extra stuff
-    replace "s/^(\s*)type dvalue_byte = MEM'.CP.CONCBASE.dvalue_byte =\n(\s*)\| DVALUE_ExtractByte of LP.Events.DV.dvalue/\1type dvalue_byte = MEM'.CP.CONCBASE.dvalue_byte =\n\2\| DVALUE_ExtractByte of LP'.Events.DV.dvalue/gm" $f
+    # replace "s/^(\s*)type dvalue_byte = MEM'.CP.CONCBASE.dvalue_byte =\n(\s*)\| DVALUE_ExtractByte of LP.Events.DV.dvalue/\1type dvalue_byte = MEM'.CP.CONCBASE.dvalue_byte =\n\2\| DVALUE_ExtractByte of LP'.Events.DV.dvalue/gm" $f
 done
 
 for f in "${MEMORYFILES[@]}"
 do
-    replace "s/^(\s*)type dvalue = LLVMParamsBigIntptr.Events.DV.dvalue =\n(\s*)\| DVALUE_Addr of ADDR.addr/\1type dvalue = LLVMParamsBigIntptr.Events.DV.dvalue =\n\2\| DVALUE_Addr of LLVMParamsBigIntptr.ADDR.addr/gm" $f
-    replace "s/^(\s*)type uvalue = LLVMParamsBigIntptr.Events.DV.uvalue =\n(\s*)\| UVALUE_Addr of ADDR.addr/\1type uvalue = LLVMParamsBigIntptr.Events.DV.uvalue =\n\2\| UVALUE_Addr of LLVMParamsBigIntptr.ADDR.addr/gm" $f
-    replace "s/(^\s*type dvalue = LLVMParamsBigIntptr.Events.DV.dvalue =(\n|.)*?DVALUE_IPTR of )IP.intptr/\1LLVMParamsBigIntptr.IP.intptr/gm" $f
-    replace "s/(^\s*type uvalue = LLVMParamsBigIntptr.Events.DV.uvalue =(\n|.)*?UVALUE_IPTR of )IP.intptr/\1LLVMParamsBigIntptr.IP.intptr/gm" $f
+    # replace "s/^(\s*)type dvalue = LLVMParamsBigIntptr.Events.DV.dvalue =\n(\s*)\| DVALUE_Addr of ADDR.addr/\1type dvalue = LLVMParamsBigIntptr.Events.DV.dvalue =\n\2\| DVALUE_Addr of LLVMParamsBigIntptr.ADDR.addr/gm" $f
+    # replace "s/^(\s*)type uvalue = LLVMParamsBigIntptr.Events.DV.uvalue =\n(\s*)\| UVALUE_Addr of ADDR.addr/\1type uvalue = LLVMParamsBigIntptr.Events.DV.uvalue =\n\2\| UVALUE_Addr of LLVMParamsBigIntptr.ADDR.addr/gm" $f
+    # replace "s/(^\s*type dvalue = LLVMParamsBigIntptr.Events.DV.dvalue =(\n|.)*?DVALUE_IPTR of )IP.intptr/\1LLVMParamsBigIntptr.IP.intptr/gm" $f
+    # replace "s/(^\s*type uvalue = LLVMParamsBigIntptr.Events.DV.uvalue =(\n|.)*?UVALUE_IPTR of )IP.intptr/\1LLVMParamsBigIntptr.IP.intptr/gm" $f
     replace "s/val ptr_to_int : InfAddr.addr -> coq_Z/val ptr_to_int : ADDR.addr -> coq_Z/g" $f
     replace "s/val ptr_to_int : FinAddr.addr -> coq_Z/val ptr_to_int : ADDR.addr -> coq_Z/g" $f
     replace "s/val address_provenance : InfAddr.addr -> coq_Prov/val address_provenance : ADDR.addr -> coq_Prov/g" $f

--- a/src/ml/debugger.ml
+++ b/src/ml/debugger.ml
@@ -4,7 +4,9 @@ open InterpretationStack.InterpreterStackBigIntptr.LLVM.Stack
 
 open InterpretationStack.InterpreterStackBigIntptr.LLVM.Global
 
-open InterpretationStack.InterpreterStackBigIntptr.LP.Events
+open InterpretationStack.InterpreterStackBigIntptr.LP
+
+open LLVMEvents
 
 open ITreeDefinition
 open Result
@@ -166,7 +168,7 @@ let print_stack_frames s =
 
 let rec debugger
     (m :
-      ( 'a coq_L4
+      ( ('a, 'b, 'c) coq_L4
       , MMEP.MMSP.coq_MemState
         * ( StoreId.store_id
           * ((lstack_frame * lstack) * (global_env * DV.dvalue)) ) )

--- a/src/ml/driver.ml
+++ b/src/ml/driver.ml
@@ -11,7 +11,7 @@
 open Printf
 open Vellvm_base
 
-open InterpretationStack.InterpreterStackBigIntptr.LP.Events
+open InterpretationStack.InterpreterStackBigIntptr.LP
 
 let of_str = Camlcoq.camlstring_of_coqstring
 

--- a/src/ml/interpreter.ml
+++ b/src/ml/interpreter.ml
@@ -14,7 +14,9 @@ open InterpretationStack.InterpreterStackBigIntptr.LLVM.Stack
 
 open InterpretationStack.InterpreterStackBigIntptr.LLVM.Global
 
-open InterpretationStack.InterpreterStackBigIntptr.LP.Events
+open InterpretationStack.InterpreterStackBigIntptr.LP
+
+open LLVMEvents
 
 open Format
 open ITreeDefinition
@@ -102,11 +104,11 @@ let debug (msg : string) =
 let current_line = ref (Camlcoq.camlstring_of_coqstring (LLVMEvents.printer_object.printer_get_loc ()))
 
 let single_step (m :
-      ( 'a coq_L4
+      ( ('a, 'b, 'c) coq_L4
       , MMEP.MMSP.coq_MemState
         * ( StoreId.store_id
           * ((lstack_frame * lstack) * (global_env * DV.dvalue)) ) )
-        itree ) : (( 'a coq_L4
+        itree ) : (( ('a, 'b, 'c) coq_L4
       , MMEP.MMSP.coq_MemState
         * ( StoreId.store_id
           * ((lstack_frame * lstack) * (global_env * DV.dvalue)) ) )
@@ -174,7 +176,7 @@ let single_step (m :
 
 let rec step
     (m :
-      ( 'a coq_L4
+      ( ('a, 'b, 'c) coq_L4
       , MMEP.MMSP.coq_MemState
         * ( StoreId.store_id
           * ((lstack_frame * lstack) * (global_env * DV.dvalue)) ) )

--- a/src/ml/main.ml
+++ b/src/ml/main.ml
@@ -16,7 +16,7 @@ open Assert
 open Driver
 open ShowAST
 
-module DV = InterpretationStack.InterpreterStackBigIntptr.LP.Events.DV
+module DV = InterpretationStack.InterpreterStackBigIntptr.LP.DV
 
 let string_of_function_id id : string =
   LLVMAst.( match id with
@@ -116,8 +116,7 @@ let make_test_h run name ll_ast t : (string * assertion) option =
      if !poison_test_flag
      then
        let expected =
-         InterpretationStack.InterpreterStackBigIntptr.LP.Events.DV
-           .DVALUE_Poison
+           DV.DVALUE_Poison
            dtyp
        in
        let str =

--- a/src/ml/test.ml
+++ b/src/ml/test.ml
@@ -13,7 +13,7 @@ open Driver
 
 open Assert
 
-open InterpretationStack.InterpreterStackBigIntptr.LP.Events
+open InterpretationStack.InterpreterStackBigIntptr.LP
 
 let default_cl_test_args = []
 

--- a/src/ml/tester.ml
+++ b/src/ml/tester.ml
@@ -4,7 +4,7 @@ open Vellvm_base
 open Result
 open Driver
 
-module DV = InterpretationStack.InterpreterStackBigIntptr.LP.Events.DV
+module DV = InterpretationStack.InterpreterStackBigIntptr.LP.DV
 
 (* test result location
    ------------------------------------------------------------- *)
@@ -194,8 +194,7 @@ let make_test name ll_ast t : string * (unit -> result_sum) =
 
   | Assertion.POISONTest (dtyp, entry, args) ->
       let expected =
-        InterpretationStack.InterpreterStackBigIntptr.LP.Events.DV
-        .DVALUE_Poison
+        DV.DVALUE_Poison
           dtyp
       in
       let strs =

--- a/src/ml/testing/assertion.ml
+++ b/src/ml/testing/assertion.ml
@@ -4,7 +4,7 @@
 open LLVMAst
 open TopLevel
 
-open InterpretationStack.InterpreterStackBigIntptr.LP.Events
+open InterpretationStack.InterpreterStackBigIntptr.LP
 
 open Llvm_printer
 open Either

--- a/src/ml/testing/generate.ml
+++ b/src/ml/testing/generate.ml
@@ -1,5 +1,5 @@
 module LL = LLVMAst
-open InterpretationStack.InterpreterStackBigIntptr.LP.Events
+open InterpretationStack.InterpreterStackBigIntptr.LP
 open QCheck
 module Z = Camlcoq.Z
 module P = Camlcoq.P

--- a/src/rocq/Handlers/Concretization.v
+++ b/src/rocq/Handlers/Concretization.v
@@ -62,16 +62,17 @@ Proof.
   eapply Monad_stateT; typeclasses eauto.
 Defined.
 
-Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL).
+Module Type ConcretizationBase (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL).
   Import MP.
   Import LP.
   Import PTOI.
   Import ITOP.
   Import PROV.
   Import GEP.
-  Import SIZEOF.
-  Import Events.
+  Import SZ.
+  Import DV.
   Import DVALUE_BYTES.
+  Import IP.
 
   Module MemHelpers := MemoryHelpers LP MP Byte.
   Import MemHelpers.
@@ -763,11 +764,11 @@ Module Type ConcretizationBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : 
 
 End ConcretizationBase.
 
-Module Type Concretization (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL) (SER : ConcretizationBase LP MP Byte) <: ConcretizationBase LP MP Byte.
+Module Type Concretization (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL) (SER : ConcretizationBase LP MP Byte) <: ConcretizationBase LP MP Byte.
   Include SER.
   Import MP.
   Import LP.
-  Import Events.
+  Import DV.
 
   Definition concretize_uvalue {M} `{Monad M} `{RAISE_ERROR M} `{RAISE_UB M} `{RAISE_OOM M}
              (uv : uvalue) : M dvalue
@@ -817,11 +818,11 @@ Module Type Concretization (LP : LLVMParams) (MP : MemoryParams LP) (Byte : Byte
   Definition concretize (uv: uvalue) (dv : dvalue) := concretize_u uv (ret dv).
 
   (* TODO: should the post condition be concretize uv dv ? *)
-  Definition pick_uvalue (uv : uvalue) : PickUvalueE {dv : dvalue | True}
+  Definition pick_uvalue (uv : uvalue) : PickUvalueE dvalue uvalue {dv : dvalue | True}
     := pick uv.
 
   (* TODO: should the post condition be concretize uv dv ? *)
-  Definition pick_unique_uvalue (uv : uvalue) : PickUvalueE {dv : dvalue | True}
+  Definition pick_unique_uvalue (uv : uvalue) : PickUvalueE dvalue uvalue {dv : dvalue | True}
     := pickUnique uv.
 
   (* Concretization encounters UB / Failure.
@@ -914,17 +915,17 @@ Module Type Concretization (LP : LLVMParams) (MP : MemoryParams LP) (Byte : Byte
 
 End Concretization.
 
-Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL) <: ConcretizationBase LP MP Byte.
+Module MakeBase (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL) <: ConcretizationBase LP MP Byte.
   Import MP.
   Import LP.
-  Import Events.
-  Import SIZEOF.
+  Import DV.
+  Import SZ.
   Import PTOI.
   Import PROV.
   Import ITOP.
-  Import DV.
   Import GEP.
   Import DVALUE_BYTES.
+  Import IP.
   Open Scope list.
 
   Export Byte.
@@ -2054,6 +2055,6 @@ Module MakeBase (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.A
   End Concretize.
 End MakeBase.
 
-Module Make (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL) (SER : ConcretizationBase LP MP Byte) : Concretization LP MP Byte SER.
+Module Make (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL) (SER : ConcretizationBase LP MP Byte) : Concretization LP MP Byte SER.
   Include Concretization LP MP Byte SER.
 End Make.

--- a/src/rocq/Handlers/Global.v
+++ b/src/rocq/Handlers/Global.v
@@ -18,8 +18,8 @@ From Vellvm Require Import
      Utils.Util
      Utils.Error
      Utils.Tactics
-     Semantics.LLVMEvents
-     Semantics.Memory.Sizeof.
+     Semantics.LLVMParams
+     Semantics.LLVMEvents.
 
 Require Import Ceres.Ceres.
 
@@ -194,8 +194,8 @@ End Globals.
 
 
 From Vellvm Require Import
-     LLVMAst
-     MemoryAddress.
+     LLVMAst.
+
 
 (* YZ TODO : Undecided about the status of this over-generalization of these events over domains of keys and values.
    The interface needs to be specialized anyway in [LLVMEvents].
@@ -203,6 +203,6 @@ From Vellvm Require Import
    it until [TopLevel] either.
    So exposing the specialization here, but it is awkward.
  *)
-Module Make (A : ADDRESS)(IP : INTPTR)(SIZEOF : Sizeof)(LLVMEvents : LLVM_INTERACTIONS(A)(IP)(SIZEOF)).
-  Definition global_env := FMapAList.alist raw_id LLVMEvents.DV.dvalue.
+Module Make (LP:LLVMParams).
+  Definition global_env := FMapAList.alist raw_id LP.DV.dvalue.
 End Make.

--- a/src/rocq/Handlers/Handlers.v
+++ b/src/rocq/Handlers/Handlers.v
@@ -25,19 +25,20 @@ From Vellvm.Handlers Require Export
      Intrinsics
      Pick
      UndefinedBehaviour
-     MemoryModelImplementation
      OOM
-     Concretization.
+     Concretization
+     MemoryModelImplementation.
+
+
 
 From Vellvm.Semantics Require Import Memory.Sizeof Memory.MemBytes GepM.
 
 (* Handlers get instantiated over the domain of addresses provided by the memory model *)
-Module LLVMEvents64 := LLVMEvents.Make(MemoryModelImplementation.FinAddr)(MemoryModelImplementation.IP64Bit)(MemoryModelImplementation.FinSizeof).
-Module Global64 := Global.Make MemoryModelImplementation.FinAddr MemoryModelImplementation.IP64Bit MemoryModelImplementation.FinSizeof LLVMEvents64.
-Module Local64  := Local.Make  MemoryModelImplementation.FinAddr MemoryModelImplementation.IP64Bit MemoryModelImplementation.FinSizeof LLVMEvents64.
-Module Stack64  := Stack.Make  MemoryModelImplementation.FinAddr MemoryModelImplementation.IP64Bit MemoryModelImplementation.FinSizeof LLVMEvents64.
 
-Module LLVMEvents := LLVMEvents.Make(MemoryModelImplementation.InfAddr)(MemoryModelImplementation.BigIP)(MemoryModelImplementation.FinSizeof).
-Module Global := Global.Make MemoryModelImplementation.InfAddr MemoryModelImplementation.BigIP MemoryModelImplementation.FinSizeof LLVMEvents.
-Module Local  := Local.Make  MemoryModelImplementation.InfAddr MemoryModelImplementation.BigIP MemoryModelImplementation.FinSizeof LLVMEvents.
-Module Stack  := Stack.Make  MemoryModelImplementation.InfAddr MemoryModelImplementation.BigIP MemoryModelImplementation.FinSizeof LLVMEvents.
+Module Global64 := Global.Make MemoryModelImplementation.LLVMParams64BitIntptr.
+Module Local64  := Local.Make MemoryModelImplementation.LLVMParams64BitIntptr.
+Module Stack64  := Stack.Make MemoryModelImplementation.LLVMParams64BitIntptr.
+
+Module Global := Global.Make MemoryModelImplementation.LLVMParamsBigIntptr.
+Module Local  := Local.Make MemoryModelImplementation.LLVMParamsBigIntptr.
+Module Stack  := Stack.Make MemoryModelImplementation.LLVMParamsBigIntptr.

--- a/src/rocq/Handlers/Intrinsics.v
+++ b/src/rocq/Handlers/Intrinsics.v
@@ -20,8 +20,8 @@ From ExtLib Require Import
 From Vellvm Require Import
      Utils.Util
      Syntax.LLVMAst
+     Semantics.LLVMParams
      Semantics.LLVMEvents
-     Semantics.Memory.Sizeof
      Semantics.IntrinsicsDefinitions.
 
 From ITree Require Import
@@ -66,12 +66,11 @@ Set Contextual Implicit.
    exception.  Unknown Calls (either to other intrinsics or external calls) are
    passed through unchanged.
 *)
-Module Make(A:MemoryAddress.ADDRESS)(IP:MemoryAddress.INTPTR)(SIZEOF:Sizeof)(LLVMIO: LLVM_INTERACTIONS(A)(IP)(SIZEOF)).
+Module Make(LP:LLVMParams).
 
-  Module IS := IntrinsicsDefinitions.Make(A)(IP)(SIZEOF)(LLVMIO).
+  Module IS := IntrinsicsDefinitions.Make(LP).
   Include IS.
-  Import LLVMIO.
-  Import DV.
+  Import LP.DV.
 
 
   (* Interprets Call events found in the given association list by their
@@ -85,11 +84,11 @@ Module Make(A:MemoryAddress.ADDRESS)(IP:MemoryAddress.INTPTR)(SIZEOF:Sizeof)(LLV
                                   end
                                ) defined_intrinsics.
 
-  Definition handle_intrinsics {E} `{FailureE -< E} `{IntrinsicE -< E} :
-    IntrinsicE ~> itree E :=
+  Definition handle_intrinsics {E} `{FailureE -< E} `{IntrinsicE dvalue uvalue -< E} :
+    (IntrinsicE dvalue uvalue) ~> itree E :=
     (* This is a bit hacky: declarations without global names are ignored by mapping them to empty string *)
-    fun X (e : IntrinsicE X) =>
-      match e in IntrinsicE Y return X = Y -> itree E Y with
+    fun X (e : IntrinsicE dvalue uvalue X) =>
+      match e in IntrinsicE _ _ Y return X = Y -> itree E Y with
       | (Intrinsic _ fname args) =>
           match assoc fname defs_assoc with
           | Some f => fun pf =>
@@ -106,7 +105,7 @@ Module Make(A:MemoryAddress.ADDRESS)(IP:MemoryAddress.INTPTR)(SIZEOF:Sizeof)(LLV
     Variable (E F : Type -> Type).
     Context `{FailureE -< F}.
     Context `{LLVMExcE uvalue -< F}.
-    Notation Eff := (E +' IntrinsicE +' F).
+    Notation Eff := (E +' IntrinsicE dvalue uvalue +' F).
 
     Definition E_trigger : Handler E Eff := fun _ e => trigger e.
     Definition F_trigger : Handler F Eff := fun _ e => trigger e.

--- a/src/rocq/Handlers/Local.v
+++ b/src/rocq/Handlers/Local.v
@@ -18,6 +18,7 @@ From Vellvm Require Import
   Utils.Error
   Utils.Tactics
   Semantics.LLVMEvents
+  Semantics.LLVMParams
   Semantics.Memory.Sizeof.
 
 Require Import Ceres.Ceres.
@@ -200,8 +201,7 @@ End Locals.
 
 
 From Vellvm Require Import
-     LLVMAst
-     MemoryAddress.
+     LLVMAst.
 
 (* YZ TODO : Undecided about the status of this over-generalization of these events over domains of keys and values.
    The interface needs to be specialized anyway in [LLVMEvents].
@@ -209,6 +209,6 @@ From Vellvm Require Import
    it until [TopLevel] either.
    So exposing the specialization here, but it is awkward.
  *)
-Module Make (A : ADDRESS)(IP : INTPTR)(SIZEOF : Sizeof)(LLVMEvents : LLVM_INTERACTIONS(A)(IP)(SIZEOF)).
-  Definition local_env := FMapAList.alist raw_id LLVMEvents.DV.uvalue.
+Module Make (LP:LLVMParams). 
+  Definition local_env := FMapAList.alist raw_id LP.DV.uvalue.
 End Make.

--- a/src/rocq/Handlers/MemoryInterpreters.v
+++ b/src/rocq/Handlers/MemoryInterpreters.v
@@ -64,20 +64,20 @@ Ltac raise_abs :=
   end.
 
 
-Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MM : MemoryModelSpec LP MP MMSP) (MemExecM : MemoryExecMonad LP MP MMSP MM).
+Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MM : MemoryModelSpec LP MP MMSP) (MemExecM : MemoryExecMonad LP MP MMSP MM).
   Import MM.
   Import MMSP.
   Import MemExecM.
-  Import LP.Events.
+  Import LP.DV.
   Import LP.PROV.
 
   Section Interpreters.
 
     Context {E : Type -> Type}.
 
-    Notation F := (PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE).
+    Notation F := (PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE).
 
-    Notation Effin := (E +' IntrinsicE +' MemoryE +' F).
+    Notation Effin := (E +' IntrinsicE dvalue uvalue +' MemoryE dvalue uvalue +' F).
     Notation Effout := (E +' F).
 
     Definition MemStateT M := stateT MemState M.
@@ -395,7 +395,7 @@ Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP
 
     (* TODO: get rid of this silly hack. *)
     Definition my_handle_memory_prop' :
-      forall T : Type, MemoryE T -> MemStateT (PropT Effout) T.
+      forall T : Type, MemoryE dvalue uvalue T -> MemStateT (PropT Effout) T.
     Proof using.
       intros T MemE.
       eapply MemPropT_lift_PropT.
@@ -403,7 +403,7 @@ Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP
     Defined.
 
     Definition my_handle_intrinsic_prop' :
-      forall T : Type, IntrinsicE T -> MemStateT (PropT Effout) T.
+      forall T : Type, IntrinsicE dvalue uvalue T -> MemStateT (PropT Effout) T.
     Proof using.
       intros T IntE.
       eapply MemPropT_lift_PropT.
@@ -411,7 +411,7 @@ Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP
     Defined.
 
     Definition my_handle_memory_prop :
-      forall T : Type, MemoryE T -> MemStateFreshT (PropT Effout) T.
+      forall T : Type, MemoryE dvalue uvalue T -> MemStateFreshT (PropT Effout) T.
     Proof using.
       intros T MemE.
       eapply MemPropT_lift_PropT_fresh.
@@ -419,7 +419,7 @@ Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP
     Defined.
 
     Definition my_handle_intrinsic_prop :
-      forall T : Type, IntrinsicE T -> MemStateFreshT (PropT Effout) T.
+      forall T : Type, IntrinsicE dvalue uvalue T -> MemStateFreshT (PropT Effout) T.
     Proof using.
       intros T IntE.
       unfold MemStateFreshT.
@@ -503,12 +503,12 @@ Module Type MemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP
   End Interpreters.
 End MemorySpecInterpreter.
 
-Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : MemoryModelExecPrimitives LP MP) (MM : MemoryModelExec LP MP MMEP) (SPEC_INTERP : MemorySpecInterpreter LP MP MMEP.MMSP MMEP.MemSpec MMEP.MemExecM).
+Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMEP : MemoryModelExecPrimitives LP MP) (MM : MemoryModelExec LP MP MMEP) (SPEC_INTERP : MemorySpecInterpreter LP MP MMEP.MMSP MMEP.MemSpec MMEP.MemExecM).
   Import MM.
   Import MMEP.
   Import MMEP.MMSP.
   Import LP.
-  Import LP.Events.
+  Import LP.DV.
   Import LP.PROV.
 
   (** Specification of the memory model *)
@@ -524,10 +524,10 @@ Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP
   Section Interpreters.
 
     Context {E : Type -> Type}.
-    Notation E := ExternalCallE.
-    Notation F := (PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE).
+    Notation E := (ExternalCallE dvalue uvalue).
+    Notation F := (PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE).
 
-    Notation Effin := (E +' IntrinsicE +' MemoryE +' F).
+    Notation Effin := (E +' IntrinsicE dvalue uvalue +' MemoryE dvalue uvalue +' F).
     Notation Effout := (E +' F).
 
     (* TODO: Why do I have to duplicate this >_<? *)
@@ -720,10 +720,10 @@ Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP
       fun R e sid m => r <- trigger e;; ret (m, (sid, r)).
 
     (* TODO: get rid of this silly hack. *)
-    Definition my_handle_memory : MemoryE ~> MemStateFreshT (itree Effout) :=
+    Definition my_handle_memory : MemoryE dvalue uvalue ~> MemStateFreshT (itree Effout) :=
       @handle_memory (MemStateFreshT (itree Effout)) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ MemStateFreshT_MemMonad.
 
-    Definition my_handle_intrinsic : IntrinsicE ~> MemStateFreshT (itree Effout) :=
+    Definition my_handle_intrinsic : IntrinsicE dvalue uvalue ~> MemStateFreshT (itree Effout) :=
       @handle_intrinsic (MemStateFreshT (itree Effout)) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ MemStateFreshT_MemMonad.
 
     Definition interp_memory_h : Effin ~> MemStateFreshT (itree Effout)
@@ -1374,10 +1374,10 @@ Module Type MemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP
   End Interpreters.
 End MemoryExecInterpreter.
 
-Module MakeMemorySpecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MS : MemoryModelSpec LP MP MMSP) (MemExecM : MemoryExecMonad LP MP MMSP MS) <: MemorySpecInterpreter LP MP MMSP MS MemExecM.
+Module MakeMemorySpecInterpreter (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MS : MemoryModelSpec LP MP MMSP) (MemExecM : MemoryExecMonad LP MP MMSP MS) <: MemorySpecInterpreter LP MP MMSP MS MemExecM.
   Include MemorySpecInterpreter LP MP MMSP MS MemExecM.
 End MakeMemorySpecInterpreter.
 
-Module MakeMemoryExecInterpreter (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : MemoryModelExecPrimitives LP MP) (ME : MemoryModelExec LP MP MMEP) (SPEC_INTERP : MemorySpecInterpreter LP MP MMEP.MMSP MMEP.MemSpec MMEP.MemExecM) <: MemoryExecInterpreter LP MP MMEP ME SPEC_INTERP.
+Module MakeMemoryExecInterpreter (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMEP : MemoryModelExecPrimitives LP MP) (ME : MemoryModelExec LP MP MMEP) (SPEC_INTERP : MemorySpecInterpreter LP MP MMEP.MMSP MMEP.MemSpec MMEP.MemExecM) <: MemoryExecInterpreter LP MP MMEP ME SPEC_INTERP.
   Include MemoryExecInterpreter LP MP MMEP ME SPEC_INTERP.
 End MakeMemoryExecInterpreter.

--- a/src/rocq/Handlers/MemoryModel.v
+++ b/src/rocq/Handlers/MemoryModel.v
@@ -73,16 +73,15 @@ Import EitherMonad.
 From Stdlib Require Import FunctionalExtensionality.
 Import Logic.
 
-Module Type MemoryModelSpecPrimitives (LP : LLVMParams) (MP : MemoryParams LP).
-  Import LP.Events.
+Module Type MemoryModelSpecPrimitives (LP : LLVMParams) (MP : MEMORY_PARAMS LP).
+  Import LP.DV.
   Import LP.ADDR.
-  Import LP.SIZEOF.
+  Import LP.SZ.
   Import LP.PROV.
 
   Import MemBytes.
-  Module MemByte := Byte LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL.
+  Module MemByte := Byte LP MP.BYTE_IMPL.
   Import MemByte.
-  Import LP.SIZEOF.
 
   (*** Internal state of memory *)
   Parameter MemState : Type.
@@ -233,30 +232,29 @@ Module Type MemoryModelSpecPrimitives (LP : LLVMParams) (MP : MemoryParams LP).
 
 End MemoryModelSpecPrimitives.
 
-Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL).
+Module MemoryHelpers (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL).
   (*** Other helpers *)
   Import MP.GEP.
   Import MP.BYTE_IMPL.
-  Import LP.
   Import LP.ADDR.
-  Import LP.Events.
-  Import LP.SIZEOF.
+  Import LP.DV.
+  Import LP.SZ.
   Import LP.PTOI.
   Import LP.ITOP.
   Import LP.PROV.
-  Import IP.
+  Import LP.IP.
   Import Byte.
   Import Util.
 
   (* TODO: Move this? *)
-  Definition intptr_seq (start : Z) (len : nat) : OOM (list IP.intptr)
-    := map_monad (IP.from_Z) (Zseq start len).
+  Definition intptr_seq (start : Z) (len : nat) : OOM (list intptr)
+    := map_monad (from_Z) (Zseq start len).
 
   (* TODO: Move this? *)
   Lemma intptr_seq_succ :
     forall off n,
       intptr_seq off (S n) =
-        hd <- IP.from_Z off;;
+        hd <- from_Z off;;
         tail <- intptr_seq (Z.succ off) n;;
         ret (hd :: tail).
   Proof.
@@ -269,7 +267,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
     forall start len seq ix ixip,
       intptr_seq start len = NoOom seq ->
       Util.Nth seq ix ixip ->
-      IP.from_Z (start + (Z.of_nat ix)) = NoOom ixip.
+      from_Z (start + (Z.of_nat ix)) = NoOom ixip.
   Proof.
     intros start len seq. revert start len.
     induction seq; intros start len ix ixip SEQ NTH.
@@ -297,21 +295,21 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
     forall start len seq x,
       intptr_seq start len = NoOom seq ->
       In x seq ->
-      (IP.to_Z x >= start)%Z.
+      (to_Z x >= start)%Z.
   Proof.
     intros start len seq x SEQ IN.
     apply In_nth_error in IN.
     destruct IN as [n IN].
 
     pose proof (intptr_seq_nth start len seq n x SEQ IN) as IX.
-    erewrite IP.from_Z_to_Z; eauto.
+    erewrite from_Z_to_Z; eauto.
     lia.
   Qed.
 
   Lemma in_intptr_seq :
     forall len start n seq,
       intptr_seq start len = NoOom seq ->
-      In n seq <-> (start <= IP.to_Z n < start + Z.of_nat len)%Z.
+      In n seq <-> (start <= to_Z n < start + Z.of_nat len)%Z.
   Proof.
   intros len start.
   revert start. induction len as [|len IHlen]; simpl; intros start n seq SEQ.
@@ -325,7 +323,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
     split.
     + intros [IN | IN].
       * subst.
-        apply IP.from_Z_to_Z in Heqo; subst.
+        apply from_Z_to_Z in Heqo; subst.
         lia.
       * pose proof (IHlen (Z.succ start) n l Heqo0) as [A B].
         specialize (A IN).
@@ -333,17 +331,17 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
         lia.
     + intros BOUND.
       cbn.
-      destruct (IP.eq_dec i n) as [EQ | NEQ]; auto.
+      destruct (eq_dec i n) as [EQ | NEQ]; auto.
       right.
 
       pose proof (IHlen (Z.succ start) n l Heqo0) as [A B].
-      apply IP.from_Z_to_Z in Heqo; subst.
-      assert (IP.to_Z i <> IP.to_Z n).
+      apply from_Z_to_Z in Heqo; subst.
+      assert (to_Z i <> to_Z n).
       { intros EQ.
-        apply IP.to_Z_inj in EQ; auto.
+        apply to_Z_inj in EQ; auto.
       }
 
-      assert ((Z.succ (IP.to_Z i) <= IP.to_Z n < Z.succ (IP.to_Z i) + Z.of_nat len)%Z) as BOUND' by lia.
+      assert ((Z.succ (to_Z i) <= to_Z n < Z.succ (to_Z i) + Z.of_nat len)%Z) as BOUND' by lia.
       specialize (B BOUND').
       auto.
   Qed.
@@ -353,7 +351,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       intptr_seq start len = NoOom seq ->
       (forall x,
           (start <= x < start + Z.of_nat len)%Z ->
-          exists ipx, IP.from_Z x = NoOom ipx /\ In ipx seq).
+          exists ipx, from_Z x = NoOom ipx /\ In ipx seq).
   Proof.
     intros start len; revert start;
       induction len;
@@ -397,12 +395,12 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
   Proof.
     intros start len SEQ.
     unfold intptr_seq in SEQ.
-    assert (MReturns [] (map_monad IP.from_Z (Zseq start len))) as RET.
+    assert (MReturns [] (map_monad from_Z (Zseq start len))) as RET.
     { cbn. unfold OOMReturns.
       rewrite SEQ.
       reflexivity.
     }
-    pose proof (@map_monad_ret_nil_inv OOM _ _ _ _ _ _ _ IP.from_Z _ RET) as SEQLEN.
+    pose proof (@map_monad_ret_nil_inv OOM _ _ _ _ _ _ _ from_Z _ RET) as SEQLEN.
     eapply Zseq_nil_len; eauto.
   Qed.
 
@@ -418,13 +416,13 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       break_match_hyp; [| solve [inv SEQ]].
       inv SEQ.
 
-      assert (MReturns [] (map_monad IP.from_Z (Zseq (Z.succ off) len))) as RET.
+      assert (MReturns [] (map_monad from_Z (Zseq (Z.succ off) len))) as RET.
       { cbn. unfold OOMReturns.
         rewrite Heqo0.
         reflexivity.
       }
 
-      pose proof (@map_monad_ret_nil_inv OOM _ _ _ _ _ _ _ IP.from_Z _ RET) as SEQLEN.
+      pose proof (@map_monad_ret_nil_inv OOM _ _ _ _ _ _ _ from_Z _ RET) as SEQLEN.
       apply Zseq_nil_len in SEQLEN.
       subst.
       cbn.
@@ -450,7 +448,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
   Lemma intptr_seq_succ_last' :
     forall l off len x,
       intptr_seq off len = NoOom l ->
-      IP.from_Z (off + Z.of_nat len) = NoOom x ->
+      from_Z (off + Z.of_nat len) = NoOom x ->
       intptr_seq off (S len) = NoOom (l ++ [x]).
   Proof.
     induction l as [ | i l']; intros off len x SEQ EQ.
@@ -492,7 +490,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
     forall len l,
       intptr_seq 1 len = NoOom l ->
       exists l', intptr_seq 0 len = NoOom l' /\
-              NoOom l = map_monad (fun ip => IP.from_Z (IP.to_Z ip + 1)) l'.
+              NoOom l = map_monad (fun ip => from_Z (to_Z ip + 1)) l'.
   Proof.
     intros len l SEQ.
     revert SEQ. revert len.
@@ -527,7 +525,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       pose proof ALL_SHIFTED as NTH_SHIFTED.
       eapply Forall2_forall in NTH_SHIFTED as [LEN_SHIFTED NTH_SHIFTED].
 
-      assert (exists y, IP.from_Z (IP.to_Z x - 1) = NoOom y) as [y YEQ].
+      assert (exists y, from_Z (to_Z x - 1) = NoOom y) as [y YEQ].
       { (* I know this because...??? *)
         (* shiftZ is the start, x is the final element in the sequence.
 
@@ -543,29 +541,29 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
 
         pose proof (Nth_last l x) as NTH.
         pose proof (intptr_seq_nth _ _ _ _ _ SEQ NTH) as SEQNTH.
-        apply IP.from_Z_to_Z in SEQNTH.
+        apply from_Z_to_Z in SEQNTH.
         rewrite SEQNTH.
 
         (* When len' is 0, y is just 0 *)
         destruct l using rev_ind.
-        - exists IP.zero.
+        - exists zero.
           cbn in SEQ_CUT.
           inv SEQ_CUT.
           cbn.
-          apply IP.from_Z_0.
+          apply from_Z_0.
         - clear IHl0.
           exists x0.
 
           pose proof (Nth_last l x0) as NTH'.
           pose proof (intptr_seq_nth _ _ _ _ _ SEQ_CUT NTH') as SEQNTH'.
-          apply IP.from_Z_to_Z in SEQNTH'.
+          apply from_Z_to_Z in SEQNTH'.
           rewrite length_app.
           rewrite Nat2Z.inj_add.
           replace ((1 + (Z.of_nat (Datatypes.length l) + Z.of_nat (Datatypes.length [x0])) - 1))%Z with ((Z.of_nat (Datatypes.length l) + Z.of_nat (Datatypes.length [x0])))%Z by lia.
           cbn.
           replace (Z.of_nat (length l) + 1)%Z with (1 + Z.of_nat (length l))%Z by lia.
           rewrite <- SEQNTH'.
-          apply IP.to_Z_from_Z.
+          apply to_Z_from_Z.
       }
 
       exists (l_shifted ++ [y]).
@@ -577,7 +575,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
         -- cbn in *.
            inv SEQ_CUT.
            break_match_hyp; inv SEQ.
-           erewrite IP.from_Z_to_Z in YEQ; eauto.
+           erewrite from_Z_to_Z in YEQ; eauto.
            cbn in YEQ.
            auto.
         -- (* I know that x = S S len' *)
@@ -588,19 +586,19 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
             eapply Nth_last.
           }
 
-          erewrite IP.from_Z_to_Z in YEQ; eauto.
+          erewrite from_Z_to_Z in YEQ; eauto.
           replace (1 + Z.of_nat (S len') - 1)%Z with (Z.of_nat (S len'))%Z in YEQ by lia.
           auto.
-      + assert (Monad.eq1 (NoOom (l ++ [x])) (map_monad (fun ip : IP.intptr => IP.from_Z (IP.to_Z ip + 1)) (l_shifted ++ [y]))) as EQ.
+      + assert (Monad.eq1 (NoOom (l ++ [x])) (map_monad (fun ip : intptr => from_Z (to_Z ip + 1)) (l_shifted ++ [y]))) as EQ.
         { rewrite map_monad_app.
           cbn.
           rewrite <- MAP_SHIFTED.
           (* Must be some way to prove that this match gives NoOom x... *)
-          assert (IP.from_Z (IP.to_Z y + 1) = NoOom x) as EQ.
-          { erewrite IP.from_Z_to_Z; eauto.
-            assert (IP.to_Z x - 1 + 1 = IP.to_Z x)%Z as EQ by lia.
+          assert (from_Z (to_Z y + 1) = NoOom x) as EQ.
+          { erewrite from_Z_to_Z; eauto.
+            assert (to_Z x - 1 + 1 = to_Z x)%Z as EQ by lia.
             rewrite EQ.
-            apply IP.to_Z_from_Z.
+            apply to_Z_from_Z.
           }
 
           rewrite EQ.
@@ -696,7 +694,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       setoid_rewrite Monad.bind_ret_l in CONSEC.
 
       (* rewrite bind_ret_l in CONSEC. *)
-      destruct (map_monad (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [DVALUE_IPTR ix]) l) eqn:HMAPM.
+      destruct (map_monad (fun ix : intptr => handle_gep_addr (DTYPE_I 8) ptr [DVALUE_IPTR ix]) l) eqn:HMAPM.
       + (* Error: should be a contradiction *)
         (* TODO: need inversion lemma. *)
         cbn in CONSEC.
@@ -709,7 +707,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
         destruct (sequence l0) eqn:HSEQUENCE.
         { cbn in CONSEC.
           apply within_ret_ret in CONSEC; auto.
-          assert (MReturns l0 (map_monad (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [DVALUE_IPTR ix]) l)) as RETS.
+          assert (MReturns l0 (map_monad (fun ix : intptr => handle_gep_addr (DTYPE_I 8) ptr [DVALUE_IPTR ix]) l)) as RETS.
           { auto. }
 
           epose proof MapMonadExtra.map_monad_length l _ _ RETS as LEN.
@@ -760,8 +758,8 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       setoid_rewrite Monad.bind_ret_l in CONSEC.
 
       destruct (map_monad
-                  (fun ix : IP.intptr =>
-                     MP.GEP.handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix])
+                  (fun ix : intptr =>
+                     MP.GEP.handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix])
                   l) eqn:HMAPM.
       + cbn in CONSEC.
         setoid_rewrite rbm_raise_bind in CONSEC; auto.
@@ -812,7 +810,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
             subst.
 
             rewrite sizeof_dtyp_i8 in GEP.
-            erewrite IP.from_Z_to_Z in GEP; [|apply FROMZ].
+            erewrite from_Z_to_Z in GEP; [|apply FROMZ].
             lia.
 
             unfold sequence in HSEQUENCE.
@@ -910,7 +908,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       inv SEQ.
 
       cbn in *.
-      rewrite IP.from_Z_0 in Heqo.
+      rewrite from_Z_0 in Heqo.
       inv Heqo.
       rewrite handle_gep_addr_0 in *.
 
@@ -969,13 +967,13 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
           (* Need something about sequences *)
       (* Since len is the length, `intptr_seq 1 len` is basically just `map (+1) (intptr_seq 0 len)` *)
       (* Unfortunately, I don't think I have a lemma that gives me
-         `IP.from_Z (x+1) = NoOom (i+1) -> IP.from_Z (x+1) = NoOom i`
+         `from_Z (x+1) = NoOom (i+1) -> from_Z (x+1) = NoOom i`
 
          Maybe something like this should be an axiom, but I think it
          gets messy because memory is bounded in the + and -
          direction.
 
-         I *DO* know that `IP.from_Z 0 = NoOom zero`, however, and all of the other elements in
+         I *DO* know that `from_Z 0 = NoOom zero`, however, and all of the other elements in
          `intptr_seq 0 len` are in `intptr_seq 1 len`.
 
          `intptr_seq 1 len =
@@ -1166,7 +1164,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       inv SEQ.
 
       cbn in *.
-      rewrite IP.from_Z_0 in Heqo.
+      rewrite from_Z_0 in Heqo.
       inv Heqo.
       rewrite handle_gep_addr_0 in *.
 
@@ -1226,13 +1224,13 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
           (* Need something about sequences *)
       (* Since len is the length, `intptr_seq 1 len` is basically just `map (+1) (intptr_seq 0 len)` *)
       (* Unfortunately, I don't think I have a lemma that gives me
-         `IP.from_Z (x+1) = NoOom (i+1) -> IP.from_Z (x+1) = NoOom i`
+         `from_Z (x+1) = NoOom (i+1) -> from_Z (x+1) = NoOom i`
 
          Maybe something like this should be an axiom, but I think it
          gets messy because memory is bounded in the + and -
          direction.
 
-         I *DO* know that `IP.from_Z 0 = NoOom zero`, however, and all of the other elements in
+         I *DO* know that `from_Z 0 = NoOom zero`, however, and all of the other elements in
          `intptr_seq 0 len` are in `intptr_seq 1 len`.
 
          `intptr_seq 1 len =
@@ -1443,7 +1441,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
         {
           unfold get_consecutive_ptrs in CONSEC'.
           cbn in CONSEC'.
-          rewrite IP.from_Z_0 in CONSEC'.
+          rewrite from_Z_0 in CONSEC'.
           break_match_hyp.
           2: {
             cbn in CONSEC'.
@@ -1500,7 +1498,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
           inv CONSEC'.
 
           rewrite sizeof_dtyp_i8 in *.
-          erewrite IP.from_Z_to_Z in Heqs1; eauto.
+          erewrite from_Z_to_Z in Heqs1; eauto.
           break_match_hyp; inv Heqo.
           lia.
         }
@@ -1627,7 +1625,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
 
           cbn in CONSEC'.
           setoid_rewrite bind_ret_l in CONSEC'.
-          destruct (map_monad (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [DVALUE_IPTR ix])
+          destruct (map_monad (fun ix : intptr => handle_gep_addr (DTYPE_I 8) ptr [DVALUE_IPTR ix])
                               (i :: l)) eqn:HMAPM.
           { cbn in CONSEC'.
             setoid_rewrite rbm_raise_bind in CONSEC'; [|typeclasses eauto].
@@ -1666,7 +1664,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
 
           apply handle_gep_addr_ix in Heqs1.
           rewrite sizeof_dtyp_i8 in Heqs1.
-          rewrite (IP.from_Z_to_Z _ _ Heqo1) in Heqs1.
+          rewrite (from_Z_to_Z _ _ Heqo1) in Heqs1.
           cbn in HSEQUENCE.
           break_match_hyp; inv HSEQUENCE.
           break_match_hyp; inv Heqo2.
@@ -1724,8 +1722,8 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       (forall p ix_nat,
           Util.Nth ptrs ix_nat p ->
           exists ix,
-            NoOom ix = IP.from_Z (Z.of_nat ix_nat) /\
-              handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix] = inr (ret p)).
+            NoOom ix = from_Z (Z.of_nat ix_nat) /\
+              handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix] = inr (ret p)).
   Proof.
     intros M HM EQM EQV Pre Post B MB WM WRET OOM ERR LAWS RAISE_OOM RAISE_ERR RWOOM RWERR
       ptr len ptrs CONSEC p ix_nat NTH.
@@ -1743,7 +1741,7 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
     cbn in CONSEC.
     setoid_rewrite bind_ret_l in CONSEC.
     destruct (map_monad
-                (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix]) l) eqn:MAP.
+                (fun ix : intptr => handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix]) l) eqn:MAP.
     { cbn in CONSEC.
       setoid_rewrite rbm_raise_bind in CONSEC; auto.
       apply rw_ret_nin_raise in CONSEC; try contradiction; auto.
@@ -1789,8 +1787,8 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
       (forall p ix_nat,
           Util.Nth ptrs ix_nat p ->
           exists ix,
-            NoOom ix = IP.from_Z (Z.of_nat ix_nat) /\
-              handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix] = inr (ret p)).
+            NoOom ix = from_Z (Z.of_nat ix_nat) /\
+              handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix] = inr (ret p)).
   Proof.
     intros M HM EQM EQV EQRET OOM ERR LAWS RAISE_OOM RAISE_ERR
       ptr len ptrs CONSEC p ix_nat NTH.
@@ -1875,10 +1873,10 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
     unfold get_consecutive_ptrs.
     destruct (intptr_seq 0 len) eqn:HSEQ.
     - pose proof (map_monad_err_succeeds
-                    (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix]) l) as HMAPM.
+                    (fun ix : intptr => handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix]) l) as HMAPM.
       forward HMAPM.
       { intros a IN.
-        destruct (int_to_ptr (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * IP.to_Z a)%Z (address_provenance ptr)) eqn:IX.
+        destruct (int_to_ptr (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * to_Z a)%Z (address_provenance ptr)) eqn:IX.
         - exists (ret a0).
           apply handle_gep_addr_ix'; cbn; auto.
         - eapply handle_gep_addr_ix'_OOM in IX; auto.
@@ -1955,10 +1953,10 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
     setoid_rewrite bind_ret_l in CONTRA.
 
     pose proof (map_monad_err_succeeds
-                  (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix]) l) as HMAPM.
+                  (fun ix : intptr => handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix]) l) as HMAPM.
       forward HMAPM.
       { intros a IN.
-        destruct (int_to_ptr (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * IP.to_Z a)%Z (address_provenance ptr)) eqn:IX.
+        destruct (int_to_ptr (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * to_Z a)%Z (address_provenance ptr)) eqn:IX.
         - exists (ret a0).
           apply handle_gep_addr_ix'; cbn; auto.
         - eapply handle_gep_addr_ix'_OOM in IX; auto.
@@ -2004,10 +2002,10 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
     unfold get_consecutive_ptrs in *.
     destruct (intptr_seq 0 len) eqn:HSEQ.
     - pose proof (map_monad_err_succeeds
-                    (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix]) l) as HMAPM.
+                    (fun ix : intptr => handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix]) l) as HMAPM.
       forward HMAPM.
       { intros a IN.
-        destruct (int_to_ptr (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * IP.to_Z a)%Z (address_provenance ptr)) eqn:IX.
+        destruct (int_to_ptr (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * to_Z a)%Z (address_provenance ptr)) eqn:IX.
         - exists (ret a0).
           apply handle_gep_addr_ix'; cbn; auto.
         - eapply handle_gep_addr_ix'_OOM in IX; auto.
@@ -2672,18 +2670,17 @@ Module MemoryHelpers (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule
   End Serialization.
 End MemoryHelpers.
 
-Module Type MemoryModelSpec (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP).
-  Import LP.
-  Import LP.Events.
+Module Type MemoryModelSpec (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP).
+  Import LP.DV.
   Import LP.ADDR.
-  Import LP.SIZEOF.
+  Import LP.SZ.
   Import LP.PROV.
   Import LP.PTOI.
   Import MMSP.
 
-  Module OVER := PTOIOverlaps ADDR PTOI SIZEOF.
+  Module OVER := PTOIOverlaps LP.ADDR LP.PTOI LP.SZ.
   Import OVER.
-  Module OVER_H := OverlapHelpers ADDR SIZEOF OVER.
+  Module OVER_H := OverlapHelpers LP.ADDR LP.SZ OVER.
   Import OVER_H.
 
   Import MemByte.
@@ -3622,7 +3619,7 @@ Module Type MemoryModelSpec (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : Mem
 
   (*** Handling memory events *)
   Section Handlers.
-    Definition handle_memory_prop : MemoryE ~> MemPropT MemState
+    Definition handle_memory_prop : MemoryE dvalue uvalue ~> MemPropT MemState
       := fun T m =>
            match m with
            (* Unimplemented *)
@@ -3658,7 +3655,7 @@ Module Type MemoryModelSpec (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : Mem
                     DVALUE_Addr src ::
                     DVALUE_IPTR len ::
                     @DVALUE_I _ volatile :: [] (* volatile ignored *)  =>
-          memcpy_spec src dst (IP.to_Z len) (equ volatile VellvmIntegers.one)
+          memcpy_spec src dst (LP.IP.to_Z len) (equ volatile VellvmIntegers.one)
       | _ => raise_error "Unsupported arguments to memcpy."
       end.
 
@@ -3688,7 +3685,7 @@ Module Type MemoryModelSpec (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : Mem
           malloc_bytes_spec_MemPropT bytes
       | [DVALUE_IPTR sz] =>
           sid <- fresh_sid;;
-          bytes <- lift_OOM (generate_num_undef_bytes (Z.to_N (IP.to_unsigned sz)) (DTYPE_I 8) sid);;
+          bytes <- lift_OOM (generate_num_undef_bytes (Z.to_N (LP.IP.to_unsigned sz)) (DTYPE_I 8) sid);;
           malloc_bytes_spec_MemPropT bytes
       | _ => raise_error "Malloc: invalid arguments."
       end.
@@ -3700,7 +3697,7 @@ Module Type MemoryModelSpec (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : Mem
       | _ => raise_error "Free: invalid arguments."
       end.
 
-    Definition handle_intrinsic_prop : IntrinsicE ~> MemPropT MemState
+    Definition handle_intrinsic_prop : IntrinsicE dvalue uvalue ~> MemPropT MemState
       := fun T e =>
            match e with
            | Intrinsic t name args =>
@@ -4106,11 +4103,11 @@ Module Type MemoryModelSpec (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : Mem
 
 End MemoryModelSpec.
 
-Module MakeMemoryModelSpec (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) <: MemoryModelSpec LP MP MMSP.
+Module MakeMemoryModelSpec (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP) <: MemoryModelSpec LP MP MMSP.
   Include MemoryModelSpec LP MP MMSP.
 End MakeMemoryModelSpec.
 
-Module Type MemoryExecMonad (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP).
+Module Type MemoryExecMonad (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP).
   Import LP.
   Import MMS.
   Import PROV.
@@ -5167,7 +5164,7 @@ Module Type MemoryExecMonad (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : Mem
            length addrs = len /\ ms = ms' /\ st = st').
   #[global] Hint Unfold get_consecutive_ptrs_post : core.
 
-  Definition intptr_seq_post len : exec_correct_post (list IP.intptr) :=
+  Definition intptr_seq_post len : exec_correct_post (list LP.IP.intptr) :=
     (fun ms st ips ms' st' => length ips = len /\ ms = ms' /\ st = st').
   #[global] Hint Unfold intptr_seq_post : core.
 
@@ -5450,14 +5447,14 @@ Module Type MemoryExecMonad (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : Mem
 
 End MemoryExecMonad.
 
-Module MakeMemoryExecMonad (LP : LLVMParams) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP) <: MemoryExecMonad LP MP MMSP MMS.
+Module MakeMemoryExecMonad (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP) <: MemoryExecMonad LP MP MMSP MMS.
   Include MemoryExecMonad LP MP MMSP MMS.
 End MakeMemoryExecMonad.
 
-Module Type MemoryModelExecPrimitives (LP : LLVMParams) (MP : MemoryParams LP).
+Module Type MemoryModelExecPrimitives (LP : LLVMParams) (MP : MEMORY_PARAMS LP).
   Import LP.
   Import LP.ADDR.
-  Import LP.SIZEOF.
+  Import LP.SZ.
   Import LP.PROV.
   Import MP.
 
@@ -5600,13 +5597,12 @@ Module Type MemoryModelExecPrimitives (LP : LLVMParams) (MP : MemoryParams LP).
   End MemoryPrimitives.
 End MemoryModelExecPrimitives.
 
-Module Type MemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : MemoryModelExecPrimitives LP MP).
-  Import LP.
+Module Type MemoryModelExec (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMEP : MemoryModelExecPrimitives LP MP).
   Import LP.ADDR.
-  Import LP.SIZEOF.
+  Import LP.SZ.
   Import LP.PROV.
   Import LP.PTOI.
-  Import LP.Events.
+  Import LP.DV.
   Import MP.
   Import MMEP.
   Import MemExecM.
@@ -5615,9 +5611,9 @@ Module Type MemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Mem
   Import MMEP.MemSpec.
   Import MemHelpers.
 
-  Module OVER := PTOIOverlaps ADDR PTOI SIZEOF.
+  Module OVER := PTOIOverlaps LP.ADDR LP.PTOI LP.SZ.
   Import OVER.
-  Module OVER_H := OverlapHelpers ADDR SIZEOF OVER.
+  Module OVER_H := OverlapHelpers LP.ADDR LP.SZ OVER.
   Import OVER_H.
 
   (*** Handling memory events *)
@@ -5705,7 +5701,7 @@ Module Type MemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Mem
         let byte := uvalue_sbyte (@UVALUE_I 8 val) (DTYPE_I 8) 0 sid in
         write_bytes dst (repeatN (Z.to_N len) byte).
 
-    Definition handle_memory `{MemMonad MemM (itree Eff)} : MemoryE ~> MemM
+    Definition handle_memory `{MemMonad MemM (itree Eff)} : MemoryE dvalue uvalue ~> MemM
       := fun T m =>
            match m with
            (* Unimplemented *)
@@ -5743,7 +5739,7 @@ Module Type MemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Mem
                     DVALUE_Addr src ::
                     DVALUE_IPTR len ::
                     @DVALUE_I _ volatile :: [] (* volatile ignored *)  =>
-          memcpy src dst (IP.to_Z len) (equ volatile VellvmIntegers.one)
+          memcpy src dst (LP.IP.to_Z len) (equ volatile VellvmIntegers.one)
       | _ => raise_error "Unsupported arguments to memcpy."
       end.
 
@@ -5772,7 +5768,7 @@ Module Type MemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Mem
           malloc_bytes bytes
       | [DVALUE_IPTR sz] =>
           sid <- fresh_sid;;
-          bytes <- lift_OOM (generate_num_undef_bytes (Z.to_N (IP.to_unsigned sz)) (DTYPE_I 8) sid);;
+          bytes <- lift_OOM (generate_num_undef_bytes (Z.to_N (LP.IP.to_unsigned sz)) (DTYPE_I 8) sid);;
           malloc_bytes bytes
       | _ => raise_error "Malloc: invalid arguments."
       end.
@@ -5784,7 +5780,7 @@ Module Type MemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Mem
       | _ => raise_error "Free: invalid arguments."
       end.
 
-    Definition handle_intrinsic `{MemMonad MemM (itree Eff)} : IntrinsicE ~> MemM
+    Definition handle_intrinsic `{MemMonad MemM (itree Eff)} : IntrinsicE dvalue uvalue ~> MemM
       := fun T e =>
            match e with
            | Intrinsic t name args =>
@@ -5819,18 +5815,18 @@ Module Type MemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Mem
   End Handlers.
 End MemoryModelExec.
 
-Module MakeMemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : MemoryModelExecPrimitives LP MP) <: MemoryModelExec LP MP MMEP.
+Module MakeMemoryModelExec (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMEP : MemoryModelExecPrimitives LP MP) <: MemoryModelExec LP MP MMEP.
   Include MemoryModelExec LP MP MMEP.
 End MakeMemoryModelExec.
 
-Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : MemoryModelExecPrimitives LP MP) (MME : MemoryModelExec LP MP MMEP).
+Module MemoryModelTheory (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (MMEP : MemoryModelExecPrimitives LP MP) (MME : MemoryModelExec LP MP MMEP).
   Import MMEP.
   Import MME.
   Import MemSpec.
   Import MMSP.
   Import MemExecM.
   Import MemHelpers.
-  Import LP.Events.
+  Import LP.DV.
 
   (* TODO: move this *)
   Lemma zip_cons :
@@ -6059,7 +6055,7 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
       forall dt ptr pre,
         exec_correct pre (read_uvalue dt ptr) (read_uvalue_spec dt ptr)
           (a0 <-
-             (_ <- get_consecutive_ptrs ptr (N.to_nat (LP.SIZEOF.sizeof_dtyp dt));;
+             (_ <- get_consecutive_ptrs ptr (N.to_nat (LP.SZ.sizeof_dtyp dt));;
               (fun (ms0 : MemState) (st0 : store_id) (bytes : list MP.BYTE_IMPL.SByte) 
                  (ms'0 : MemState) (st'0 : store_id) =>
                  Forall
@@ -6077,7 +6073,6 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
 
     (* TODO: move this? *)
     Import MP.
-    Import LP.
     Import GEP.
     Lemma MemMonad_run_get_consecutive_ptrs:
       forall {M RunM : Type -> Type} {MM : Monad M} {MRun : Monad RunM}
@@ -6114,7 +6109,7 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
 
         destruct
           (map_monad
-             (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix])
+             (fun ix : LP.IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix])
              NOOM_seq) eqn:HMAPM.
         + cbn.
           rewrite MemMonad_run_bind.
@@ -6341,6 +6336,8 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
       apply exec_correct_ret.
     Qed.
 
+    Import LP.
+    
     Lemma get_consecutive_ptrs_preserves_state :
       forall st ms st' ms' ptr bytes a,
         @within MemM EQM err_ub_oom (prod store_id MemState) (prod store_id MemState)
@@ -6349,7 +6346,7 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
                 RunOOM EQM EQRI MLAWS MM) MRun
              (@MemMonad_eq1_runm_equiv MemM (itree Eff) MM0 MRun MPROV MSID MMS MERR MUB MOOM RunERR
                 RunUB RunOOM EQM EQRI MLAWS MM) RunERR RunUB RunOOM MM0 MRun MPROV MSID MMS MERR MUB
-             MOOM RunERR RunUB RunOOM EQM EQRI MLAWS MM) (list ADDR.addr)
+             MOOM RunERR RunUB RunOOM EQM EQRI MLAWS MM) (list LP.ADDR.addr)
           (@get_consecutive_ptrs MemM MM0 MOOM MERR ptr (@Datatypes.length BYTE_IMPL.SByte bytes))
           (@pair store_id MemState st ms)
           (@ret err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -6382,22 +6379,25 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
       auto.
     Qed.
 
+
+    Import IP.
+    
     Lemma write_bytes_correct :
       forall ptr bytes,
         exec_correct
           (fun ms st => Forall (fun byte => exists s, MemByte.sbyte_sid byte = inr s /\ (s < st)%N) bytes)
           (write_bytes ptr bytes) (write_bytes_spec ptr bytes)
           (@exec_correct_post_bind (list ADDR.addr) unit
-             (@exec_correct_post_bind (list IP.intptr) (list ADDR.addr)
+             (@exec_correct_post_bind (list intptr) (list ADDR.addr)
                 (@lift_OOM exec_correct_post Monad_exec_correct_post RAISE_OOM_exec_correct_post
-                   (list IP.intptr) (intptr_seq 0 (@Datatypes.length BYTE_IMPL.SByte bytes)))
-                (fun ixs : list IP.intptr =>
+                   (list intptr) (intptr_seq 0 (@Datatypes.length BYTE_IMPL.SByte bytes)))
+                (fun ixs : list intptr =>
                    @exec_correct_post_bind (list (OOM ADDR.addr)) (list ADDR.addr)
                      (@lift_err_RAISE_ERROR (list (OOM ADDR.addr)) exec_correct_post Monad_exec_correct_post
                         RAISE_ERROR_exec_correct_post
-                        (@map_monad (sum string) (EitherMonad.Monad_either string) IP.intptr
+                        (@map_monad (sum string) (EitherMonad.Monad_either string) intptr
                            (OOM ADDR.addr)
-                           (fun ix : IP.intptr =>
+                           (fun ix : intptr =>
                               handle_gep_addr (DTYPE_I 8) ptr (@cons dvalue (DVALUE_IPTR ix) (@nil dvalue)))
                            ixs))
                      (fun addrs : list (OOM ADDR.addr) =>
@@ -6493,7 +6493,7 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
     Proof.
       intros uv dt sid st H.
       apply Forall_map.
-      remember (N.to_nat (SIZEOF.sizeof_dtyp dt)) as n.
+      remember (N.to_nat (SZ.sizeof_dtyp dt)) as n.
       clear Heqn.
       remember 0 as start.
       clear Heqstart.
@@ -6518,16 +6518,16 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
              (fun a : list BYTE_IMPL.SByte =>
                 (fun a0 : list BYTE_IMPL.SByte =>
                    @exec_correct_post_bind (list ADDR.addr) unit
-                     (@exec_correct_post_bind (list IP.intptr) (list ADDR.addr)
+                     (@exec_correct_post_bind (list intptr) (list ADDR.addr)
                         (@lift_OOM exec_correct_post Monad_exec_correct_post RAISE_OOM_exec_correct_post
-                           (list IP.intptr) (intptr_seq 0 (@Datatypes.length BYTE_IMPL.SByte a0)))
-                        (fun ixs : list IP.intptr =>
+                           (list intptr) (intptr_seq 0 (@Datatypes.length BYTE_IMPL.SByte a0)))
+                        (fun ixs : list intptr =>
                            @exec_correct_post_bind (list (OOM ADDR.addr)) (list ADDR.addr)
                              (@lift_err_RAISE_ERROR (list (OOM ADDR.addr)) exec_correct_post
                                 Monad_exec_correct_post RAISE_ERROR_exec_correct_post
-                                (@map_monad (sum string) (EitherMonad.Monad_either string) IP.intptr
+                                (@map_monad (sum string) (EitherMonad.Monad_either string) intptr
                                    (OOM ADDR.addr)
-                                   (fun ix : IP.intptr =>
+                                   (fun ix : intptr =>
                                       handle_gep_addr (DTYPE_I 8) ptr (@cons dvalue (DVALUE_IPTR ix) (@nil dvalue)))
                                    ixs))
                              (fun addrs : list (OOM ADDR.addr) =>
@@ -7013,16 +7013,16 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
                    ms0 = ms'0 /\ st0 = st'0));;
            (fun a1 : list BYTE_IMPL.SByte =>
               @exec_correct_post_bind (list ADDR.addr) unit
-                (@exec_correct_post_bind (list IP.intptr) (list ADDR.addr)
+                (@exec_correct_post_bind (list intptr) (list ADDR.addr)
                    (@lift_OOM exec_correct_post Monad_exec_correct_post RAISE_OOM_exec_correct_post
-                      (list IP.intptr) (intptr_seq 0 (@Datatypes.length BYTE_IMPL.SByte a1)))
-                   (fun ixs : list IP.intptr =>
+                      (list intptr) (intptr_seq 0 (@Datatypes.length BYTE_IMPL.SByte a1)))
+                   (fun ixs : list intptr =>
                       @exec_correct_post_bind (list (OOM ADDR.addr)) (list ADDR.addr)
                         (@lift_err_RAISE_ERROR (list (OOM ADDR.addr)) exec_correct_post Monad_exec_correct_post
                            RAISE_ERROR_exec_correct_post
-                           (@map_monad err (EitherMonad.Monad_either string) IP.intptr 
+                           (@map_monad err (EitherMonad.Monad_either string) intptr 
                               (OOM ADDR.addr)
-                              (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) dst [DVALUE_IPTR ix]) ixs))
+                              (fun ix : intptr => handle_gep_addr (DTYPE_I 8) dst [DVALUE_IPTR ix]) ixs))
                         (fun addrs : list (OOM ADDR.addr) =>
                            @lift_OOM exec_correct_post Monad_exec_correct_post RAISE_OOM_exec_correct_post
                              (list ADDR.addr) (@sequence OOM MonadOOM ADDR.addr addrs))))
@@ -7086,19 +7086,19 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
           (fun ms st => sid < st)
           (memset dst val len sid volatile) (memset_spec dst val len sid volatile)
           (@exec_correct_post_bind (list ADDR.addr) unit
-             (@exec_correct_post_bind (list IP.intptr) (list ADDR.addr)
+             (@exec_correct_post_bind (list intptr) (list ADDR.addr)
                 (@lift_OOM exec_correct_post Monad_exec_correct_post RAISE_OOM_exec_correct_post
-                   (list IP.intptr)
+                   (list intptr)
                    (intptr_seq 0
                       (@Datatypes.length BYTE_IMPL.SByte
                          (@repeatN BYTE_IMPL.SByte (Z.to_N len)
                             (BYTE_IMPL.uvalue_sbyte (@UVALUE_I 8 val) (DTYPE_I 8) 0 sid)))))
-                (fun ixs : list IP.intptr =>
+                (fun ixs : list intptr =>
                    @exec_correct_post_bind (list (OOM ADDR.addr)) (list ADDR.addr)
                      (@lift_err_RAISE_ERROR (list (OOM ADDR.addr)) exec_correct_post Monad_exec_correct_post
                         RAISE_ERROR_exec_correct_post
-                        (@map_monad err (EitherMonad.Monad_either string) IP.intptr (OOM ADDR.addr)
-                           (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) dst [DVALUE_IPTR ix]) ixs))
+                        (@map_monad err (EitherMonad.Monad_either string) intptr (OOM ADDR.addr)
+                           (fun ix : intptr => handle_gep_addr (DTYPE_I 8) dst [DVALUE_IPTR ix]) ixs))
                      (fun addrs : list (OOM ADDR.addr) =>
                         @lift_OOM exec_correct_post Monad_exec_correct_post RAISE_OOM_exec_correct_post
                           (list ADDR.addr) (@sequence OOM MonadOOM ADDR.addr addrs))))
@@ -7132,7 +7132,7 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
     Qed.
 
     Lemma handle_memory_correct :
-      forall T (m : MemoryE T) pre,
+      forall T (m : MemoryE dvalue uvalue T) pre,
         exec_correct pre (handle_memory T m) (handle_memory_prop T m) exec_correct_id_post.
     Proof using Type.
       intros T m pre.
@@ -7355,7 +7355,7 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
     Qed.
 
     Lemma handle_intrinsic_correct:
-      forall T (e : IntrinsicE T) pre,
+      forall T (e : IntrinsicE dvalue uvalue T) pre,
         exec_correct pre (handle_intrinsic T e) (handle_intrinsic_prop T e) exec_correct_id_post.
     Proof using Type.
       intros T e pre.
@@ -7410,7 +7410,7 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
   End Correctness.
 
   Import LP.PROV.
-  Import LP.SIZEOF.
+  Import LP.SZ.
   Import LP.ADDR.
 
   Lemma find_free_block_inv :
@@ -7666,16 +7666,16 @@ Module MemoryModelTheory (LP : LLVMParams) (MP : MemoryParams LP) (MMEP : Memory
 
 End MemoryModelTheory.
 
-Module MemStateInfiniteHelpers (LP : LLVMParamsBig) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP).
+Module MemStateInfiniteHelpers (LP : LLVMParamsBig) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP).
   (* Intptrs are "big" *)
-  Import LP.Events.
+  Import LP.DV.
   Import LP.ITOP.
   Import LP.PTOI.
   Import LP.IP_BIG.
-  Import LP.IP.
+  Import LP.
   Import LP.ADDR.
   Import LP.PROV.
-  Import LP.SIZEOF.
+  Import LP.SZ.
 
   Import MMSP.
   Import MMS.
@@ -7749,13 +7749,13 @@ Module MemStateInfiniteHelpers (LP : LLVMParamsBig) (MP : MemoryParams LP) (MMSP
     cbn.
 
     pose proof map_monad_err_succeeds
-         (fun ix : intptr =>
-            handle_gep_addr (DTYPE_I 8) ptr [LP.Events.DV.DVALUE_IPTR ix])
+         (fun ix : IP.intptr =>
+            handle_gep_addr (DTYPE_I 8) ptr [DV.DVALUE_IPTR ix])
          ips as HMAPM.
 
     forward HMAPM.
     { intros a IN.
-      destruct (int_to_ptr (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * LP.IP.to_Z a)%Z (address_provenance ptr)) eqn:IX.
+      destruct (int_to_ptr (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * IP.to_Z a)%Z (address_provenance ptr)) eqn:IX.
       - exists (ret a0).
         apply handle_gep_addr_ix'; cbn; auto.
       - eapply handle_gep_addr_ix'_OOM in IX; auto.
@@ -7783,7 +7783,7 @@ Module MemStateInfiniteHelpers (LP : LLVMParamsBig) (MP : MemoryParams LP) (MMSP
       apply handle_gep_addr_ix_OOM in GEP; auto.
       destruct GEP as [msg' GEP].
       pose proof
-        (LP.I2P_BIG.int_to_ptr_safe (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * to_Z ix)
+        (LP.I2P_BIG.int_to_ptr_safe (ptr_to_int ptr + Z.of_N (sizeof_dtyp (DTYPE_I 8)) * IP.to_Z ix)
            (address_provenance ptr)) as SAFE.
       rewrite GEP in SAFE.
       contradiction.
@@ -7792,16 +7792,9 @@ Module MemStateInfiniteHelpers (LP : LLVMParamsBig) (MP : MemoryParams LP) (MMSP
 
 End MemStateInfiniteHelpers.
 
-Module Type MemoryModelInfiniteSpec (LP : LLVMParamsBig) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP).
+Module Type MemoryModelInfiniteSpec (LP : LLVMParamsBig) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP).
   (* Intptrs are "big" *)
-  Import LP.Events.
-  Import LP.ITOP.
-  Import LP.PTOI.
-  Import LP.IP_BIG.
-  Import LP.IP.
-  Import LP.ADDR.
   Import LP.PROV.
-  Import LP.SIZEOF.
 
   Import MMSP.
   Import MMS.
@@ -7825,15 +7818,15 @@ Module Type MemoryModelInfiniteSpec (LP : LLVMParamsBig) (MP : MemoryParams LP) 
 
 End MemoryModelInfiniteSpec.
 
-Module MemoryModelInfiniteSpecHelpers (LP : LLVMParamsBig) (MP : MemoryParams LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP) (MMIS : MemoryModelInfiniteSpec LP MP MMSP MMS).
-  Import LP.Events.
+Module MemoryModelInfiniteSpecHelpers (LP : LLVMParamsBig) (MP : MEMORY_PARAMS LP) (MMSP : MemoryModelSpecPrimitives LP MP) (MMS : MemoryModelSpec LP MP MMSP) (MMIS : MemoryModelInfiniteSpec LP MP MMSP MMS).
+  Import LP.DV.
   Import LP.ITOP.
   Import LP.PTOI.
   Import LP.IP_BIG.
   Import LP.IP.
   Import LP.ADDR.
   Import LP.PROV.
-  Import LP.SIZEOF.
+  Import LP.SZ.
 
   Import MMSP.
   Import MMS.

--- a/src/rocq/Handlers/MemoryModelImplementation.v
+++ b/src/rocq/Handlers/MemoryModelImplementation.v
@@ -120,14 +120,14 @@ Module IP64Bit := FiniteIntptr.IP64Bit.
 Module BigIP := FiniteIntptr.BigIP.
 Module FinSizeof := FiniteSizeof.FinSizeof.
 
-Module MakeFiniteMemoryModelSpec (LP : LLVMParams) (MP : MemoryParams LP).
+Module MakeFiniteMemoryModelSpec (LP : LLVMParams) (MP : MEMORY_PARAMS LP).
   Module FMSP := FiniteMemoryModelSpecPrimitives LP MP.
   Module FMS := MakeMemoryModelSpec LP MP FMSP.
 
   Export FMSP FMS.
 End MakeFiniteMemoryModelSpec.
 
-Module MakeFiniteMemoryModelExec (LP : LLVMParams) (MP : MemoryParams LP).
+Module MakeFiniteMemoryModelExec (LP : LLVMParams) (MP : MEMORY_PARAMS LP).
   Module FMEP := FiniteMemoryModelExecPrimitives LP MP.
   Module FME := MakeMemoryModelExec LP MP FMEP.
 End MakeFiniteMemoryModelExec.
@@ -135,8 +135,8 @@ End MakeFiniteMemoryModelExec.
 Module MakeFiniteMemory (LP : LLVMParams) <: Memory LP.
   Import LP.
 
-  Module GEP := GepM.Make ADDR IP SIZEOF Events PTOI PROV ITOP.
-  Module Byte := FinByte ADDR IP SIZEOF Events.
+  Module GEP := GepM.Make LP.
+  Module Byte := FinByte LP.
   Module DVALUE_BYTE := DvalueBytes.Make LP.
 
   Module MP := MemoryParams.Make LP GEP Byte DVALUE_BYTE.
@@ -147,7 +147,7 @@ Module MakeFiniteMemory (LP : LLVMParams) <: Memory LP.
   Module MEM_EXEC_INTERP := MakeMemoryExecInterpreter LP MP MMEP MEM_MODEL MEM_SPEC_INTERP.
 
   (* Concretization *)
-  Module ByteM := MemBytes.Byte ADDR IP SIZEOF LP.Events MP.BYTE_IMPL.
+  Module ByteM := MemBytes.Byte LP MP.BYTE_IMPL.
   Module CP := ConcretizationParams.Make LP MP ByteM.
 
   Export GEP Byte MP MEM_MODEL CP.
@@ -180,7 +180,7 @@ Module MemoryBigIntptrInfiniteSpec <: MemoryModelInfiniteSpec LLVMParamsBigIntpt
   Module MMS := MemoryBigIntptr.MMEP.MemSpec.
   Module MME := MemoryBigIntptr.MEM_MODEL.
 
-  Import LP.Events.
+  Import LP.DV.
   Import LP.ITOP.
   Import LP.PTOI.
   Import LP.IP_BIG.
@@ -188,7 +188,7 @@ Module MemoryBigIntptrInfiniteSpec <: MemoryModelInfiniteSpec LLVMParamsBigIntpt
   Import LP.IP.
   Import LP.ADDR.
   Import LP.PROV.
-  Import LP.SIZEOF.
+  Import LP.SZ.
 
   Import MMSP.
   Import MMS.
@@ -215,7 +215,7 @@ Module MemoryBigIntptrInfiniteSpec <: MemoryModelInfiniteSpec LLVMParamsBigIntpt
   Import ExecInterp.
 
   #[local] Parameter (E : Type -> Type).
-  Notation Eff := (E +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE).
+  Notation Eff := (E +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE).
 
   Import Eq.
   Import MMSP.
@@ -428,7 +428,7 @@ Module MemoryBigIntptrInfiniteSpec <: MemoryModelInfiniteSpec LLVMParamsBigIntpt
       cbn in REST.
       destruct (map_monad
                   (fun ix : IP.intptr =>
-                     GEP.handle_gep_addr (DTYPE_I 8) a [Events.DV.DVALUE_IPTR ix]) seq) eqn:HMAPM.
+                     GEP.handle_gep_addr (DTYPE_I 8) a [LP.DV.DVALUE_IPTR ix]) seq) eqn:HMAPM.
 
       { (* Error, should be contradiction *)
         cbn in REST.
@@ -518,7 +518,7 @@ Module MemoryBigIntptrInfiniteSpec <: MemoryModelInfiniteSpec LLVMParamsBigIntpt
       cbn in REST.
       destruct (map_monad
                   (fun ix : IP.intptr =>
-                     GEP.handle_gep_addr (DTYPE_I 8) a [Events.DV.DVALUE_IPTR ix]) seq) eqn:HMAPM.
+                     GEP.handle_gep_addr (DTYPE_I 8) a [LP.DV.DVALUE_IPTR ix]) seq) eqn:HMAPM.
 
       { (* Error, should be contradiction *)
         cbn in REST.
@@ -629,7 +629,7 @@ Module MemoryBigIntptrInfiniteSpec <: MemoryModelInfiniteSpec LLVMParamsBigIntpt
 
     destruct (map_monad
                 (fun ix : IP.intptr =>
-                   GEP.handle_gep_addr (DTYPE_I 8) a [Events.DV.DVALUE_IPTR ix]) seq) eqn:HMAPM.
+                   GEP.handle_gep_addr (DTYPE_I 8) a [LP.DV.DVALUE_IPTR ix]) seq) eqn:HMAPM.
 
     { (* Error *)
       cbn in HMAPM.

--- a/src/rocq/Handlers/MemoryModules/FiniteExecPrimitives.v
+++ b/src/rocq/Handlers/MemoryModules/FiniteExecPrimitives.v
@@ -73,15 +73,14 @@ Open Scope monad_scope.
 
 #[local] Open Scope Z_scope.
 
-Module FiniteMemoryModelExecPrimitives (LP : LLVMParams) (MP : MemoryParams LP) <: MemoryModelExecPrimitives LP MP.
+Module FiniteMemoryModelExecPrimitives (LP : LLVMParams) (MP : MEMORY_PARAMS LP) <: MemoryModelExecPrimitives LP MP.
   Module MMSP := FiniteMemoryModelSpecPrimitives LP MP.
   Module MemSpec := MakeMemoryModelSpec LP MP MMSP.
   Module MemExecM := MakeMemoryExecMonad LP MP MMSP MemSpec.
   Import MemExecM.
 
-  Import LP.
   Import LP.ADDR.
-  Import LP.SIZEOF.
+  Import LP.SZ.
   Import LP.PROV.
   Import LP.PTOI.
   Import LP.ITOP.
@@ -3345,6 +3344,9 @@ Module FiniteMemoryModelExecPrimitives (LP : LLVMParams) (MP : MemoryParams LP) 
       }
     Qed.
 
+
+    Import LP.
+    
     (* TODO: move this? *)
     Lemma MemMonad_run_get_consecutive_ptrs:
       forall {M RunM : Type -> Type} {MM : Monad M} {MRun : Monad RunM}
@@ -3380,7 +3382,7 @@ Module FiniteMemoryModelExecPrimitives (LP : LLVMParams) (MP : MemoryParams LP) 
 
         destruct
           (map_monad
-             (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix])
+             (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [DV.DVALUE_IPTR ix])
              NOOM_seq) eqn:HMAPM.
         + cbn.
           rewrite MemMonad_run_bind.
@@ -3769,7 +3771,7 @@ Module FiniteMemoryModelExecPrimitives (LP : LLVMParams) (MP : MemoryParams LP) 
       exists ms2. exists l.
       split; auto.
 
-      destruct (map_monad (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix]) l) eqn:HMAPM; cbn in *.
+      destruct (map_monad (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [LP.DV.DVALUE_IPTR ix]) l) eqn:HMAPM; cbn in *.
       destruct MAPM as [_ [_ [[] _]]].
       destruct MAPM as [sab [a [[EQSAB EQA] SEQUENCE]]]; subst.
       exists ms2. exists l0.
@@ -3790,7 +3792,7 @@ Module FiniteMemoryModelExecPrimitives (LP : LLVMParams) (MP : MemoryParams LP) 
       destruct CONSEC as [ms' [ixs [SEQ MAPM]]].
       destruct (intptr_seq 0 len) eqn:HSEQ; cbn in SEQ; inv SEQ.
       cbn.
-      destruct (map_monad (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix]) l) eqn:HMAPM; cbn in *.
+      destruct (map_monad (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [DV.DVALUE_IPTR ix]) l) eqn:HMAPM; cbn in *.
       destruct MAPM as [_ [_ [[] _]]].
       destruct MAPM as [sab [a [[EQSAB EQA] SEQUENCE]]]; subst.
       destruct (Monads.sequence l0) eqn:HSEQUENCE;
@@ -3809,7 +3811,7 @@ Module FiniteMemoryModelExecPrimitives (LP : LLVMParams) (MP : MemoryParams LP) 
       destruct CONSEC as [ms' [ixs [SEQ MAPM]]].
       destruct (intptr_seq 0 len) eqn:HSEQ; cbn in SEQ; inv SEQ.
       destruct (map_monad
-                  (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [Events.DV.DVALUE_IPTR ix]) l) eqn:HMAPM.
+                  (fun ix : IP.intptr => handle_gep_addr (DTYPE_I 8) ptr [DV.DVALUE_IPTR ix]) l) eqn:HMAPM.
       destruct MAPM as [_ [_ [[] _]]].
       destruct MAPM as [sab [a [[EQSAB EQA] SEQUENCE]]]; subst.
       destruct (Monads.sequence l0) eqn:HSEQUENCE.

--- a/src/rocq/Handlers/MemoryModules/FiniteSizeof.v
+++ b/src/rocq/Handlers/MemoryModules/FiniteSizeof.v
@@ -12,12 +12,12 @@ From Vellvm.Syntax Require Import
 
 From Vellvm.Semantics Require Import
      DynamicValues
-     LLVMEvents
+     LLVMParams
      Memory.MemBytes
      Memory.Sizeof
      StoreId.
 
-Module FinSizeof : Sizeof.
+Module FinSizeof : SIZEOF.
   (* TODO: make parameter? *)
   Definition ptr_size : nat := 8.
 
@@ -178,11 +178,10 @@ End FinSizeof.
 Inductive UByte (uvalue : Type) :=
 | mkUByte (uv : uvalue) (dt : dtyp) (idx : N) (sid : store_id) : UByte uvalue.
 
-Module FinByte (ADDR : MemoryAddress.ADDRESS) (IP : MemoryAddress.INTPTR) (SIZEOF : Sizeof) (LLVMEvents:LLVM_INTERACTIONS(ADDR)(IP)(SIZEOF)) : ByteImpl(ADDR)(IP)(SIZEOF)(LLVMEvents)
-with  Definition SByte := UByte LLVMEvents.DV.uvalue
-with  Definition uvalue_sbyte := mkUByte LLVMEvents.DV.uvalue.
-  Import LLVMEvents.
-  Import DV.
+Module FinByte (LP:LLVMParams) : ByteImpl(LP)
+with  Definition SByte := UByte LP.DV.uvalue
+with  Definition uvalue_sbyte := mkUByte LP.DV.uvalue.
+  Import LP.DV.
 
   Definition SByte := UByte uvalue.
 

--- a/src/rocq/Handlers/MemoryModules/FiniteSpecPrimitives.v
+++ b/src/rocq/Handlers/MemoryModules/FiniteSpecPrimitives.v
@@ -50,21 +50,19 @@ Open Scope monad_scope.
 
 #[local] Open Scope Z_scope.
 
-Module FiniteMemoryModelSpecPrimitives (LP : LLVMParams) (MP : MemoryParams LP) <: MemoryModelSpecPrimitives LP MP.
-  Import LP.
-  Import LP.Events.
+Module FiniteMemoryModelSpecPrimitives (LP : LLVMParams) (MP : MEMORY_PARAMS LP) <: MemoryModelSpecPrimitives LP MP.
+  Import LP.DV.
   Import LP.ADDR.
-  Import LP.SIZEOF.
+  Import LP.SZ.
   Import LP.PROV.
-  Import PTOI.
-  Import ITOP.
+  Import LP.PTOI.
+  Import LP.ITOP.
   Import MP.
   Import GEP.
 
   Import MemBytes.
-  Module MemByte := Byte LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL.
+  Module MemByte := Byte LP MP.BYTE_IMPL.
   Import MemByte.
-  Import LP.SIZEOF.
 
 
   Section Datatype_Definition.

--- a/src/rocq/Handlers/Pick.v
+++ b/src/rocq/Handlers/Pick.v
@@ -57,12 +57,12 @@ Import MonadNotation.
   - The propositional one capture in [Prop] all possible values
   - The executable one interprets [undef] as 0 at the type
  *)
-Module Make (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL) (CP : ConcretizationParams LP MP Byte).
+Module Make (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL) (CP : ConcretizationParams LP MP Byte).
   Import CP.
   Import CONC.
   Import MP.
   Import LP.
-  Import Events.
+  Import DV.
 
   Section PickPropositional.
 
@@ -107,7 +107,7 @@ Module Make (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR 
     Arguments lift_err_ub_oom_post_ret {_ _ _ _ _ _} _ _ _.
 
 
-    Inductive PickUvalue_handler  {E} `{FE:FailureE -< E} `{FO:UBE -< E} `{OO: OOME -< E} : PickUvalueE ~> PropT E :=
+    Inductive PickUvalue_handler  {E} `{FE:FailureE -< E} `{FO:UBE -< E} `{OO: OOME -< E} : PickUvalueE dvalue uvalue ~> PropT E :=
     | PickUV_UniqueUB : forall x t,
         ~ (unique_prop x) ->
         PickUvalue_handler (@pickUnique _ _ (fun _ _ => True) x) t
@@ -144,7 +144,7 @@ Module Make (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR 
       Definition model_undef_k_spec
         `{UB: UBE -< E +' F}
         {T R : Type}
-        (e : (E +' PickUvalueE +' F) T)
+        (e : (E +' PickUvalueE dvalue uvalue +' F) T)
         (ta : itree (E +' F) T)
         (k2 : T -> itree (E +' F) R)
         (t2 : itree (E +' F) R) : Prop
@@ -172,7 +172,7 @@ Module Make (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR 
         interp_prop_oom_r (OOM:=OOME) (case_ E_trigger_prop (case_ PickUvalue_handler F_trigger_prop)) RR (@model_undef_k_spec UB).
 
       Definition model_undef `{FailureE -< E +' F} `{UBE -< E +' F} `{OOME -< F}
-        {T} (RR : T -> T -> Prop) (ts : PropT (E +' PickUvalueE +' F) T) : PropT (E +' F) T:=
+        {T} (RR : T -> T -> Prop) (ts : PropT (E +' PickUvalueE dvalue uvalue +' F) T) : PropT (E +' F) T:=
         fun t_picked => exists t_pre, ts t_pre /\ model_undef_h RR t_pre t_picked.
     End PARAMS_MODEL.
 
@@ -2382,7 +2382,7 @@ Module Make (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR 
       }
     Qed.
 
-    Definition concretize_picks {E} `{FailureE -< E} `{UBE -< E} `{OOME -< E} : PickUvalueE ~> itree E :=
+    Definition concretize_picks {E} `{FailureE -< E} `{UBE -< E} `{OOME -< E} : PickUvalueE dvalue uvalue ~> itree E :=
       fun T p =>
         match p with
         | pick u

--- a/src/rocq/Handlers/SerializationTheory.v
+++ b/src/rocq/Handlers/SerializationTheory.v
@@ -22,14 +22,13 @@ From Vellvm Require Import
 Import MonadNotation.
 Import MonadReturnsLaws.
 
-Module MemBytesTheory (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL) (CP : ConcretizationParams LP MP Byte).
+Module MemBytesTheory (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL) (CP : ConcretizationParams LP MP Byte).
   Import CP.
   Import CONC.
   Import MP.
   Import LP.
 
-  Import Events.
-  Import SIZEOF.
+  Import SZ.
   Import PTOI.
   Import PROV.
   Import ITOP.
@@ -199,18 +198,17 @@ Module MemBytesTheory (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModul
   Qed.
 End MemBytesTheory.
 
-Module SerializationTheory (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL) (CP : ConcretizationParams LP MP Byte).
+Module SerializationTheory (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL) (CP : ConcretizationParams LP MP Byte).
   Import CP.
   Import CONC.
   Import MP.
   Import LP.
 
-  Import Events.
-
   Module MBT := MemBytesTheory LP MP Byte CP.
   Import MBT.
   Import Byte.
-  Import SIZEOF.
+  Import SZ.
+  Import DV.
 
   Module Mem := MakeFiniteMemory LP.
   Import Mem.

--- a/src/rocq/Handlers/Stack.v
+++ b/src/rocq/Handlers/Stack.v
@@ -22,6 +22,7 @@ From Vellvm Require Import
      Semantics.MemoryAddress
      Semantics.Memory.Sizeof
      Semantics.DynamicValues
+     Semantics.LLVMParams
      Semantics.LLVMEvents
      Handlers.Local.
 
@@ -226,8 +227,7 @@ From ExtLib Require Import
    it until [TopLevel] either.
    We are hence exposing the specialization here, but it is slightly awkward.
  *)
-Module Make (A : ADDRESS)(IP : INTPTR)(SIZEOF : Sizeof)(LLVMEvents : LLVM_INTERACTIONS(A)(IP)(SIZEOF)).
-  Definition lstack_frame := @stack_frame LLVMEvents.DV.uvalue (list (raw_id * LLVMEvents.DV.uvalue)).
-  Definition lstack := @stack LLVMEvents.DV.uvalue (list (raw_id * LLVMEvents.DV.uvalue)).
+Module Make (LP:LLVMParams).
+  Definition lstack_frame := @stack_frame LP.DV.uvalue (list (raw_id * LP.DV.uvalue)).
+  Definition lstack := @stack LP.DV.uvalue (list (raw_id * LP.DV.uvalue)).
 End Make.
-Set Printing Implicit.

--- a/src/rocq/QC/GenAST.v
+++ b/src/rocq/QC/GenAST.v
@@ -18,9 +18,6 @@ From Vellvm.Syntax Require Import
   TypToDtyp
   DynamicTypes.
 
-From Vellvm.Handlers Require Import
-  Handlers.
-
 From Vellvm.Semantics Require Import
   TopLevel.
 
@@ -2234,16 +2231,16 @@ Section ExpGenerators.
   gen_ibinop_exp_typ (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) (t : typ) {struct t} : GenLLVM (exp typ)
   := ibinop <- lift gen_ibinop;;
 
-    if Handlers.LLVMEvents.DV.iop_is_div ibinop && Handlers.LLVMEvents.DV.iop_is_signed ibinop
+    if AstLib.iop_is_div ibinop && AstLib.iop_is_signed ibinop
     then
       ret (OP_IBinop ibinop) <*> ret t <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t <*> gen_non_zero_exp_size 0%nat t
     else
-      if Handlers.LLVMEvents.DV.iop_is_div ibinop
+      if AstLib.iop_is_div ibinop
       then
         ret (OP_IBinop ibinop) <*> ret t <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t <*> gen_gt_zero_exp_size 0%nat t
       else
         exp_value <- gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t;;
-        if Handlers.LLVMEvents.DV.iop_is_shift ibinop
+        if AstLib.iop_is_shift ibinop
         then
           let max_shift_size :=
             match t with
@@ -2264,11 +2261,11 @@ Section ExpGenerators.
   :=
     match ty with
     | TYPE_FP FP_float => fbinop <- lift gen_fbinop;;
-                   if (Handlers.LLVMEvents.DV.fop_is_div fbinop)
+                   if (AstLib.fop_is_div fbinop)
                    then ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty
                    else ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty
     | TYPE_FP FP_double => fbinop <- lift gen_fbinop;;
-                    if (Handlers.LLVMEvents.DV.fop_is_div fbinop)
+                    if (AstLib.fop_is_div fbinop)
                     then ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty
                     else ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty
     | _ => failGen "gen_fbinop_exp"
@@ -2363,16 +2360,10 @@ End ExpGenerators.
 
 Require Import Semantics.LLVMEvents.
 Require Import Semantics.InterpretationStack.
-Require Import Handlers.Handlers.
 From ITree Require Import
   ITree
   Interp.Recursion
   Events.Exception.
-
-Import TopLevel64BitIntptr.
-Import DV.
-Import MemoryModelImplementation.LLVMParams64BitIntptr.Events.
-
 
 Section InstrGenerators.
 

--- a/src/rocq/QC/GenAlive2.v
+++ b/src/rocq/QC/GenAlive2.v
@@ -44,14 +44,14 @@ Set Warnings "-extraction-opaque-accessed,-extraction".
 
 Unset Guard Checking.
 
-Module GEN_ALIVE2 (ADDR : MemoryAddress.ADDRESS) (IP:MemoryAddress.INTPTR) (SIZEOF : Sizeof).
+Module GEN_ALIVE2 (ADDR : MemoryAddress.ADDRESS) (IP:MemoryAddress.INTPTR) (SZ : SIZEOF).
   Definition is_nil {A} (l : list A) : bool :=
     match l with
     | nil => true
     | _ => false
     end.
 
-  Module DV := DynamicValues.DVALUE(ADDR)(IP)(SIZEOF).
+  Module DV := DynamicValues.DVALUE(ADDR)(IP)(SZ).
   Import DV.
   Definition var_context := list (ident * typ).
   Record GenState :=

--- a/src/rocq/Semantics/ConcretizationParams.v
+++ b/src/rocq/Semantics/ConcretizationParams.v
@@ -4,11 +4,11 @@ From Vellvm Require Import
      Semantics.Memory.MemBytes
      Handlers.Concretization.
 
-Module Type ConcretizationParams (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL).
+Module Type ConcretizationParams (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL).
   Module CONCBASE := Concretization.MakeBase LP MP Byte.
   Module CONC := Concretization.Make LP MP Byte CONCBASE.
 End ConcretizationParams.
 
-Module Make (LP' : LLVMParams) (MP' : MemoryParams LP') (Byte' : ByteModule LP'.ADDR LP'.IP LP'.SIZEOF LP'.Events MP'.BYTE_IMPL) : ConcretizationParams LP' MP' Byte'.
+Module Make (LP' : LLVMParams) (MP' :MEMORY_PARAMS LP') (Byte' : ByteModule LP' MP'.BYTE_IMPL) : ConcretizationParams LP' MP' Byte'.
   Include ConcretizationParams LP' MP' Byte'.
 End Make.

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -123,23 +123,23 @@ Definition fast_mode_object : fast_mode :=
     itrees in the second phase.
  *)
 
-Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP.ADDR LP.IP LP.SIZEOF LP.Events MP.BYTE_IMPL) (CP : ConcretizationParams LP MP Byte).
+Module Denotation (LP : LLVMParams) (MP : MEMORY_PARAMS LP) (Byte : ByteModule LP MP.BYTE_IMPL) (CP : ConcretizationParams LP MP Byte).
   Import CP.
   Import CONC.
   Import MP.
   Import LP.
-  Import Events.
+  Import DV.
 
   Definition dv_zero_initializer (t:dtyp) : err dvalue :=
     default_dvalue_of_dtyp t.
-
+  
   (** ** Ident lookups
       Look-ups depend on the nature of the [ident], that may be local or global.
       In each case, we simply trigger the corresponding read event.
       Note: global maps contain [dvalue]s, while local maps contain [uvalue]s.
       We perform the conversion here.
    *)
-  Definition lookup_id (i:ident) : itree lookup_E uvalue :=
+  Definition lookup_id (i:ident) : itree (lookup_E dvalue uvalue) uvalue :=
     match i with
     | ID_Global x => dv <- trigger (GlobalRead x);; ret (dvalue_to_uvalue dv)
     | ID_Local x  => trigger (LocalRead x)
@@ -215,16 +215,17 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     
   Definition denote_float_syntax_as_float (f:float_syntax) : option float := 
     float_of_float_syntax f.
-  
+
+
   Fixpoint denote_exp'
-           (top:option dtyp) (o:exp dtyp) {struct o} : itree exp_E uvalue :=
+           (top:option dtyp) (o:exp dtyp) {struct o} : itree (exp_E dvalue uvalue) uvalue :=
     let eval_texp '(dt,ex) := denote_exp' (Some dt) ex
     in
     match o with
 
     (* The translation injects the [lookup_E] interface used by [lookup_id] to the ambient one *)
     | EXP_Ident i =>
-      translate LU_to_exp (lookup_id i)
+      translate (@LU_to_exp dvalue uvalue) (lookup_id i)
                 
     | EXP_Integer x =>
       match top with
@@ -408,20 +409,20 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
         end
     end.
 
-  Definition denote_exp (top:option dtyp) (o:exp dtyp) : itree exp_E uvalue
+  Definition denote_exp (top:option dtyp) (o:exp dtyp) : itree (exp_E dvalue uvalue) uvalue
     := uv <- denote_exp' top o;;
        concretize_if_no_undef_or_poison uv.
 
   Arguments denote_exp _ _ : simpl nomatch.
 
-  Definition denote_op (o:exp dtyp) : itree exp_E uvalue :=
+  Definition denote_op (o:exp dtyp) : itree (exp_E dvalue uvalue) uvalue :=
     denote_exp None o.
   Arguments denote_op _ : simpl nomatch.
 
 
   (* TODO: it would be nice to generalize this, but I really need to
      care about where the exception event is *)
-  Definition catch_llvm_exc_instr_E_h : IFun instr_E (fun R : Type => eitherT uvalue (itree instr_E) R).
+  Definition catch_llvm_exc_instr_E_h : IFun (instr_E dvalue uvalue) (fun R : Type => eitherT uvalue (itree (instr_E dvalue uvalue)) R).
     red.
     intros T e.
     refine
@@ -434,7 +435,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
        end).
   Defined.
 
-  Definition catch_llvm_exc_L0_h : IFun L0 (fun R : Type => eitherT uvalue (itree L0) R).
+  Definition catch_llvm_exc_L0_h : IFun (L0 dvalue uvalue) (fun R : Type => eitherT uvalue (itree (L0 dvalue uvalue)) R).
     red.
     intros T e.
     refine
@@ -447,7 +448,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
        end).
   Defined.
 
-  Definition catch_llvm_exc_L0'_h : IFun L0' (fun R : Type => eitherT uvalue (itree L0') R).
+  Definition catch_llvm_exc_L0'_h : IFun (L0' dvalue uvalue) (fun R : Type => eitherT uvalue (itree (L0' dvalue uvalue)) R).
     red.
     intros T e.
     refine
@@ -460,13 +461,13 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
        end).
   Defined.
 
-  Definition catch_llvm_exc_instr_E : itree instr_E ~> eitherT uvalue (itree instr_E)
+  Definition catch_llvm_exc_instr_E : itree (instr_E dvalue uvalue) ~> eitherT uvalue (itree (instr_E dvalue uvalue))
       := interp_either catch_llvm_exc_instr_E_h.
 
-  Definition catch_llvm_exc_L0 : itree L0 ~> eitherT uvalue (itree L0)
+  Definition catch_llvm_exc_L0 : itree (L0 dvalue uvalue) ~> eitherT uvalue (itree (L0 dvalue uvalue))
       := interp_either catch_llvm_exc_L0_h.
 
-  Definition catch_llvm_exc_L0' : itree L0' ~> eitherT uvalue (itree L0')
+  Definition catch_llvm_exc_L0' : itree (L0' dvalue uvalue) ~> eitherT uvalue (itree (L0' dvalue uvalue))
     := interp_either catch_llvm_exc_L0'_h.
 
   Definition local_write {E} `{LocalE raw_id uvalue -< E} `{FailureE -< E} `{UBE -< E} `{OOME -< E}
@@ -474,7 +475,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     uv' <- concretize_if_no_undef_or_poison uv;;
     trigger (LocalWrite id uv').
 
-  Definition denote_cmpxchg id cpx : itree instr_E unit :=
+  Definition denote_cmpxchg id cpx : itree (instr_E dvalue uvalue) unit :=
     (* SAZ: This will have to be revisited when we have a truly concurrent semantics. *)
     let '(ptr_ty, ptr_val) := cpx.(c_ptr) in
     let '(cmp_ty, cmp_val) := cpx.(c_cmp) in
@@ -487,9 +488,9 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     if (dtyp_eq_dec cmp_ty new_ty) then
 
       (* evaluate the arguments to the instruction *)
-      ptr_uv <- translate exp_to_instr (denote_exp (Some ptr_ty) ptr_val) ;;
-      cmp_uv <- translate exp_to_instr (denote_exp' (Some cmp_ty) cmp_val) ;;
-      new_uv <- translate exp_to_instr (denote_exp' (Some cmp_ty) new_val) ;;
+      ptr_uv <- translate (@exp_to_instr dvalue uvalue) (denote_exp (Some ptr_ty) ptr_val) ;;
+      cmp_uv <- translate (@exp_to_instr dvalue uvalue) (denote_exp' (Some cmp_ty) cmp_val) ;;
+      new_uv <- translate (@exp_to_instr dvalue uvalue) (denote_exp' (Some cmp_ty) new_val) ;;
 
       (* Perform the load - load addresses must be unique *)
       ptr_dv <- concretize_or_pick_unique ptr_uv;;
@@ -526,7 +527,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
            Similarly, it does not state whether the `disjoint` flag for `or` can be applied,
            so we set it to false.
   *)
-  Definition denote_atomic_rmw_operation a_op (pv : uvalue) (val : uvalue) : itree instr_E uvalue :=
+  Definition denote_atomic_rmw_operation a_op (pv : uvalue) (val : uvalue) : itree (instr_E dvalue uvalue) uvalue :=
     match a_op with
     | Axchg =>
         (* xchg: *ptr = val *)
@@ -576,14 +577,14 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     | Ausub_sat => raise ("Unsupported atomicrwm operation")
     end.
 
-  Definition denote_atomicrmw id armw : itree instr_E unit :=
+  Definition denote_atomicrmw id armw : itree (instr_E dvalue uvalue) unit :=
     let '(ptr_ty, ptr_val) := armw.(a_ptr) in
     let '(a_ty, a_val) := armw.(a_val) in
     let a_op := armw.(a_operation) in
 
     (* evaluate the arguments to the instruction *)
-    ptr_uv <- translate exp_to_instr (denote_exp (Some ptr_ty) ptr_val) ;;
-    a_uv <- translate exp_to_instr (denote_exp' (Some a_ty) a_val) ;;
+    ptr_uv <- translate (@exp_to_instr dvalue uvalue) (denote_exp (Some ptr_ty) ptr_val) ;;
+    a_uv <- translate (@exp_to_instr dvalue uvalue) (denote_exp' (Some a_ty) a_val) ;;
 
     (* Perform the load - load addresses must be unique *)
     ptr_dv <- concretize_or_pick_unique ptr_uv;;
@@ -601,7 +602,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
   (* An instruction has only side-effects, it therefore returns [unit] *)
   Definition denote_instr
-    (i: (instr_id * instr dtyp * list (metadata dtyp))) (varargs : option ADDR.addr) : itree instr_E unit :=
+    (i: (instr_id * instr dtyp * list (metadata dtyp))) (varargs : option ADDR.addr) : itree (instr_E dvalue uvalue) unit :=
     let '(i, md) := i in
     (* The following two lines set up file location information. *)
     (* extract it from the metadata: *)
@@ -615,7 +616,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     (* Pure operations *)
 
     | (IId id, INSTR_Op op) =>
-        uv <- translate exp_to_instr (denote_op op) ;;
+        uv <- translate (@exp_to_instr dvalue uvalue) (denote_op op) ;;
         local_write id uv ;;
         ret tt
     (* Allocation *)
@@ -641,7 +642,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
             dv <- trigger (Alloca dt 1 align);;
             local_write id (dvalue_to_uvalue dv)
         | Some (t, num_exp) =>
-            un <- translate exp_to_instr (denote_exp (Some t) num_exp);;
+            un <- translate (@exp_to_instr dvalue uvalue) (denote_exp (Some t) num_exp);;
             n <- concretize_or_pick_unique un;;
             dv <- trigger (Alloca dt (Z.to_N (dvalue_int_unsigned n)) align);;
             local_write id (dvalue_to_uvalue dv)
@@ -650,7 +651,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
     (* Load *)
     | (IId id, INSTR_Load dt (du,ptr) _) =>
-      ua <- translate exp_to_instr (denote_exp (Some du) ptr);;
+      ua <- translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some du) ptr);;
       (* Load addresses must be unique *)
       da <- concretize_or_pick_unique ua;;
       uv <- trigger (Load dt da);;
@@ -659,8 +660,8 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
     (* Store *)
     | (IVoid _, INSTR_Store (dt, val) (du, ptr) _) =>
-      uv <- translate exp_to_instr (denote_exp (Some dt) val) ;;
-      ua <- translate exp_to_instr (denote_exp (Some du) ptr) ;;
+      uv <- translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some dt) val) ;;
+      ua <- translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some du) ptr) ;;
       (* Store addresses must be unique *)
       da <- concretize_or_pick_unique ua ;;
       match da with
@@ -674,7 +675,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     (* Call *)
     (* TODO: technically operand bundles can affect semantics *)
     | (pt, INSTR_Call (dt, f) args _ _) =>
-      uvs <- map_monad (fun '(t, op) => (translate exp_to_instr (denote_exp (Some t) op))) (List.map fst args) ;;
+      uvs <- map_monad (fun '(t, op) => (translate (@exp_to_instr dvalue uvalue) (denote_exp (Some t) op))) (List.map fst args) ;;
       returned_value <-
         match intrinsic_exp f with
           (* TODO: look at whether these can be moved to IntrinsicsDefinitions.v *)
@@ -683,7 +684,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
           then
             match args, varargs with
             | [ ((t, e), _) ], Some varargs =>
-                ua <- translate exp_to_instr (denote_exp (Some t) e);;
+                ua <- translate (@exp_to_instr dvalue uvalue) (denote_exp (Some t) e);;
                 da <- concretize_or_pick_unique ua;;
                 match da with
                 | DVALUE_Poison dt => raiseUB ("Store to poisoned address.")
@@ -697,9 +698,9 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
             then
               match args with
               | [((DTYPE_Pointer, exp_dest), _); ((DTYPE_Pointer, exp_src), _)] =>
-                  usrc <- translate exp_to_instr (denote_exp (Some DTYPE_Pointer) exp_src);;
+                  usrc <- translate (@exp_to_instr dvalue uvalue) (denote_exp (Some DTYPE_Pointer) exp_src);;
                   dsrc <- concretize_or_pick_unique usrc;;
-                  udest <- translate exp_to_instr (denote_exp (Some DTYPE_Pointer) exp_dest);;
+                  udest <- translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some DTYPE_Pointer) exp_dest);;
                   ddest <- concretize_or_pick_unique udest;;
                   vargs <- trigger (Load DTYPE_Pointer dsrc);;
                   trigger (Store DTYPE_Pointer ddest vargs);;
@@ -716,7 +717,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
                    | inr dv => ret (dvalue_to_uvalue dv)
                    end
       | None =>
-        fv <- translate exp_to_instr (denote_exp None f);;
+        fv <- translate (@exp_to_instr dvalue uvalue)  (denote_exp None f);;
         res <- trigger (Call dt fv uvs);;
         match res with
         | inl exc => raiseLLVM exc
@@ -735,7 +736,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     | (IVoid _, INSTR_Comment _) => ret tt
 
     | (pt, INSTR_VAArg (t, ptr_to_args_exp) argty) =>
-        uptr_to_args <- translate exp_to_instr (denote_exp (Some DTYPE_Pointer) ptr_to_args_exp);;
+        uptr_to_args <- translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some DTYPE_Pointer) ptr_to_args_exp);;
         ptr_to_args <- concretize_or_pick_unique uptr_to_args;;
         uargs <- trigger (Load DTYPE_Pointer ptr_to_args);;
         args <- concretize_or_pick_unique uargs;;
@@ -790,7 +791,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
   (* A [terminator] either returns from a function call, producing a [dvalue],
          or jumps to a new [block_id]. *)
 
-  Definition denote_terminator (trm: (instr_id * terminator dtyp * list (metadata dtyp))): itree instr_E (block_id + uvalue) :=
+  Definition denote_terminator (trm: (instr_id * terminator dtyp * list (metadata dtyp))): itree (instr_E dvalue uvalue) (block_id + uvalue) :=
     let '(iid, t, md) := trm in
     let err_loc := location_error_string md in
     let bogus := set_loc err_loc in
@@ -798,14 +799,14 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     match t with
 
     | TERM_Ret (dt, op) =>
-      dv <- (translate exp_to_instr (denote_exp (Some dt) op)) ;;
+      dv <- (translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some dt) op)) ;;
       ret (inr dv)
 
     | TERM_Ret_void =>
         ret (inr UVALUE_None)
 
     | TERM_Br (dt,op) br1 br2 =>
-      uv <- (translate exp_to_instr (denote_exp (Some dt) op)) ;;
+      uv <- (translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some dt) op)) ;;
       dv <- concretize_or_pick_unique uv;;
       match dv with
       | @DVALUE_I 1 comparison_bit =>
@@ -821,7 +822,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
                         
                          
     | TERM_Switch (dt,e) default_br dests =>
-      uselector <- (translate exp_to_instr (denote_exp (Some dt) e));;
+      uselector <- (translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some dt) e));;
       (* Selection on [undef] is UB *)
       selector <- concretize_or_pick_unique uselector;;
       if dvalue_is_poison selector
@@ -840,8 +841,8 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
                                  
       (* TODO: technically operand bundles can affect the semantics of invoke *)
     | TERM_Invoke (dt, fnptrval) args to_label unwind_label anns _ =>
-      uvs <- map_monad (fun '(t, op) => (translate exp_to_instr (denote_exp (Some t) op))) (List.map fst args) ;;
-      fv <- (translate exp_to_instr (denote_exp None fnptrval)) ;;
+      uvs <- map_monad (fun '(t, op) => (translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some t) op))) (List.map fst args) ;;
+      fv <- (translate (@exp_to_instr dvalue uvalue)  (denote_exp None fnptrval)) ;;
       rv <- trigger (Call dt fv uvs) ;;
       (* branch to to_label *)
       match rv with
@@ -858,7 +859,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
       end
 
     | TERM_Resume (t, expr) =>
-      exn <- translate exp_to_instr (denote_exp (Some t) expr);;
+      exn <- translate (@exp_to_instr dvalue uvalue)  (denote_exp (Some t) expr);;
       raiseLLVM exn
 
     (* Currently unhandled VIR terminators *)
@@ -866,10 +867,10 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     end.
 
   (* Denoting a list of instruction simply binds the trees together *)
-  Definition denote_code (c: code dtyp) (varargs : option ADDR.addr) : itree instr_E unit :=
+  Definition denote_code (c: code dtyp) (varargs : option ADDR.addr) : itree (instr_E dvalue uvalue) unit :=
     map_monad_ (fun i => denote_instr i varargs) c.
 
-  Definition denote_phi (bid_from : block_id) (id_p : local_id * phi dtyp * (list (metadata dtyp))) : itree exp_E (local_id * uvalue) :=
+  Definition denote_phi (bid_from : block_id) (id_p : local_id * phi dtyp * (list (metadata dtyp))) : itree (exp_E dvalue uvalue) (local_id * uvalue) :=
     let '(id, Phi dt args, md) := id_p in
     let err_loc := location_error_string md in
     let bogus := set_loc err_loc in
@@ -881,16 +882,16 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
     | None => raise (err_loc ++ ": jump: phi node doesn't include block ")
     end.
 
-  Definition denote_phis (bid_from: block_id) (phis: list (local_id * phi dtyp * (list (metadata dtyp)))): itree instr_E unit :=
+  Definition denote_phis (bid_from: block_id) (phis: list (local_id * phi dtyp * (list (metadata dtyp)))): itree (instr_E dvalue uvalue) unit :=
     dvs <- map_monad
-             (fun x => translate exp_to_instr (denote_phi bid_from x))
+             (fun x => translate (@exp_to_instr dvalue uvalue) (denote_phi bid_from x))
              phis;;
     map_monad (fun '(id,dv) => local_write id dv) dvs;;
     ret tt.
 
   (* A block ends with a terminator, it either jumps to another block,
          or returns a dynamic value *)
-  Definition denote_block (b: block dtyp) (bid_from : block_id) (varargs : option ADDR.addr) : itree instr_E (block_id + uvalue) :=
+  Definition denote_block (b: block dtyp) (bid_from : block_id) (varargs : option ADDR.addr) : itree (instr_E dvalue uvalue) (block_id + uvalue) :=
     denote_phis bid_from (blk_phis b);;
     denote_code (blk_code b) varargs;;
     denote_terminator (blk_term b).
@@ -909,7 +910,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
          If it ever returns a dynamic value, we exit the loop by returning the [dvalue].
    *)
   Definition denote_ocfg (bks: ocfg dtyp) (varargs : option ADDR.addr)
-    : (block_id * block_id) -> itree instr_E ((block_id * block_id) + uvalue) :=
+    : (block_id * block_id) -> itree (instr_E dvalue uvalue) ((block_id * block_id) + uvalue) :=
     iter (C := ktree _) (bif := sum)
          (fun '((bid_from,bid_src) : block_id * block_id) =>
             match find_block bks bid_src with
@@ -922,7 +923,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
               end
             end).
 
-  Definition denote_cfg (f: cfg dtyp) (varargs : option ADDR.addr) : itree instr_E uvalue :=
+  Definition denote_cfg (f: cfg dtyp) (varargs : option ADDR.addr) : itree (instr_E dvalue uvalue) uvalue :=
     r <- denote_ocfg (blks f) varargs (init f,init f) ;;
     match r with
     | inl bid => raise ("Can't find block in denote_cfg " ++ show (snd bid))
@@ -932,7 +933,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
   (* The denotation of an itree function is a coq function that takes
          a list of uvalues and returns the appropriate semantics. *)
   Definition function_denotation : Type :=
-    list uvalue -> itree L0' uvalue.
+    list uvalue -> itree (L0' dvalue uvalue) uvalue.
 
   Fixpoint combine_lists_varargs {A B:Type} (l1:list A) (l2:list B) : err (list (A * B) * list B) :=
     match l1, l2 with
@@ -946,18 +947,19 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
         ret ([], vargs)
     end.
 
-  Definition pop_call_frame {E k v exc} `{MemoryE -< E} `{StackE k v exc -< E} : itree E unit :=
+  Definition pop_call_frame {E k v exc} `{MemoryE dvalue uvalue -< E} `{StackE k v exc -< E} : itree E unit :=
     trigger StackPop;;
     trigger MemPop.
 
+   
   (* Push call frame, return varargs address *)
-  Definition push_call_frame (df:definition dtyp (cfg dtyp)) (args : list uvalue) : itree L0' ADDR.addr :=
+  Definition push_call_frame (df:definition dtyp (cfg dtyp)) (args : list uvalue) : itree (L0' dvalue uvalue) ADDR.addr :=
     (* We match the arguments variables to the inputs *)
     '(bs, vs) <- lift_err ret (combine_lists_varargs (df_args df) args) ;;
     dts <- lift_err ret (map_monad dtyp_of_uvalue_fun vs);;
     let dt := DTYPE_Packed_struct dts in
     (* generate the corresponding writes to the local stack frame *)
-    trigger MemPush ;;
+    trigger (@MemPush dvalue uvalue) ;;
     trigger (StackPush bs) ;;
     varargs <- trigger (Alloca dt 1 None);;
     trigger (Store dt varargs (UVALUE_Packed_struct vs));;
@@ -970,7 +972,7 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
   Definition denote_function (df:definition dtyp (cfg dtyp)) : function_denotation :=
     fun (args : list uvalue) =>
       varg <- push_call_frame df args;;
-      rv <- translate instr_to_L0' (denote_cfg (df_instrs df) (Some varg));;
+      rv <- translate (@instr_to_L0' dvalue uvalue) (denote_cfg (df_instrs df) (Some varg));;
       pop_call_frame;;
       ret rv.
 
@@ -997,8 +999,8 @@ Module Denotation (LP : LLVMParams) (MP : MemoryParams LP) (Byte : ByteModule LP
 
   Definition denote_mcfg
     (fundefs:IntMap function_denotation) (dt : dtyp)
-    (f_value : uvalue) (args : list uvalue) : itree L0 (uvalue + uvalue) :=
-    @mrec CallE (ExternalCallE +' _)
+    (f_value : uvalue) (args : list uvalue) : itree (L0 dvalue uvalue) (uvalue + uvalue) :=
+    @mrec (@CallE uvalue) (ExternalCallE dvalue uvalue +' _)
       (fun T call =>
          match call with
          | Call dt fv args =>

--- a/src/rocq/Semantics/DynamicValues.v
+++ b/src/rocq/Semantics/DynamicValues.v
@@ -113,9 +113,9 @@ Definition ll_double := Floats.float.
 
 
 (* Sizeof is needed for for ConcatBytes case *)
-Module DVALUE(A:Vellvm.Semantics.MemoryAddress.ADDRESS)(IP:Vellvm.Semantics.MemoryAddress.INTPTR)(SIZEOF:Sizeof).
+Module DVALUE(A:Vellvm.Semantics.MemoryAddress.ADDRESS)(IP:Vellvm.Semantics.MemoryAddress.INTPTR)(S:SIZEOF).
 
-  Import SIZEOF.
+  Import S.
   Import IP.
 
   (* The set of dynamic values manipulated by an LLVM program. *)
@@ -3358,38 +3358,6 @@ Module DVALUE(A:Vellvm.Semantics.MemoryAddress.ADDRESS)(IP:Vellvm.Semantics.Memo
        | _ => 0
        end.
 
-  (* Check if this is an instruction which can trigger UB with division by 0. *)
-  Definition iop_is_div (iop : ibinop) : bool :=
-    match iop with
-    | UDiv _ => true
-    | SDiv _ => true
-    | URem   => true
-    | SRem   => true
-    | _      => false
-    end.
-
-  Definition iop_is_signed (iop : ibinop) : bool :=
-    match iop with
-    | SDiv _ => true
-    | SRem   => true
-    | _      => false
-    end.
-
-  Definition iop_is_shift (iop : ibinop) : bool :=
-    match iop with
-    | Shl _ _ => true
-    | LShr _ => true
-    | AShr _ => true
-    | _ => false
-    end.
-
-  (* Check if this is an instruction which can trigger UB with division by 0. *)
-  Definition fop_is_div (fop : fbinop) : bool :=
-    match fop with
-    | FDiv => true
-    | FRem => true
-    | _    => false
-    end.
 
   Definition undef_i1 : uvalue  := UVALUE_Undef (DTYPE_I 1).
   Definition undef_i8 : uvalue  := UVALUE_Undef (DTYPE_I 8).

--- a/src/rocq/Semantics/GepM.v
+++ b/src/rocq/Semantics/GepM.v
@@ -7,7 +7,7 @@ From ExtLib Require Import
 From Vellvm Require Import
   DynamicTypes
   VellvmIntegers
-  LLVMEvents
+  Semantics.LLVMParams
   Semantics.MemoryAddress
   Semantics.Memory.Sizeof
   Utils.Error
@@ -16,15 +16,14 @@ From Vellvm Require Import
 Import ListNotations.
 Import MonadNotation.
 
-Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITOP : ITOP Addr PROV PTOI) (IP:INTPTR) (SIZEOF:Sizeof) (LLVMEvents:LLVM_INTERACTIONS(Addr)(IP)(SIZEOF)).
-  Import LLVMEvents.
-  Import DV.
-  Import PROV.
-  Import Addr.
-  Import PTOI.
-  Import ITOP.
-  Import IP.
-  Import SIZEOF.
+Module Type GEPM (LP:LLVMParams).
+  Import LP.DV.
+  Import LP.PROV.
+  Import LP.ADDR.
+  Import LP.PTOI.
+  Import LP.ITOP.
+  Import LP.IP.
+  Import LP.SZ.
 
   (** ** Get Element Pointer
       Retrieve the address of a subelement of an indexable (i.e. aggregate) [dtyp] [t] (i.e. vector, array, struct, packed struct).
@@ -84,7 +83,7 @@ Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITO
         | _ => failwith ("non-i64-indexable type")
         end
       | DVALUE_IPTR i =>
-        let k := IP.to_Z i in
+        let k := to_Z i in
         let n := BinIntDef.Z.to_nat k in
         match t with
         | DTYPE_Array _ ta
@@ -115,7 +114,7 @@ Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITO
       ptr' <- handle_gep_h t (ptr + Z.of_N (sizeof_dtyp t) * (signed i)) vs' ;;
       ret (int_to_ptr ptr' prov)
     | DVALUE_IPTR i :: vs' =>
-      ptr' <- handle_gep_h t (ptr + Z.of_N (sizeof_dtyp t) * (IP.to_Z i)) vs' ;;
+      ptr' <- handle_gep_h t (ptr + Z.of_N (sizeof_dtyp t) * (to_Z i)) vs' ;;
       ret (int_to_ptr ptr' prov)
     | [] => failwith "handle_gep_addr: no indices"
     | _ => failwith "handle_gep_addr: unsupported index type"
@@ -123,11 +122,11 @@ Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITO
 
   Lemma handle_gep_addr_0 :
     forall (dt : dtyp) (p : addr),
-      handle_gep_addr dt p [DVALUE_IPTR IP.zero] = inr (ret p).
+      handle_gep_addr dt p [DVALUE_IPTR zero] = inr (ret p).
   Proof.
     intros dt p.
     cbn.
-    rewrite IP.to_Z_0.
+    rewrite to_Z_0.
     replace (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * 0)%Z with (ptr_to_int p) by lia.
     rewrite int_to_ptr_ptr_to_int; auto.
   Qed.
@@ -143,7 +142,7 @@ Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITO
   Lemma handle_gep_addr_ix :
     forall (dt : dtyp) (p p' : addr) ix,
       handle_gep_addr dt p [DVALUE_IPTR ix] = inr (ret p') ->
-      ptr_to_int p' = (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * IP.to_Z ix)%Z.
+      ptr_to_int p' = (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z.
   Proof.
     intros dt p p' ix GEP.
     cbn in *.
@@ -155,7 +154,7 @@ Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITO
     forall (dt : dtyp) (p p' : addr) ix msg,
       handle_gep_addr dt p [DVALUE_IPTR ix] = inr (Oom msg) ->
       exists msg',
-        int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * IP.to_Z ix)%Z (address_provenance p) = Oom msg'.
+        int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (address_provenance p) = Oom msg'.
   Proof.
     intros dt p p' ix msg GEP.
     cbn in *.
@@ -166,7 +165,7 @@ Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITO
 
   Lemma handle_gep_addr_ix' :
     forall (dt : dtyp) (p p' : addr) ix,
-      ret p' = int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * IP.to_Z ix)%Z (address_provenance p) ->
+      ret p' = int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (address_provenance p) ->
       handle_gep_addr dt p [DVALUE_IPTR ix] = inr (ret p').
   Proof.
     intros dt p p' ix IX.
@@ -177,7 +176,7 @@ Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITO
 
   Lemma handle_gep_addr_ix'_OOM :
     forall (dt : dtyp) (p p' : addr) ix msg,
-      int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * IP.to_Z ix)%Z (address_provenance p) = Oom msg ->
+      int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (address_provenance p) = Oom msg ->
       exists msg', handle_gep_addr dt p [DVALUE_IPTR ix] = inr (Oom msg').
   Proof.
     intros dt p p' ix msg IX.
@@ -311,14 +310,6 @@ Module Type GEPM (Addr:ADDRESS) (PTOI : PTOI Addr) (PROV : PROVENANCE Addr) (ITO
     end.
 End GEPM.
 
-Module Make (ADDR : ADDRESS) (IP : INTPTR) (SIZE : Sizeof) (Events : LLVM_INTERACTIONS(ADDR)(IP)(SIZE)) (PTOI : PTOI ADDR) (PROV : PROVENANCE ADDR) (ITOP : ITOP ADDR PROV PTOI) <: GEPM(ADDR)(PTOI)(PROV)(ITOP)(IP)(SIZE)(Events).
-  Import ADDR.
-  Import Events.
-  Import DV.
-  Import SIZE.
-  Import PTOI.
-  Import ITOP.
-  Import PROV.
-
-  Include GEPM (ADDR)(PTOI)(PROV)(ITOP)(IP)(SIZE)(Events).
+Module Make (LP:LLVMParams) <: GEPM(LP).
+  Include GEPM LP.
 End Make.

--- a/src/rocq/Semantics/InfiniteToFinite.v
+++ b/src/rocq/Semantics/InfiniteToFinite.v
@@ -88,12 +88,12 @@ Module InfiniteToFinite.
   (* TODO: Move these refine_OOM_h lemmas? *)
   Import Morphisms.
 
+  (* SAZ: There is still some redundancy in the module system here -- we have multiple paths to DV1 and DV2. *)
+  Module DV1 := InterpreterStackBigIntptr.LP.DV.
+  Module DV2 := InterpreterStack64BitIntptr.LP.DV.
 
-  Module E1 := InterpreterStackBigIntptr.LP.Events.
-  Module E2 := InterpreterStack64BitIntptr.LP.Events.
-
-  #[local] Notation E1 := (E1.ExternalCallE +' OOME +' UBE +' DebugE +' FailureE).
-  #[local] Notation E2 := (E2.ExternalCallE +' OOME +' UBE +' DebugE +' FailureE).
+  #[local] Notation E1 := (ExternalCallE DV1.dvalue DV1.uvalue +' OOME +' UBE +' DebugE +' FailureE).
+  #[local] Notation E2 := (ExternalCallE DV2.dvalue DV2.uvalue +' OOME +' UBE +' DebugE +' FailureE).
   #[local] Notation OOM_h := (refine_OOM_handler).
 
   Module InfLLVM := Vellvm.Semantics.InterpretationStack.InterpreterStackBigIntptr.LLVM.
@@ -117,9 +117,11 @@ Module InfiniteToFinite.
 
   (* Module EC2 := EventConvert FinLP InfLP FinToInfAddrConvert InfToFinAddrConvert FinLP.Events InfLP.Events DVC1. *)
 
-  Module DVCS := DVConvertSafe FinLP InfLP FinToInfAddrConvert InfToFinAddrConvert FinToInfAddrConvertSafe FinToInfIntptrConvertSafe FinLP.Events InfLP.Events DVC2 DVC1.
+  Module DVCS := DVConvertSafe FinLP InfLP FinToInfAddrConvert InfToFinAddrConvert FinToInfAddrConvertSafe FinToInfIntptrConvertSafe DVC2 DVC1.
   Import DVCS.
 
+  Import IntMaps.
+  
   Lemma unsigned_repr_eq:
     forall sz i, ((0 <=? i)%Z && (i <? @Integers.modulus sz)%Z)%bool = true ->
          @Integers.unsigned sz (Integers.repr i) = i.
@@ -180,7 +182,7 @@ Module InfiniteToFinite.
   Definition convert_SByte (sb1 : MemoryBigIntptr.MP.BYTE_IMPL.SByte) : OOM (Memory64BitIntptr.MP.BYTE_IMPL.SByte).
     destruct sb1.
     refine (uv' <- DVC1.uvalue_convert_strict uv;;
-            ret (FiniteSizeof.mkUByte LLVMParams64BitIntptr.Events.DV.uvalue uv' dt idx sid)).
+            ret (FiniteSizeof.mkUByte DV2.uvalue uv' dt idx sid)).
   Defined.
 
   Definition lift_SByte (sb1 : Memory64BitIntptr.MP.BYTE_IMPL.SByte) : MemoryBigIntptr.MP.BYTE_IMPL.SByte.
@@ -360,465 +362,6 @@ Module InfiniteToFinite.
     let mem' := IntMaps.IP.filter_dom in_bounds mem in
     IntMaps.IM.map lift_mem_byte mem'.
 
-  Lemma Forall2_cons_inversion :
-    forall {A B} f (x:A) (y:B) xs ys,
-      Forall2 f (x::xs) (y::ys) -> f x y /\ Forall2 f xs ys.
-  Proof.
-    intros.
-    inversion H; subst.
-    tauto.
-  Qed.
-
-  Lemma filter_dom_map_eq :
-    forall {A B} (f : IntMaps.IM.key -> bool) (g : A -> B) (m : IntMaps.IntMap A) ,
-      forall k e,
-        IntMaps.IM.MapsTo k e (IntMaps.IM.map g (IntMaps.IP.filter_dom f m))
-        <->
-          IntMaps.IM.MapsTo k e (IntMaps.IP.filter_dom f (IntMaps.IM.map g m)).
-  Proof.
-    intros.
-    unfold IntMaps.IP.filter_dom.
-    split; intros H.
-    - rewrite IntMaps.IP.filter_iff.
-      apply IntMaps.IP.F.map_mapsto_iff in H.
-      destruct H as [a [EQ HM]].
-      apply IntMaps.IP.filter_iff in HM.
-      destruct HM.
-      split; auto.
-      apply IntMaps.IP.F.map_mapsto_iff.
-      exists a. tauto.
-      repeat red; intros; subst; auto.
-      repeat red; intros; subst; auto.
-    - rewrite IntMaps.IP.filter_iff in H.
-      destruct H.
-      apply IntMaps.IP.F.map_mapsto_iff in H.
-      destruct H as [a [EQ HM]].
-      apply IntMaps.IP.F.map_mapsto_iff.
-      exists a. split; auto.
-      apply IntMaps.IP.filter_iff; auto.
-      repeat red; intros; subst; auto.
-      repeat red; intros; subst; auto.
-  Qed.
-
-  Lemma MapsTo_filter_true :
-    forall {A} (f : IntMaps.IM.key -> A -> bool) m,
-    forall k e,
-       (f k e = true /\ IntMaps.IM.MapsTo k e m) <->
-        IntMaps.IM.MapsTo k e (IntMaps.IP.filter f m).
-  Proof.
-    intros.
-    split; intros.
-    - apply IntMaps.IP.filter_iff.
-      + repeat red; intros; subst; auto.
-      + tauto.
-    - apply IntMaps.IP.filter_iff in H.
-      + tauto.
-      + repeat red; intros; subst; auto.
-  Qed.
-
-  Lemma MapsTo_filter_subset :
-    forall {A} (f : IntMaps.IM.key -> A -> bool) m,
-    forall k e,
-      IntMaps.IM.MapsTo k e (IntMaps.IP.filter f m) ->
-      IntMaps.IM.MapsTo k e m.
-  Proof.
-    intros.
-    apply IntMaps.IP.filter_iff in H.
-    + tauto.
-    + repeat red; intros; subst; auto.
-  Qed.
-
-  Lemma not_MapsTo_filter :
-    forall {A} (f : IntMaps.IM.key -> A -> bool) m,
-    forall k e,
-      ~ IntMaps.IM.MapsTo k e m ->
-      ~ IntMaps.IM.MapsTo k e (IntMaps.IP.filter f m).
-  Proof.
-    intros.
-    intro C.
-    apply H.
-    eapply MapsTo_filter_subset.
-    eauto.
-  Qed.
-
-  Lemma MapsTo_filter_dom_true :
-    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
-    forall k e,
-      (f k = true /\ IntMaps.IM.MapsTo k e m) <->
-        IntMaps.IM.MapsTo k e (IntMaps.IP.filter_dom f m).
-  Proof.
-    intros.
-    unfold IntMaps.IP.filter_dom.
-    rewrite <- MapsTo_filter_true.
-    tauto.
-  Qed.
-
-  Lemma MapsTo_filter_dom_subset :
-    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
-    forall k e,
-      IntMaps.IM.MapsTo k e (IntMaps.IP.filter_dom f m) ->
-      IntMaps.IM.MapsTo k e m.
-  Proof.
-    intros.
-    unfold IntMaps.IP.filter_dom.
-    eapply MapsTo_filter_subset.
-    eauto.
-  Qed.
-
-  Lemma not_MapsTo_filter_dom :
-    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
-    forall k e,
-      ~ IntMaps.IM.MapsTo k e m ->
-      ~ IntMaps.IM.MapsTo k e (IntMaps.IP.filter_dom f m).
-  Proof.
-    intros.
-    intro C.
-    apply H.
-    eapply MapsTo_filter_dom_subset.
-    eauto.
-  Qed.
-
-  Lemma find_filter_true :
-    forall {A} (f : IntMaps.IM.key -> A -> bool) (m : IntMaps.IntMap A),
-      forall k a,
-        IntMaps.IM.find k (IntMaps.IP.filter f m) = Some a <->
-          IntMaps.IM.find k m = Some a /\ (f k a = true).
-  Proof.
-    intros.
-    split; intros H.
-    - apply IntMaps.IP.F.find_mapsto_iff in H.
-      apply IntMaps.IP.filter_iff in H.
-      destruct H.
-      split; auto.
-      apply IntMaps.IP.F.find_mapsto_iff. assumption.
-      repeat red; intros; subst; auto.
-    - destruct H.
-      apply IntMaps.IP.F.find_mapsto_iff.
-      apply IntMaps.IP.filter_iff.
-      repeat red; intros; subst; auto.
-      apply IntMaps.IP.F.find_mapsto_iff in H.
-      split; auto.
-  Qed.
-
-  Lemma find_filter_dom_true :
-    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
-      forall k a,
-        IntMaps.IM.find k (IntMaps.IP.filter_dom f m) = Some a <->
-          IntMaps.IM.find k m = Some a /\ (f k = true).
-  Proof.
-    intros.
-    unfold IntMaps.IP.filter_dom.
-    apply find_filter_true.
-  Qed.
-
-  Lemma IntMaps_find_None :
-    forall {A} (k : IntMaps.IM.key) (m:IntMaps.IntMap A),
-      IntMaps.IM.find k m = None <-> forall e, ~ IntMaps.IM.MapsTo k e m.
-  Proof.
-    intros.
-    split; intros H.
-    - intros. intro C.
-      apply IntMaps.IP.F.find_mapsto_iff in C.
-      rewrite H in C. inversion C.
-    - destruct (IntMaps.IM.find k m) eqn:EQ; auto.
-      apply IntMaps.IP.F.find_mapsto_iff in EQ.
-      apply H in EQ.
-      contradiction.
-  Qed.
-
-  Lemma find_filter_None :
-    forall {A} (f : IntMaps.IM.key -> A -> bool) (m : IntMaps.IntMap A),
-    forall k,
-      IntMaps.IM.find k m = None ->
-        IntMaps.IM.find k (IntMaps.IP.filter f m) = None.
-  Proof.
-    intros.
-    rewrite IntMaps_find_None.
-    intros e C.
-    rewrite IntMaps_find_None in H.
-    specialize (H e).
-    apply H.
-    apply (MapsTo_filter_subset f m).
-    auto.
-  Qed.
-
-  Lemma find_filter_dom_None :
-    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
-    forall k,
-      IntMaps.IM.find k m = None ->
-        IntMaps.IM.find k (IntMaps.IP.filter_dom f m) = None.
-  Proof.
-    intros.
-    unfold IntMaps.IP.filter_dom.
-    apply find_filter_None.
-    assumption.
-  Qed.
-
-  Lemma find_filter_dom_false :
-    forall {elt m k f},
-      f k = false ->
-      IntMaps.IM.find (elt:=elt) k (IntMaps.IP.filter_dom f m) = None.
-  Proof.
-    intros elt m k f F.
-    unfold IntMaps.IP.filter_dom.
-    apply IntMaps_find_None.
-    intros e CONTRA.
-    apply IntMaps.IP.filter_iff in CONTRA; try typeclasses eauto.
-    destruct CONTRA as [_ CONTRA].
-    rewrite F in CONTRA; inv CONTRA.
-  Qed.
-
-  #[global] Instance filter_dom_Proper {elt f} :
-    Proper (IntMaps.IM.Equal (elt:=elt) ==> IntMaps.IM.Equal) (IntMaps.IP.filter_dom f).
-  Proof.
-    unfold Proper, respectful.
-    intros x y EQ.
-    red.
-    intros y0.
-    destruct (IntMaps.IM.find (elt:=elt) y0 (IntMaps.IP.filter_dom f x)) eqn:FIND.
-    - apply find_filter_dom_true in FIND as (FIND&TRUE).
-      red in EQ.
-      rewrite EQ in FIND.
-      symmetry.
-      apply find_filter_dom_true.
-      split; auto.
-    - (* Two ways for this to be none... Either y0 was filtered out,
-           or y0 was not in the original map *)
-      destruct (IntMaps.IM.find (elt:=elt) y0 x) eqn:FIND'.
-      + destruct (f y0) eqn:F.
-        * epose proof find_filter_dom_true f x y0 e.
-          destruct H.
-          forward H0; auto.
-          rewrite FIND in H0.
-          discriminate.
-        * symmetry.
-          apply find_filter_dom_false; auto.
-      + symmetry.
-        apply find_filter_dom_None.
-        rewrite <- EQ.
-        auto.
-  Qed.
-
-  Lemma IntMaps_map_empty_Equal :
-    forall {A B} (f : A -> B),
-      IntMaps.IM.Equal (IntMaps.IM.map f (IntMaps.IM.empty A)) (IntMaps.IM.empty B).
-  Proof.
-    intros A B f.
-    red.
-    intros y.
-    cbn; auto.
-  Qed.
-
-  Lemma IntMaps_map_id_Equal :
-    forall {A} (m : IntMaps.IntMap A),
-      IntMaps.IM.Equal (IntMaps.IM.map id m) m.
-  Proof.
-    intros A B f.
-    destruct (IntMaps.IM.find (elt:=A) f B) eqn:FIND.
-    - apply IntMaps.IP.F.find_mapsto_iff.
-      apply IntMaps.IP.F.find_mapsto_iff in FIND.
-      apply IntMaps.IP.F.map_mapsto_iff.
-      exists a.
-      split; cbn; eauto.
-    - eapply IntMaps_find_None.
-      intros e CONTRA.
-      apply IntMaps_find_None with (e:=e) in FIND.
-      apply FIND.
-      apply IntMaps.IP.F.map_mapsto_iff in CONTRA.
-      destruct CONTRA as (a & H & CONTRA); subst; auto.
-  Qed.
-
-  Lemma IntMaps_map_compose_Equal :
-    forall {A B C} (f : A -> B) (g : B -> C) (m : IntMaps.IntMap A),
-      IntMaps.IM.Equal (IntMaps.IM.map (fun a => g (f a)) m) (IntMaps.IM.map g (IntMaps.IM.map f m)).
-  Proof.
-    intros A B C f g m.
-    red.
-    intros y.
-    destruct (IntMaps.IM.find (elt:=C) y (IntMaps.IM.map g (IntMaps.IM.map f m))) eqn:FIND.
-    - apply IntMaps.IP.F.find_mapsto_iff.
-      apply IntMaps.IP.F.find_mapsto_iff in FIND.
-      apply IntMaps.IP.F.map_mapsto_iff in FIND.
-      destruct FIND as (?&?&FIND).
-      apply IntMaps.IP.F.map_mapsto_iff in FIND.
-      destruct FIND as (?&?&?).
-      subst.
-      apply IntMaps.IP.F.map_mapsto_iff.
-      exists x0.
-      split; cbn; eauto.
-    - eapply IntMaps_find_None.
-      intros e CONTRA.
-      apply IntMaps_find_None with (e:=e) in FIND.
-      apply FIND.
-      apply IntMaps.IP.F.map_mapsto_iff in CONTRA.
-      destruct CONTRA as (a & H & CONTRA); subst; auto.
-      apply IntMaps.IP.F.map_mapsto_iff.
-      exists (f a).
-      split; eauto.
-      apply IntMaps.IP.F.map_mapsto_iff.
-      exists a.
-      split; eauto.
-  Qed.
-
-  Lemma IntMaps_map_add_Equal :
-    forall {A B} (f : A -> B) (m : IntMaps.IntMap A) k a,
-      IntMaps.IM.Equal (IntMaps.IM.map f (IntMaps.IM.add k a m))
-        (IntMaps.IM.add k (f a) (IntMaps.IM.map f m)).
-  Proof.
-    intros A B f m k a.
-    red.
-    intros y.
-    destruct (IntMaps.IM.find (elt:=B) y (IntMaps.IM.add k (f a) (IntMaps.IM.map f m))) eqn:FIND.
-    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
-      + rewrite IntMaps.IP.F.add_eq_o in FIND; eauto.
-        inv FIND.
-        apply IntMaps.IP.F.find_mapsto_iff.
-        apply IntMaps.IP.F.map_mapsto_iff.
-        exists a.
-        split; eauto.
-        apply IntMaps.IP.F.add_mapsto_iff;
-          eauto.
-      + rewrite IntMaps.IP.F.add_neq_o in FIND; eauto.
-        apply IntMaps.IP.F.find_mapsto_iff in FIND.
-        eapply IntMaps.IP.F.map_mapsto_iff in FIND.
-        destruct FIND as (?&?&?); subst.
-
-        apply IntMaps.IP.F.find_mapsto_iff.
-        apply IntMaps.IP.F.map_mapsto_iff.
-        exists x.
-        split; eauto.
-        apply IntMaps.IP.F.add_mapsto_iff;
-          eauto.
-    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
-      + rewrite IntMaps.IP.F.add_eq_o in FIND; eauto.
-        discriminate.
-      + rewrite IntMaps.IP.F.add_neq_o in FIND; eauto.
-        eapply IntMaps_find_None.
-        intros e CONTRA.
-        apply IntMaps_find_None with (e:=e) in FIND.
-        apply FIND.
-        apply IntMaps.IP.F.map_mapsto_iff in CONTRA.
-        destruct CONTRA as (a' & H & CONTRA); subst; auto.        
-        apply IntMaps.IP.F.map_mapsto_iff.
-        exists a'.
-        split; eauto.
-        apply IntMaps.IP.F.add_neq_mapsto_iff in CONTRA; eauto.
-  Qed.
-
-  Lemma IntMaps_map_list_map_Equal :
-    forall {A B} (f : A -> B) l,
-      IntMaps.IM.Equal (IntMaps.IM.map f (IntMaps.IP.of_list l)) (IntMaps.IP.of_list (List.map (fun '(i, x) => (i, f x)) l)).
-  Proof.
-    intros A B f l.
-    induction l.
-    - cbn.
-      apply IntMaps_map_empty_Equal.
-    - cbn.
-      unfold IntMaps.IP.uncurry in *.
-      destruct a.
-      cbn in *.
-      rewrite <- IHl.
-      eapply IntMaps_map_add_Equal.
-  Qed.
-
-  Lemma IntMaps_filter_dom_add_true_Equal :
-    forall {A} f k (a : A) m,
-      f k = true ->
-      IntMaps.IM.Equal
-        (IntMaps.IP.filter_dom f (IntMaps.IM.add k a m))
-        (IntMaps.IM.add k a (IntMaps.IP.filter_dom f m)).
-  Proof.
-    intros A f k a m F.
-    red.
-    intros y.
-    destruct (IntMaps.IM.find (elt:=A) y (IntMaps.IM.add k a (IntMaps.IP.filter_dom f m))) eqn:FIND.
-    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
-      + rewrite IntMaps.IP.F.add_eq_o in FIND; eauto.
-        inv FIND.
-        apply find_filter_dom_true.
-        split; eauto.
-        rewrite IntMaps.IP.F.add_eq_o; eauto.
-      + rewrite IntMaps.IP.F.add_neq_o in FIND; eauto.
-        apply find_filter_dom_true in FIND.
-        destruct FIND.
-        apply find_filter_dom_true.
-        split; eauto.
-        rewrite IntMaps.IP.F.add_neq_o; eauto.
-    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
-      + rewrite IntMaps.IP.F.add_eq_o in FIND; eauto.
-        discriminate.
-      + rewrite IntMaps.IP.F.add_neq_o in FIND; eauto.
-        destruct (IntMaps.IM.find (elt:=A) y m) eqn:FIND'.
-        * destruct (f y) eqn:FY.
-          { pose proof conj FIND' FY.
-            apply find_filter_dom_true in H.
-            rewrite FIND in H.
-            discriminate.
-          }
-
-          eapply find_filter_dom_false; eauto.
-        * eapply find_filter_dom_None.
-          rewrite IntMaps.IP.F.add_neq_o; eauto.
-  Qed.
-
-  Lemma IntMaps_filter_dom_add_false_Equal :
-    forall {A} f k (a : A) m,
-      f k = false ->
-      IntMaps.IM.Equal
-        (IntMaps.IP.filter_dom f (IntMaps.IM.add k a m))
-        (IntMaps.IP.filter_dom f m).
-  Proof.
-    intros A f k a m F.
-    intros y.
-    destruct (IntMaps.IM.find (elt:=A) y (IntMaps.IP.filter_dom f m)) eqn:FIND.
-    - apply find_filter_dom_true in FIND.
-      destruct FIND.
-
-      pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
-      + rewrite F in H0; inv H0.
-      + apply find_filter_dom_true.
-        rewrite IntMaps.IP.F.add_neq_o; eauto.
-    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
-      + eapply find_filter_dom_false; eauto.
-      + destruct (IntMaps.IM.find (elt:=A) y m) eqn:FIND'.
-        * destruct (f y) eqn:FY.
-          { pose proof conj FIND' FY.
-            apply find_filter_dom_true in H.
-            rewrite FIND in H.
-            discriminate.
-          }
-          eapply find_filter_dom_false; eauto.
-        * eapply find_filter_dom_None.
-          rewrite IntMaps.IP.F.add_neq_o; eauto.
-  Qed.
-
-  Lemma IntMaps_filter_dom_list_filter_Equal :
-    forall {A : Type} (f : IntMaps.IM.key -> bool) (l : list (IntMaps.IM.key * A)),
-      IntMaps.IM.Equal (IntMaps.IP.filter_dom f (IntMaps.IP.of_list l))
-        (IntMaps.IP.of_list (filter (fun '(i, x) => f i) l)).
-  Proof.
-    intros A f l.
-    induction l.
-    - cbn.
-      reflexivity.
-    - Opaque IntMaps.IM.Equal.
-      Opaque IntMaps.IP.filter_dom.
-      destruct a; cbn.
-      break_match_goal.
-      + cbn.
-        unfold IntMaps.IP.uncurry in *.
-        cbn.
-        rewrite IntMaps_filter_dom_add_true_Equal; eauto.
-        rewrite IHl.
-        reflexivity.
-      + cbn.
-        unfold IntMaps.IP.uncurry in *.
-        cbn.
-        rewrite IntMaps_filter_dom_add_false_Equal; eauto.
-
-        Transparent IntMaps.IM.Equal.
-        Transparent IntMaps.IP.filter_dom.
-  Qed.
 
   Lemma lift_memory_convert_memory_inversion :
     forall {mem_inf mem_fin},
@@ -2405,10 +1948,10 @@ Lemma lift_memory_convert_mem_byte :
     Forall2 sbyte_refine bytes_inf bytes_fin.
 
   (** More refinement relations *)
-  Definition L3_E1E2_orutt_strict (t1 : PropT InfLP.Events.L3 (InfMemMMSP.MemState *
-                                                                 (store_id * (InfLLVM.Stack.lstack_frame * InfLLVM.Stack.lstack * (InfLLVM.Global.global_env * InfLP.Events.DV.dvalue)))))
-    (t2 : PropT FinLP.Events.L3 (FinMemMMSP.MemState *
-                                   (store_id * (FinLLVM.Stack.lstack_frame * FinLLVM.Stack.lstack * (FinLLVM.Global.global_env * FinLP.Events.DV.dvalue)))))
+  Definition L3_E1E2_orutt_strict (t1 : PropT (L3 DV1.dvalue DV1.uvalue) (InfMemMMSP.MemState *
+                                                                 (store_id * (InfLLVM.Stack.lstack_frame * InfLLVM.Stack.lstack * (InfLLVM.Global.global_env * DV1.dvalue)))))
+    (t2 : PropT (L3 DV2.dvalue DV2.uvalue) (FinMemMMSP.MemState *
+                                   (store_id * (FinLLVM.Stack.lstack_frame * FinLLVM.Stack.lstack * (FinLLVM.Global.global_env * DV2.dvalue)))))
     : Prop :=
     forall t', t2 t' ->
                exists t, t1 t /\
@@ -2982,7 +2525,7 @@ Lemma lift_memory_convert_mem_byte :
   Unset Implicit Arguments.
   Unset Contextual Implicit.
   Definition get_inf_tree' :
-    forall (t_fin2 : itree L3 (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))), itree InfLP.Events.L3 TopLevelBigIntptr.res_L6.
+    forall (t_fin2 : itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue) (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))), itree (L3 DV1.dvalue DV1.uvalue) TopLevelBigIntptr.res_L6.
   Proof.
     cofix CIH.
     intros t_fin2.
@@ -3012,18 +2555,18 @@ Lemma lift_memory_convert_mem_byte :
       apply t.
     - (* Vis *)
       inversion e; clear e; subst.
-      { (* ExternalCallE *)
-        inversion H; subst.
+      { cbn. (* ExternalCallE *)
+        inversion X0; subst.
         { (* External Call *)
           apply go.
-          apply (VisF (subevent _ (E1.ExternalCall t (fin_to_inf_uvalue f) (map fin_to_inf_dvalue args)))).
+          apply (VisF (subevent _ (@ExternalCall _ _ t (fin_to_inf_uvalue f) (map fin_to_inf_dvalue args)))).
 
           (* Continuation *)
           intros x.
           apply CIH.
 
           pose proof (DVCInfFin.dvalue_convert_strict x).
-          destruct H0.
+          destruct H.
           - exact (k d).
           - (* OOM -- somewhat worried about this case *)
             exact (raiseOOM s).
@@ -3031,7 +2574,7 @@ Lemma lift_memory_convert_mem_byte :
 
         { (* Stdout *)
           apply go.
-          apply (VisF (subevent _ (E1.IO_stdout str))).
+          apply (VisF (subevent _ (IO_stdout str))).
           intros [].
           apply CIH.
           apply k. apply tt.
@@ -3039,19 +2582,19 @@ Lemma lift_memory_convert_mem_byte :
 
         { (* Stderr *)
           apply go.
-          apply (VisF (subevent _ (E1.IO_stderr str))).
+          apply (VisF (subevent _ (IO_stderr str))).
           intros [].
           apply CIH.
           apply k. apply tt.
         }
       }
 
-      inversion H; clear H; subst.
+      inversion X0; clear X0; subst.
       { (* PickUvalue *)
-        inversion H0; subst.
+        inversion X1; subst.
       - (* pickUnique *)
         apply go.
-        apply (VisF (subevent _ (E1.pickUnique (fin_to_inf_uvalue x)))).
+        apply (VisF (subevent _ (pickUnique (fin_to_inf_uvalue x)))).
 
         (* Continuation *)
         intros res.
@@ -3068,7 +2611,7 @@ Lemma lift_memory_convert_mem_byte :
           exact (raiseOOM s).
       - (* pickNonPoison *)
         apply go.
-        apply (VisF (subevent _ (E1.pickNonPoison (fin_to_inf_uvalue x)))).
+        apply (VisF (subevent _ (pickNonPoison (fin_to_inf_uvalue x)))).
 
         (* Continuation *)
         intros res.
@@ -3085,7 +2628,7 @@ Lemma lift_memory_convert_mem_byte :
           exact (raiseOOM s).
       - (* pick *)
         apply go.
-        apply (VisF (subevent _ (E1.pick (fin_to_inf_uvalue x)))).
+        apply (VisF (subevent _ (pick (fin_to_inf_uvalue x)))).
 
         (* Continuation *)
         intros res.
@@ -3102,40 +2645,38 @@ Lemma lift_memory_convert_mem_byte :
           exact (raiseOOM s).
       }
 
-      inversion H0; clear H0; subst.
+      inversion H; clear H; subst.
       { (* OOM *)
-        inversion H; subst.
+        inversion H0; subst.
         exact (raiseOOM "").
       }
 
-      inversion H; clear H; subst.
+      inversion H0; clear H0; subst.
       { (* LLVMExcE *)
-        inversion H0; subst.
-        exact (raiseLLVM (fin_to_inf_uvalue H)).
+        inversion H; subst.
+        exact (raiseLLVM (fin_to_inf_uvalue H0)).
       }
 
-      inversion H0; clear H0; subst.
+      inversion H; clear H; subst.
       { (* UBE *)
-        inversion H; subst.
+        inversion H0; subst.
         exact (raiseUB "").
       }
 
-      inversion H; clear H; subst.
+      inversion H0; clear H0; subst.
       { (* DebugE *)
-        inversion H0; subst.
+        inversion H; subst.
         apply go.
-        apply (VisF (subevent _ (Debug H))).
+        apply (VisF (subevent _ (Debug H0))).
         intros H1.
         apply CIH.
         apply k; auto.
       }
 
       { (* FailureE *)
-        inversion H0; subst.
+        inversion H; subst.
         exact (LLVMEvents.raise "").
       }
-
-      (* Show Proof. *)
   Defined.
 
   (*
@@ -3151,33 +2692,63 @@ Lemma lift_memory_convert_mem_byte :
   *)
 
   Definition get_inf_tree :
-    forall (t_fin2 : itree L3 res_L6), itree InfLP.Events.L3 TopLevelBigIntptr.res_L6 :=
-cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) :
-    itree InfLP.Events.L3 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
-  (fun _observe : itreeF L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
+    forall (t_fin2 : itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue) res_L6), itree (L3 DV1.dvalue DV1.uvalue) TopLevelBigIntptr.res_L6 :=
+cofix CIH
+  (t_fin2 : itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) :
+    itree (L3 DV1.dvalue DV1.uvalue)
+      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+         (prod store_id
+            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
+  (fun
+     _observe : itreeF (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                  (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                  (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                     (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
    match
      _observe
      return
-       (itree InfLP.Events.L3
-          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+       (itree (L3 DV1.dvalue DV1.uvalue)
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
    with
    | @RetF _ _ _ r =>
        (fun r0 : prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))) =>
-        @ret (itree InfLP.Events.L3) (@Monad_itree InfLP.Events.L3)
-          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+        @ret (itree (L3 DV1.dvalue DV1.uvalue)) (@Monad_itree (L3 DV1.dvalue DV1.uvalue))
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
           match
-            r0 return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+            r0
+            return
+              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                 (prod store_id
+                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
           with
           | @pair _ _ m p =>
               (fun (ms : FinMem.MMEP.MMSP.MemState) (p0 : prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))) =>
                match
-                 p0 return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                 p0
+                 return
+                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                      (prod store_id
+                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                with
                | @pair _ _ s p1 =>
                    (fun (sid : store_id) (p2 : prod (prod lstack_frame lstack) (prod global_env dvalue)) =>
                     match
                       p2
-                      return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                      return
+                        (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                           (prod store_id
+                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                     with
                     | @pair _ _ p3 p4 =>
                         (fun p5 : prod lstack_frame lstack =>
@@ -3185,7 +2756,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                            p5
                            return
                              (forall _ : prod global_env dvalue,
-                              prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                              prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                          with
                          | @pair _ _ l l0 =>
                              (fun (lenv : lstack_frame) (s0 : lstack) (p6 : prod global_env dvalue) =>
@@ -3193,16 +2767,27 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 p6
                                 return
                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                     (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                     (prod store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                               with
                               | @pair _ _ g d =>
                                   (fun (genv : global_env) (res : dvalue) =>
                                    @pair InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                     (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))) (lift_MemState ms)
-                                     (@pair store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)) sid
-                                        (@pair (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)
-                                           (@pair InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack (lift_stack_frame lenv) (lift_stack s0))
-                                           (@pair InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue (lift_global_env genv) (fin_to_inf_dvalue res)))))
+                                     (prod store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))
+                                     (lift_MemState ms)
+                                     (@pair store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))
+                                        sid
+                                        (@pair (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)
+                                           (@pair InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack
+                                              (lift_stack_frame lenv) (lift_stack s0))
+                                           (@pair InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue
+                                              (lift_global_env genv) (fin_to_inf_dvalue res)))))
                                     g d
                               end) l l0
                          end) p3 p4
@@ -3211,757 +2796,1151 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           end)
          r
    | @TauF _ _ _ t =>
-       (fun t0 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) =>
-        @go InfLP.Events.L3 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-          (@TauF InfLP.Events.L3
-             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-             (itree InfLP.Events.L3
-                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+       (fun
+          t0 : itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) =>
+        @go (L3 DV1.dvalue DV1.uvalue)
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+          (@TauF (L3 DV1.dvalue DV1.uvalue)
+             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                (prod store_id
+                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+             (itree (L3 DV1.dvalue DV1.uvalue)
+                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                   (prod store_id
+                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
              (CIH t0)))
          t
    | @VisF _ _ _ X e k =>
-       (fun (X0 : Type) (e0 : L3 X0) (k0 : forall _ : X0, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
+       (fun (X0 : Type) (e0 : L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0)
+          (k0 : forall _ : X0,
+                itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                  (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
         let X1 :
-          itree InfLP.Events.L3
-            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+          itree (L3 DV1.dvalue DV1.uvalue)
+            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+               (prod store_id
+                  (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
           match
             e0
             return
-              (itree InfLP.Events.L3
-                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+              (itree (L3 DV1.dvalue DV1.uvalue)
+                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                    (prod store_id
+                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
           with
           | @inl1 _ _ _ x =>
-              (fun H : ExternalCallE X0 =>
-               (fun H0 : ExternalCallE X0 =>
-                let X1 :
-                  (fun T : Type =>
-                   forall _ : @eq Type T X0,
-                   itree InfLP.Events.L3
-                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                    X0 :=
-                  match
-                    H0 in (ExternalCallE T)
-                    return
-                      (forall _ : @eq Type T X0,
-                       itree InfLP.Events.L3
-                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                  with
-                  | @ExternalCall t f args =>
-                      (fun (t0 : dtyp) (f0 : uvalue) (args0 : list dvalue) (H1 : @eq Type dvalue X0) =>
-                       (fun H2 : @eq Type dvalue X0 =>
-                        let H3 : @eq Type dvalue X0 := H2 in
-                        @eq_rect Type dvalue
-                          (fun _ : Type =>
-                           forall (_ : dtyp) (_ : uvalue) (_ : list dvalue),
-                           itree InfLP.Events.L3
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                          (fun (t1 : dtyp) (f1 : uvalue) (args1 : list dvalue) =>
-                           @eq_rect Type dvalue
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : dvalue, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE dvalue) =>
-                              @go InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L3
-                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L3
-                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                   E1.DV.dvalue
-                                   (@subevent E1.ExternalCallE InfLP.Events.L3
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))))
-                                         (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE))
-                                      E1.DV.dvalue (E1.ExternalCall t1 (fin_to_inf_uvalue f1) (@map DVCFinInf.DV1.dvalue DVCFinInf.DV2.dvalue fin_to_inf_dvalue args1)))
-                                   (fun x0 : E1.DV.dvalue =>
-                                    CIH
-                                      (let H4 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x0 in
-                                       match H4 return (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
-                                       | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 d0) d
-                                       | @Oom _ s =>
-                                           (fun s0 : string =>
-                                            @raiseOOM L3
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))))) ExternalCallE
-                                                 (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) PickUvalueE
-                                                    (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
-                                              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
-                                             s
-                                       end))))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 t0 f0 args0)
-                        t f args
-                  | @IO_stdout str =>
-                      (fun (str0 : list int8) (H1 : @eq Type unit X0) =>
-                       (fun H2 : @eq Type unit X0 =>
-                        let H3 : @eq Type unit X0 := H2 in
-                        @eq_rect Type unit
-                          (fun _ : Type =>
-                           forall _ : list int8,
-                           itree InfLP.Events.L3
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                          (fun str1 : list int8 =>
-                           @eq_rect Type unit
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : unit, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE unit) =>
-                              @go InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L3
-                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L3
-                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                   unit
-                                   (@subevent E1.ExternalCallE InfLP.Events.L3
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))))
-                                         (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE))
-                                      unit (E1.IO_stdout str1))
-                                   (fun H4 : unit =>
-                                    match
-                                      H4
-                                      return
-                                        (itree InfLP.Events.L3
-                                           (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                    with
-                                    | @tt => CIH (k1 tt)
-                                    end)))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 str0)
-                        str
-                  | @IO_stderr str =>
-                      (fun (str0 : list int8) (H1 : @eq Type unit X0) =>
-                       (fun H2 : @eq Type unit X0 =>
-                        let H3 : @eq Type unit X0 := H2 in
-                        @eq_rect Type unit
-                          (fun _ : Type =>
-                           forall _ : list int8,
-                           itree InfLP.Events.L3
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                          (fun str1 : list int8 =>
-                           @eq_rect Type unit
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : unit, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE unit) =>
-                              @go InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L3
-                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L3
-                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                   unit
-                                   (@subevent E1.ExternalCallE InfLP.Events.L3
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))))
-                                         (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE))
-                                      unit (E1.IO_stderr str1))
-                                   (fun H4 : unit =>
-                                    match
-                                      H4
-                                      return
-                                        (itree InfLP.Events.L3
-                                           (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                    with
-                                    | @tt => CIH (k1 tt)
-                                    end)))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 str0)
-                        str
-                  end in
-                X1 (@eq_refl Type X0)) H) x
+              (fun X1 : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0 =>
+               (fun X2 : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0 =>
+                (let X3 :
+                   (fun T : Type =>
+                    forall _ : @eq Type T X0,
+                    itree (L3 DV1.dvalue DV1.uvalue)
+                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                         (prod store_id
+                            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                     X0 :=
+                   match
+                     X2 in (ExternalCallE _ _ T)
+                     return
+                       (forall _ : @eq Type T X0,
+                        itree (L3 DV1.dvalue DV1.uvalue)
+                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                             (prod store_id
+                                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                   with
+                   | @ExternalCall _ _ t f args =>
+                       (fun (t0 : dtyp) (f0 : DVCInfFin.DV2.uvalue) (args0 : list DVCInfFin.DV2.dvalue) (H : @eq Type DVCInfFin.DV2.dvalue X0) =>
+                        (fun H0 : @eq Type DVCInfFin.DV2.dvalue X0 =>
+                         let H1 : @eq Type DVCInfFin.DV2.dvalue X0 := H0 in
+                         @eq_rect Type DVCInfFin.DV2.dvalue
+                           (fun _ : Type =>
+                            forall (_ : dtyp) (_ : DVCInfFin.DV2.uvalue) (_ : list DVCInfFin.DV2.dvalue),
+                            itree (L3 DV1.dvalue DV1.uvalue)
+                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                 (prod store_id
+                                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                           (fun (t1 : dtyp) (f1 : DVCInfFin.DV2.uvalue) (args1 : list DVCInfFin.DV2.dvalue) =>
+                            @eq_rect Type DVCInfFin.DV2.dvalue
+                              (fun X3 : Type =>
+                               forall
+                                 (_ : forall _ : X3,
+                                      itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X3),
+                               itree (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                              (fun
+                                 (k1 : forall _ : DVCInfFin.DV2.dvalue,
+                                       itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                         (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue DVCInfFin.DV2.dvalue) =>
+                               @go (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                 (@VisF (L3 DV1.dvalue DV1.uvalue)
+                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                    (itree (L3 DV1.dvalue DV1.uvalue)
+                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                          (prod store_id
+                                             (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                    DVCFinInf.DV2.dvalue
+                                    (@subevent (ExternalCallE DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue) (L3 DV1.dvalue DV1.uvalue)
+                                       (@ExternalCallE_L3 DV1.dvalue DV1.uvalue) DVCFinInf.DV2.dvalue
+                                       (@ExternalCall DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue t1 (fin_to_inf_uvalue f1)
+                                          (@map DVCFinInf.DV1.dvalue DVCFinInf.DV2.dvalue fin_to_inf_dvalue args1)))
+                                    (fun x0 : DVCFinInf.DV2.dvalue =>
+                                     CIH
+                                       (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x0 in
+                                        match
+                                          H2
+                                          return
+                                            (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        with
+                                        | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 d0) d
+                                        | @Oom _ s =>
+                                            (fun s0 : string =>
+                                             @raiseOOM (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue) (@OOME_L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                               s0)
+                                              s
+                                        end))))
+                              X0 H0 k0 X2)
+                           X0 H1)
+                          H t0 f0 args0)
+                         t f args
+                   | @IO_stdout _ _ str =>
+                       (fun (str0 : list int8) (H : @eq Type unit X0) =>
+                        (fun H0 : @eq Type unit X0 =>
+                         let H1 : @eq Type unit X0 := H0 in
+                         @eq_rect Type unit
+                           (fun _ : Type =>
+                            forall _ : list int8,
+                            itree (L3 DV1.dvalue DV1.uvalue)
+                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                 (prod store_id
+                                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                           (fun str1 : list int8 =>
+                            @eq_rect Type unit
+                              (fun X3 : Type =>
+                               forall
+                                 (_ : forall _ : X3,
+                                      itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X3),
+                               itree (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                              (fun
+                                 (k1 : forall _ : unit,
+                                       itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                         (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue unit) =>
+                               @go (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                 (@VisF (L3 DV1.dvalue DV1.uvalue)
+                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                    (itree (L3 DV1.dvalue DV1.uvalue)
+                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                          (prod store_id
+                                             (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                    unit
+                                    (@subevent (ExternalCallE DV1.dvalue DV1.uvalue) (L3 DV1.dvalue DV1.uvalue) (@ExternalCallE_L3 DV1.dvalue DV1.uvalue)
+                                       unit (@IO_stdout DV1.dvalue DV1.uvalue str1))
+                                    (fun H2 : unit =>
+                                     match
+                                       H2
+                                       return
+                                         (itree (L3 DV1.dvalue DV1.uvalue)
+                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                               (prod store_id
+                                                  (prod
+                                                     (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     with
+                                     | @tt => CIH (k1 tt)
+                                     end)))
+                              X0 H0 k0 X2)
+                           X0 H1)
+                          H str0)
+                         str
+                   | @IO_stderr _ _ str =>
+                       (fun (str0 : list int8) (H : @eq Type unit X0) =>
+                        (fun H0 : @eq Type unit X0 =>
+                         let H1 : @eq Type unit X0 := H0 in
+                         @eq_rect Type unit
+                           (fun _ : Type =>
+                            forall _ : list int8,
+                            itree (L3 DV1.dvalue DV1.uvalue)
+                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                 (prod store_id
+                                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                           (fun str1 : list int8 =>
+                            @eq_rect Type unit
+                              (fun X3 : Type =>
+                               forall
+                                 (_ : forall _ : X3,
+                                      itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X3),
+                               itree (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                              (fun
+                                 (k1 : forall _ : unit,
+                                       itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                         (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue unit) =>
+                               @go (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                 (@VisF (L3 DV1.dvalue DV1.uvalue)
+                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                    (itree (L3 DV1.dvalue DV1.uvalue)
+                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                          (prod store_id
+                                             (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                    unit
+                                    (@subevent (ExternalCallE DV1.dvalue DV1.uvalue) (L3 DV1.dvalue DV1.uvalue) (@ExternalCallE_L3 DV1.dvalue DV1.uvalue)
+                                       unit (@IO_stderr DV1.dvalue DV1.uvalue str1))
+                                    (fun H2 : unit =>
+                                     match
+                                       H2
+                                       return
+                                         (itree (L3 DV1.dvalue DV1.uvalue)
+                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                               (prod store_id
+                                                  (prod
+                                                     (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     with
+                                     | @tt => CIH (k1 tt)
+                                     end)))
+                              X0 H0 k0 X2)
+                           X0 H1)
+                          H str0)
+                         str
+                   end in
+                 X3 (@eq_refl Type X0))
+                :
+                itree (L3 DV1.dvalue DV1.uvalue)
+                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                     (prod store_id
+                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                 X1)
+                x
           | @inr1 _ _ _ x =>
-              (fun H : sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) X0 =>
-               (fun H0 : sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) X0 =>
-                let X1 :
-                  itree InfLP.Events.L3
-                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+              (fun
+                 X1 : sum1 (PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                        (sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) X0 =>
+               (fun
+                  X2 : sum1 (PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                         (sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) X0 =>
+                let X3 :
+                  itree (L3 DV1.dvalue DV1.uvalue)
+                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                       (prod store_id
+                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                   match
-                    H0
+                    X2
                     return
-                      (itree InfLP.Events.L3
-                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                      (itree (L3 DV1.dvalue DV1.uvalue)
+                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                            (prod store_id
+                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                   with
                   | @inl1 _ _ _ x0 =>
-                      (fun H1 : PickUvalueE X0 =>
-                       (fun H2 : PickUvalueE X0 =>
-                        let X1 :
+                      (fun X3 : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0 =>
+                       (fun X4 : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0 =>
+                        let X5 :
                           (fun T : Type =>
                            forall _ : @eq Type T X0,
-                           itree InfLP.Events.L3
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                           itree (L3 DV1.dvalue DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                             X0 :=
                           match
-                            H2 in (@PickE _ _ _ T)
+                            X4 in (@PickE _ _ _ T)
                             return
                               (forall _ : @eq Type T X0,
-                               itree InfLP.Events.L3
+                               itree (L3 DV1.dvalue DV1.uvalue)
                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           with
                           | @pickUnique _ _ _ x1 =>
-                              (fun (x2 : uvalue) (H3 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0) =>
-                               (fun H4 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 =>
-                                let H5 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 := H4 in
-                                @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
+                              (fun (x2 : DVCInfFin.DV2.uvalue) (H : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0) =>
+                               (fun H0 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 =>
+                                let H1 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 := H0 in
+                                @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
                                   (fun _ : Type =>
-                                   forall _ : uvalue,
-                                   itree InfLP.Events.L3
+                                   forall _ : DVCInfFin.DV2.uvalue,
+                                   itree (L3 DV1.dvalue DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                  (fun x3 : uvalue =>
-                                   @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
-                                     (fun X1 : Type =>
-                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE X1),
-                                      itree InfLP.Events.L3
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                  (fun x3 : DVCInfFin.DV2.uvalue =>
+                                   @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
+                                     (fun X5 : Type =>
+                                      forall
+                                        (_ : forall _ : X5,
+                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X5),
+                                      itree (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                     (fun (k1 : forall _ : @sig dvalue (fun _ : dvalue => True), itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE (@sig dvalue (fun _ : dvalue => True))) =>
-                                      @go InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     (fun
+                                        (k1 : forall _ : @sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True),
+                                              itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue
+                                               (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))) =>
+                                      @go (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                        (@VisF InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                        (@VisF (L3 DV1.dvalue DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                           (itree InfLP.Events.L3
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                           (itree (L3 DV1.dvalue DV1.uvalue)
                                               (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                 (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                           (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True))
-                                           (@subevent (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.L3
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True))
-                                                 (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.PickUvalueE
-                                                    (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.PickUvalueE)))
-                                              (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True)) (@E1.pickUnique DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True) (fin_to_inf_uvalue x3)))
-                                           (fun res : @sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True) =>
+                                                 (prod store_id
+                                                    (prod
+                                                       (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                           (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                           (@subevent (@PickE DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True))
+                                              (L3 DV1.dvalue DV1.uvalue) (@PickE_L3 DV1.dvalue DV1.uvalue) (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                              (@pickUnique DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True)
+                                                 (fin_to_inf_uvalue x3)))
+                                           (fun res : @sig DV1.dvalue (fun _ : DV1.dvalue => True) =>
                                             match
                                               res
                                               return
-                                                (itree InfLP.Events.L3
+                                                (itree (L3 DV1.dvalue DV1.uvalue)
                                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                      (prod store_id
+                                                         (prod
+                                                            (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                               InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             with
                                             | @exist _ _ x4 t =>
-                                                (fun (x5 : InfLP.Events.DV.dvalue) (t0 : True) =>
+                                                (fun (x5 : DV1.dvalue) (t0 : True) =>
                                                  CIH
-                                                   (let H6 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
-                                                    match H6 return (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
-                                                    | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 (@exist dvalue (fun _ : dvalue => True) d0 t0)) d
+                                                   (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
+                                                    match
+                                                      H2
+                                                      return
+                                                        (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                    with
+                                                    | @NoOom _ d =>
+                                                        (fun d0 : DVCInfFin.DV2.dvalue =>
+                                                         k1 (@exist DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True) d0 t0)) d
                                                     | @Oom _ s =>
                                                         (fun s0 : string =>
-                                                         @raiseOOM L3
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))))) ExternalCallE
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) PickUvalueE
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
-                                                           (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
+                                                         @raiseOOM (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (@OOME_L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                                           s0)
                                                           s
                                                     end))
                                                   x4 t
                                             end)))
-                                     X0 H4 k0 H2)
-                                  X0 H5)
-                                 H3 x2)
+                                     X0 H0 k0 X4)
+                                  X0 H1)
+                                 H x2)
                                 x1
                           | @pickNonPoison _ _ _ x1 =>
-                              (fun (x2 : uvalue) (H3 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0) =>
-                               (fun H4 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 =>
-                                let H5 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 := H4 in
-                                @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
+                              (fun (x2 : DVCInfFin.DV2.uvalue) (H : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0) =>
+                               (fun H0 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 =>
+                                let H1 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 := H0 in
+                                @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
                                   (fun _ : Type =>
-                                   forall _ : uvalue,
-                                   itree InfLP.Events.L3
+                                   forall _ : DVCInfFin.DV2.uvalue,
+                                   itree (L3 DV1.dvalue DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                  (fun x3 : uvalue =>
-                                   @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
-                                     (fun X1 : Type =>
-                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE X1),
-                                      itree InfLP.Events.L3
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                  (fun x3 : DVCInfFin.DV2.uvalue =>
+                                   @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
+                                     (fun X5 : Type =>
+                                      forall
+                                        (_ : forall _ : X5,
+                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X5),
+                                      itree (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                     (fun (k1 : forall _ : @sig dvalue (fun _ : dvalue => True), itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE (@sig dvalue (fun _ : dvalue => True))) =>
-                                      @go InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     (fun
+                                        (k1 : forall _ : @sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True),
+                                              itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue
+                                               (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))) =>
+                                      @go (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                        (@VisF InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                        (@VisF (L3 DV1.dvalue DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                           (itree InfLP.Events.L3
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                           (itree (L3 DV1.dvalue DV1.uvalue)
                                               (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                 (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                           (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True))
-                                           (@subevent (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.L3
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True))
-                                                 (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.PickUvalueE
-                                                    (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.PickUvalueE)))
-                                              (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True)) (@E1.pickNonPoison DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True) (fin_to_inf_uvalue x3)))
-                                           (fun res : @sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True) =>
+                                                 (prod store_id
+                                                    (prod
+                                                       (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                           (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                           (@subevent (@PickE DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True))
+                                              (L3 DV1.dvalue DV1.uvalue) (@PickE_L3 DV1.dvalue DV1.uvalue) (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                              (@pickNonPoison DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True)
+                                                 (fin_to_inf_uvalue x3)))
+                                           (fun res : @sig DV1.dvalue (fun _ : DV1.dvalue => True) =>
                                             match
                                               res
                                               return
-                                                (itree InfLP.Events.L3
+                                                (itree (L3 DV1.dvalue DV1.uvalue)
                                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                      (prod store_id
+                                                         (prod
+                                                            (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                               InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             with
                                             | @exist _ _ x4 t =>
-                                                (fun (x5 : InfLP.Events.DV.dvalue) (t0 : True) =>
+                                                (fun (x5 : DV1.dvalue) (t0 : True) =>
                                                  CIH
-                                                   (let H6 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
-                                                    match H6 return (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
-                                                    | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 (@exist dvalue (fun _ : dvalue => True) d0 t0)) d
+                                                   (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
+                                                    match
+                                                      H2
+                                                      return
+                                                        (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                    with
+                                                    | @NoOom _ d =>
+                                                        (fun d0 : DVCInfFin.DV2.dvalue =>
+                                                         k1 (@exist DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True) d0 t0)) d
                                                     | @Oom _ s =>
                                                         (fun s0 : string =>
-                                                         @raiseOOM L3
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))))) ExternalCallE
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) PickUvalueE
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
-                                                           (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
+                                                         @raiseOOM (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (@OOME_L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                                           s0)
                                                           s
                                                     end))
                                                   x4 t
                                             end)))
-                                     X0 H4 k0 H2)
-                                  X0 H5)
-                                 H3 x2)
+                                     X0 H0 k0 X4)
+                                  X0 H1)
+                                 H x2)
                                 x1
                           | @pick _ _ _ x1 =>
-                              (fun (x2 : uvalue) (H3 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0) =>
-                               (fun H4 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 =>
-                                let H5 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 := H4 in
-                                @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
+                              (fun (x2 : DVCInfFin.DV2.uvalue) (H : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0) =>
+                               (fun H0 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 =>
+                                let H1 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 := H0 in
+                                @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
                                   (fun _ : Type =>
-                                   forall _ : uvalue,
-                                   itree InfLP.Events.L3
+                                   forall _ : DVCInfFin.DV2.uvalue,
+                                   itree (L3 DV1.dvalue DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                  (fun x3 : uvalue =>
-                                   @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
-                                     (fun X1 : Type =>
-                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE X1),
-                                      itree InfLP.Events.L3
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                  (fun x3 : DVCInfFin.DV2.uvalue =>
+                                   @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
+                                     (fun X5 : Type =>
+                                      forall
+                                        (_ : forall _ : X5,
+                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X5),
+                                      itree (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                     (fun (k1 : forall _ : @sig dvalue (fun _ : dvalue => True), itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE (@sig dvalue (fun _ : dvalue => True))) =>
-                                      @go InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     (fun
+                                        (k1 : forall _ : @sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True),
+                                              itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue
+                                               (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))) =>
+                                      @go (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                        (@VisF InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                        (@VisF (L3 DV1.dvalue DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                           (itree InfLP.Events.L3
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                           (itree (L3 DV1.dvalue DV1.uvalue)
                                               (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                 (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                           (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True))
-                                           (@subevent (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.L3
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True))
-                                                 (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.PickUvalueE
-                                                    (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.PickUvalueE)))
-                                              (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True)) (@E1.pick DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True) (fin_to_inf_uvalue x3)))
-                                           (fun res : @sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True) =>
+                                                 (prod store_id
+                                                    (prod
+                                                       (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                           (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                           (@subevent (@PickE DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True))
+                                              (L3 DV1.dvalue DV1.uvalue) (@PickE_L3 DV1.dvalue DV1.uvalue) (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                              (@pick DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True) (fin_to_inf_uvalue x3)))
+                                           (fun res : @sig DV1.dvalue (fun _ : DV1.dvalue => True) =>
                                             match
                                               res
                                               return
-                                                (itree InfLP.Events.L3
+                                                (itree (L3 DV1.dvalue DV1.uvalue)
                                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                      (prod store_id
+                                                         (prod
+                                                            (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                               InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             with
                                             | @exist _ _ x4 t =>
-                                                (fun (x5 : InfLP.Events.DV.dvalue) (t0 : True) =>
+                                                (fun (x5 : DV1.dvalue) (t0 : True) =>
                                                  CIH
-                                                   (let H6 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
-                                                    match H6 return (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
-                                                    | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 (@exist dvalue (fun _ : dvalue => True) d0 t0)) d
+                                                   (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
+                                                    match
+                                                      H2
+                                                      return
+                                                        (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                    with
+                                                    | @NoOom _ d =>
+                                                        (fun d0 : DVCInfFin.DV2.dvalue =>
+                                                         k1 (@exist DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True) d0 t0)) d
                                                     | @Oom _ s =>
                                                         (fun s0 : string =>
-                                                         @raiseOOM L3
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))))) ExternalCallE
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) PickUvalueE
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
-                                                           (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
+                                                         @raiseOOM (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (@OOME_L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                                           s0)
                                                           s
                                                     end))
                                                   x4 t
                                             end)))
-                                     X0 H4 k0 H2)
-                                  X0 H5)
-                                 H3 x2)
+                                     X0 H0 k0 X4)
+                                  X0 H1)
+                                 H x2)
                                 x1
                           end in
-                        X1 (@eq_refl Type X0)) H1) x0
+                        X5 (@eq_refl Type X0)) X3) x0
                   | @inr1 _ _ _ x0 =>
-                      (fun H1 : sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
-                       (fun H2 : sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
-                        let X1 :
-                          itree InfLP.Events.L3
-                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                      (fun H : sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
+                       (fun H0 : sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
+                        let X3 :
+                          itree (L3 DV1.dvalue DV1.uvalue)
+                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                               (prod store_id
+                                  (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                           match
-                            H2
+                            H0
                             return
-                              (itree InfLP.Events.L3
+                              (itree (L3 DV1.dvalue DV1.uvalue)
                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           with
                           | @inl1 _ _ _ x1 =>
-                              (fun H3 : OOME X0 =>
-                               (fun H4 : OOME X0 =>
-                                let X1 :
+                              (fun H1 : OOME X0 =>
+                               (fun H2 : OOME X0 =>
+                                let X3 :
                                   (fun T : Type =>
                                    forall _ : @eq Type T X0,
-                                   itree InfLP.Events.L3
+                                   itree (L3 DV1.dvalue DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                     X0 :=
                                   match
-                                    H4 in (OOME T)
+                                    H2 in (OOME T)
                                     return
                                       (forall _ : @eq Type T X0,
-                                       itree InfLP.Events.L3
+                                       itree (L3 DV1.dvalue DV1.uvalue)
                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                            (prod store_id
+                                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   with
                                   | @ThrowOOM x2 =>
-                                      (fun (H5 : unit) (H6 : @eq Type Empty_set X0) =>
-                                       (fun H7 : @eq Type Empty_set X0 =>
-                                        let H8 : @eq Type Empty_set X0 := H7 in
+                                      (fun (H3 : unit) (H4 : @eq Type Empty_set X0) =>
+                                       (fun H5 : @eq Type Empty_set X0 =>
+                                        let H6 : @eq Type Empty_set X0 := H5 in
                                         @eq_rect Type Empty_set
                                           (fun _ : Type =>
                                            forall _ : unit,
-                                           itree InfLP.Events.L3
+                                           itree (L3 DV1.dvalue DV1.uvalue)
                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                (prod store_id
+                                                   (prod
+                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           (fun _ : unit =>
                                            @eq_rect Type Empty_set
-                                             (fun X1 : Type =>
-                                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : OOME X1),
-                                              itree InfLP.Events.L3
+                                             (fun X3 : Type =>
+                                              forall
+                                                (_ : forall _ : X3,
+                                                     itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                (_ : OOME X3),
+                                              itree (L3 DV1.dvalue DV1.uvalue)
                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                             (fun (_ : forall _ : Empty_set, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : OOME Empty_set) =>
-                                              @raiseOOM InfLP.Events.L3
-                                                (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                   (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
+                                                   (prod store_id
+                                                      (prod
+                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                             (fun
+                                                (_ : forall _ : Empty_set,
+                                                     itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                (_ : OOME Empty_set) =>
+                                              @raiseOOM (L3 DV1.dvalue DV1.uvalue) (@OOME_L3 DV1.dvalue DV1.uvalue)
                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                                   (prod store_id
+                                                      (prod
+                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                                                 EmptyString)
-                                             X0 H7 k0 H4)
-                                          X0 H8)
-                                         H6 H5)
+                                             X0 H5 k0 H2)
+                                          X0 H6)
+                                         H4 H3)
                                         x2
                                   end in
-                                X1 (@eq_refl Type X0)) H3) x1
+                                X3 (@eq_refl Type X0)) H1) x1
                           | @inr1 _ _ _ x1 =>
-                              (fun H3 : sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
-                               (fun H4 : sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
-                                let X1 :
-                                  itree InfLP.Events.L3
+                              (fun H1 : sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
+                               (fun H2 : sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
+                                let X3 :
+                                  itree (L3 DV1.dvalue DV1.uvalue)
                                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                       (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                   match
-                                    H4
+                                    H2
                                     return
-                                      (itree InfLP.Events.L3
+                                      (itree (L3 DV1.dvalue DV1.uvalue)
                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                            (prod store_id
+                                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   with
                                   | @inl1 _ _ _ x2 =>
-                                      (fun H5 : LLVMExcE uvalue X0 =>
-                                       (fun H6 : LLVMExcE uvalue X0 =>
-                                        let X1 :
+                                      (fun H3 : LLVMExcE DVCInfFin.DV2.uvalue X0 =>
+                                       (fun H4 : LLVMExcE DVCInfFin.DV2.uvalue X0 =>
+                                        let X3 :
                                           (fun T : Type =>
                                            forall _ : @eq Type T X0,
-                                           itree InfLP.Events.L3
+                                           itree (L3 DV1.dvalue DV1.uvalue)
                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                (prod store_id
+                                                   (prod
+                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             X0 :=
                                           match
-                                            H6 in (LLVMExcE _ T)
+                                            H4 in (LLVMExcE _ T)
                                             return
                                               (forall _ : @eq Type T X0,
-                                               itree InfLP.Events.L3
+                                               itree (L3 DV1.dvalue DV1.uvalue)
                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                    (prod store_id
+                                                       (prod
+                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           with
                                           | @LLVMExc _ x3 =>
-                                              (fun (H7 : uvalue) (H8 : @eq Type Empty_set X0) =>
-                                               (fun H9 : @eq Type Empty_set X0 =>
-                                                let H10 : @eq Type Empty_set X0 := H9 in
+                                              (fun (H5 : DVCInfFin.DV2.uvalue) (H6 : @eq Type Empty_set X0) =>
+                                               (fun H7 : @eq Type Empty_set X0 =>
+                                                let H8 : @eq Type Empty_set X0 := H7 in
                                                 @eq_rect Type Empty_set
                                                   (fun _ : Type =>
-                                                   forall _ : uvalue,
-                                                   itree InfLP.Events.L3
+                                                   forall _ : DVCInfFin.DV2.uvalue,
+                                                   itree (L3 DV1.dvalue DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                  (fun H11 : uvalue =>
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                  (fun H9 : DVCInfFin.DV2.uvalue =>
                                                    @eq_rect Type Empty_set
-                                                     (fun X1 : Type =>
-                                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : LLVMExcE uvalue X1),
-                                                      itree InfLP.Events.L3
+                                                     (fun X3 : Type =>
+                                                      forall
+                                                        (_ : forall _ : X3,
+                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                        (_ : LLVMExcE DVCInfFin.DV2.uvalue X3),
+                                                      itree (L3 DV1.dvalue DV1.uvalue)
                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                     (fun (_ : forall _ : Empty_set, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : LLVMExcE uvalue Empty_set) =>
-                                                      @raiseLLVM InfLP.Events.L3 DVCFinInf.DV2.uvalue
+                                                           (prod store_id
+                                                              (prod
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                    InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                     (fun
+                                                        (_ : forall _ : Empty_set,
+                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                        (_ : LLVMExcE DVCInfFin.DV2.uvalue Empty_set) =>
+                                                      @raiseLLVM (L3 DV1.dvalue DV1.uvalue) DVCFinInf.DV2.uvalue
                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                        (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (LLVMExcE InfLP.Events.DV.uvalue))))))
-                                                        (fin_to_inf_uvalue H11))
-                                                     X0 H9 k0 H6)
-                                                  X0 H10)
-                                                 H8 H7)
+                                                           (prod store_id
+                                                              (prod
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                    InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                        (@LLVMExcE_L3 DV1.dvalue DV1.uvalue) (fin_to_inf_uvalue H9))
+                                                     X0 H7 k0 H4)
+                                                  X0 H8)
+                                                 H6 H5)
                                                 x3
                                           end in
-                                        X1 (@eq_refl Type X0)) H5) x2
+                                        X3 (@eq_refl Type X0)) H3) x2
                                   | @inr1 _ _ _ x2 =>
-                                      (fun H5 : sum1 UBE (sum1 DebugE FailureE) X0 =>
-                                       (fun H6 : sum1 UBE (sum1 DebugE FailureE) X0 =>
-                                        let X1 :
-                                          itree InfLP.Events.L3
+                                      (fun H3 : sum1 UBE (sum1 DebugE FailureE) X0 =>
+                                       (fun H4 : sum1 UBE (sum1 DebugE FailureE) X0 =>
+                                        let X3 :
+                                          itree (L3 DV1.dvalue DV1.uvalue)
                                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                               (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                               (prod store_id
+                                                  (prod
+                                                     (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                           match
-                                            H6
+                                            H4
                                             return
-                                              (itree InfLP.Events.L3
+                                              (itree (L3 DV1.dvalue DV1.uvalue)
                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                    (prod store_id
+                                                       (prod
+                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           with
                                           | @inl1 _ _ _ x3 =>
-                                              (fun H7 : UBE X0 =>
-                                               (fun H8 : UBE X0 =>
-                                                let X1 :
+                                              (fun H5 : UBE X0 =>
+                                               (fun H6 : UBE X0 =>
+                                                let X3 :
                                                   (fun T : Type =>
                                                    forall _ : @eq Type T X0,
-                                                   itree InfLP.Events.L3
+                                                   itree (L3 DV1.dvalue DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                     X0 :=
                                                   match
-                                                    H8 in (UBE T)
+                                                    H6 in (UBE T)
                                                     return
                                                       (forall _ : @eq Type T X0,
-                                                       itree InfLP.Events.L3
+                                                       itree (L3 DV1.dvalue DV1.uvalue)
                                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                            (prod store_id
+                                                               (prod
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                     InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                     InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   with
                                                   | @ThrowUB x4 =>
-                                                      (fun (H9 : unit) (H10 : @eq Type Empty_set X0) =>
-                                                       (fun H11 : @eq Type Empty_set X0 =>
-                                                        let H12 : @eq Type Empty_set X0 := H11 in
+                                                      (fun (H7 : unit) (H8 : @eq Type Empty_set X0) =>
+                                                       (fun H9 : @eq Type Empty_set X0 =>
+                                                        let H10 : @eq Type Empty_set X0 := H9 in
                                                         @eq_rect Type Empty_set
                                                           (fun _ : Type =>
                                                            forall _ : unit,
-                                                           itree InfLP.Events.L3
+                                                           itree (L3 DV1.dvalue DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           (fun _ : unit =>
                                                            @eq_rect Type Empty_set
-                                                             (fun X1 : Type =>
-                                                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : UBE X1),
-                                                              itree InfLP.Events.L3
+                                                             (fun X3 : Type =>
+                                                              forall
+                                                                (_ : forall _ : X3,
+                                                                     itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : UBE X3),
+                                                              itree (L3 DV1.dvalue DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                             (fun (_ : forall _ : Empty_set, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : UBE Empty_set) =>
-                                                              @raiseUB InfLP.Events.L3
-                                                                (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                                   (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                                      (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                         (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                            (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 UBE UBE (sum1 DebugE FailureE) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun UBE))))))
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                             (fun
+                                                                (_ : forall _ : Empty_set,
+                                                                     itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : UBE Empty_set) =>
+                                                              @raiseUB (L3 DV1.dvalue DV1.uvalue) (@UBE_L3 DV1.dvalue DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue))))
                                                                 EmptyString)
-                                                             X0 H11 k0 H8)
-                                                          X0 H12)
-                                                         H10 H9)
+                                                             X0 H9 k0 H6)
+                                                          X0 H10)
+                                                         H8 H7)
                                                         x4
                                                   end in
-                                                X1 (@eq_refl Type X0)) H7) x3
+                                                X3 (@eq_refl Type X0)) H5) x3
                                           | @inr1 _ _ _ x3 =>
-                                              (fun H7 : sum1 DebugE FailureE X0 =>
-                                               (fun H8 : sum1 DebugE FailureE X0 =>
-                                                let X1 :
-                                                  itree InfLP.Events.L3
+                                              (fun H5 : sum1 DebugE FailureE X0 =>
+                                               (fun H6 : sum1 DebugE FailureE X0 =>
+                                                let X3 :
+                                                  itree (L3 DV1.dvalue DV1.uvalue)
                                                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                       (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                                       (prod store_id
+                                                          (prod
+                                                             (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                                   match
-                                                    H8
+                                                    H6
                                                     return
-                                                      (itree InfLP.Events.L3
+                                                      (itree (L3 DV1.dvalue DV1.uvalue)
                                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                            (prod store_id
+                                                               (prod
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                     InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                     InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   with
                                                   | @inl1 _ _ _ x4 =>
-                                                      (fun H9 : DebugE X0 =>
-                                                       (fun H10 : DebugE X0 =>
-                                                        let X1 :
+                                                      (fun H7 : DebugE X0 =>
+                                                       (fun H8 : DebugE X0 =>
+                                                        let X3 :
                                                           (fun T : Type =>
                                                            forall _ : @eq Type T X0,
-                                                           itree InfLP.Events.L3
+                                                           itree (L3 DV1.dvalue DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                             X0 :=
                                                           match
-                                                            H10 in (DebugE T)
+                                                            H8 in (DebugE T)
                                                             return
                                                               (forall _ : @eq Type T X0,
-                                                               itree InfLP.Events.L3
+                                                               itree (L3 DV1.dvalue DV1.uvalue)
                                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                    (prod store_id
+                                                                       (prod
+                                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                             InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           with
                                                           | @Debug x5 =>
-                                                              (fun (H11 : unit) (H12 : @eq Type unit X0) =>
-                                                               (fun H13 : @eq Type unit X0 =>
-                                                                let H14 : @eq Type unit X0 := H13 in
+                                                              (fun (H9 : unit) (H10 : @eq Type unit X0) =>
+                                                               (fun H11 : @eq Type unit X0 =>
+                                                                let H12 : @eq Type unit X0 := H11 in
                                                                 @eq_rect Type unit
                                                                   (fun _ : Type =>
                                                                    forall _ : unit,
-                                                                   itree InfLP.Events.L3
+                                                                   itree (L3 DV1.dvalue DV1.uvalue)
                                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                                  (fun H15 : unit =>
+                                                                        (prod store_id
+                                                                           (prod
+                                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                 InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                                  (fun H13 : unit =>
                                                                    @eq_rect Type unit
-                                                                     (fun X1 : Type =>
-                                                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : DebugE X1),
-                                                                      itree InfLP.Events.L3
+                                                                     (fun X3 : Type =>
+                                                                      forall
+                                                                        (_ : forall _ : X3,
+                                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                        (_ : DebugE X3),
+                                                                      itree (L3 DV1.dvalue DV1.uvalue)
                                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                                     (fun (k1 : forall _ : unit, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : DebugE unit) =>
-                                                                      @go InfLP.Events.L3
+                                                                           (prod store_id
+                                                                              (prod
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                    InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                                     (fun
+                                                                        (k1 : forall _ : unit,
+                                                                              itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                                (prod FinMem.MMEP.MMSP.MemState
+                                                                                   (prod store_id
+                                                                                      (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                        (_ : DebugE unit) =>
+                                                                      @go (L3 DV1.dvalue DV1.uvalue)
                                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                        (@VisF InfLP.Events.L3
+                                                                           (prod store_id
+                                                                              (prod
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                    InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                        (@VisF (L3 DV1.dvalue DV1.uvalue)
                                                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                           (itree InfLP.Events.L3
+                                                                              (prod store_id
+                                                                                 (prod
+                                                                                    (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                       InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                       InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                           (itree (L3 DV1.dvalue DV1.uvalue)
                                                                               (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                                 (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                                 (prod store_id
+                                                                                    (prod
+                                                                                       (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                          InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                          InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                                            unit
-                                                                           (@subevent DebugE InfLP.Events.L3
-                                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                                                 (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                                                    (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                                       (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                                          (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 DebugE FailureE) UBE
-                                                                                             (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 DebugE DebugE FailureE (@ReSum_id (forall _ : Type, Type) IFun Id_IFun DebugE)))))))
-                                                                              unit (Debug H15))
-                                                                           (fun H16 : unit => CIH (k1 H16))))
-                                                                     X0 H13 k0 H10)
-                                                                  X0 H14)
-                                                                 H12 H11)
+                                                                           (@subevent DebugE (L3 DV1.dvalue DV1.uvalue) (@DebugE_L3 DV1.dvalue DV1.uvalue)
+                                                                              unit (Debug H13))
+                                                                           (fun H14 : unit => CIH (k1 H14))))
+                                                                     X0 H11 k0 H8)
+                                                                  X0 H12)
+                                                                 H10 H9)
                                                                 x5
                                                           end in
-                                                        X1 (@eq_refl Type X0)) H9) x4
+                                                        X3 (@eq_refl Type X0)) H7) x4
                                                   | @inr1 _ _ _ x4 =>
-                                                      (fun H9 : FailureE X0 =>
-                                                       (fun H10 : FailureE X0 =>
-                                                        let X1 :
+                                                      (fun H7 : FailureE X0 =>
+                                                       (fun H8 : FailureE X0 =>
+                                                        let X3 :
                                                           (fun T : Type =>
                                                            forall _ : @eq Type T X0,
-                                                           itree InfLP.Events.L3
+                                                           itree (L3 DV1.dvalue DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                             X0 :=
                                                           match
-                                                            H10 in (FailureE T)
+                                                            H8 in (FailureE T)
                                                             return
                                                               (forall _ : @eq Type T X0,
-                                                               itree InfLP.Events.L3
+                                                               itree (L3 DV1.dvalue DV1.uvalue)
                                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                    (prod store_id
+                                                                       (prod
+                                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                             InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           with
                                                           | @Throw x5 =>
-                                                              (fun (H11 : unit) (H12 : @eq Type Empty_set X0) =>
-                                                               (fun H13 : @eq Type Empty_set X0 =>
-                                                                let H14 : @eq Type Empty_set X0 := H13 in
+                                                              (fun (H9 : unit) (H10 : @eq Type Empty_set X0) =>
+                                                               (fun H11 : @eq Type Empty_set X0 =>
+                                                                let H12 : @eq Type Empty_set X0 := H11 in
                                                                 @eq_rect Type Empty_set
                                                                   (fun _ : Type =>
                                                                    forall _ : unit,
-                                                                   itree InfLP.Events.L3
+                                                                   itree (L3 DV1.dvalue DV1.uvalue)
                                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                        (prod store_id
+                                                                           (prod
+                                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                 InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                                   (fun _ : unit =>
                                                                    @eq_rect Type Empty_set
-                                                                     (fun X1 : Type =>
-                                                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : FailureE X1),
-                                                                      itree InfLP.Events.L3
+                                                                     (fun X3 : Type =>
+                                                                      forall
+                                                                        (_ : forall _ : X3,
+                                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                        (_ : FailureE X3),
+                                                                      itree (L3 DV1.dvalue DV1.uvalue)
                                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                                     (fun (_ : forall _ : Empty_set, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : FailureE Empty_set) =>
-                                                                      @LLVMEvents.raise InfLP.Events.L3
+                                                                           (prod store_id
+                                                                              (prod
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                    InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                                     (fun
+                                                                        (_ : forall _ : Empty_set,
+                                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                        (_ : FailureE Empty_set) =>
+                                                                      @LLVMEvents.raise (L3 DV1.dvalue DV1.uvalue)
                                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                        (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                                 (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                                    (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 DebugE FailureE) UBE
-                                                                                       (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE FailureE DebugE (@ReSum_id (forall _ : Type, Type) IFun Id_IFun FailureE)))))))
-                                                                        EmptyString)
-                                                                     X0 H13 k0 H10)
-                                                                  X0 H14)
-                                                                 H12 H11)
+                                                                           (prod store_id
+                                                                              (prod
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                    InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                        (@FailureE_L3 DV1.dvalue DV1.uvalue) EmptyString)
+                                                                     X0 H11 k0 H8)
+                                                                  X0 H12)
+                                                                 H10 H9)
                                                                 x5
                                                           end in
-                                                        X1 (@eq_refl Type X0)) H9) x4
+                                                        X3 (@eq_refl Type X0)) H7) x4
                                                   end in
-                                                X1) H7) x3
+                                                X3) H5) x3
                                           end in
-                                        X1) H5) x2
+                                        X3) H3) x2
                                   end in
-                                X1) H3) x1
+                                X3) H1) x1
                           end in
-                        X1) H1) x0
+                        X3) H) x0
                   end in
-                X1) H) x
+                X3) X1) x
           end in
         X1) X e k
    end) (@_observe _ _ t_fin2).
 
-  Definition _get_inf_tree (t_fin2 : itree' L3 res_L6) : itree InfLP.Events.L3 TopLevelBigIntptr.res_L6 :=
-   match t_fin2
+
+  Definition _get_inf_tree (t_fin2 : itree' (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue) res_L6) : itree (L3 DV1.dvalue DV1.uvalue) TopLevelBigIntptr.res_L6 :=
+    match t_fin2
      return
-       (itree InfLP.Events.L3
-          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+       (itree (L3 DV1.dvalue DV1.uvalue)
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
    with
    | @RetF _ _ _ r =>
        (fun r0 : prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))) =>
-        @ret (itree InfLP.Events.L3) (@Monad_itree InfLP.Events.L3)
-          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+        @ret (itree (L3 DV1.dvalue DV1.uvalue)) (@Monad_itree (L3 DV1.dvalue DV1.uvalue))
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
           match
-            r0 return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+            r0
+            return
+              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                 (prod store_id
+                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
           with
           | @pair _ _ m p =>
               (fun (ms : FinMem.MMEP.MMSP.MemState) (p0 : prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))) =>
                match
-                 p0 return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                 p0
+                 return
+                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                      (prod store_id
+                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                with
                | @pair _ _ s p1 =>
                    (fun (sid : store_id) (p2 : prod (prod lstack_frame lstack) (prod global_env dvalue)) =>
                     match
                       p2
-                      return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                      return
+                        (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                           (prod store_id
+                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                     with
                     | @pair _ _ p3 p4 =>
                         (fun p5 : prod lstack_frame lstack =>
@@ -3969,7 +3948,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                            p5
                            return
                              (forall _ : prod global_env dvalue,
-                              prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                              prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                          with
                          | @pair _ _ l l0 =>
                              (fun (lenv : lstack_frame) (s0 : lstack) (p6 : prod global_env dvalue) =>
@@ -3977,16 +3959,27 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 p6
                                 return
                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                     (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                     (prod store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                               with
                               | @pair _ _ g d =>
                                   (fun (genv : global_env) (res : dvalue) =>
                                    @pair InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                     (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))) (lift_MemState ms)
-                                     (@pair store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)) sid
-                                        (@pair (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)
-                                           (@pair InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack (lift_stack_frame lenv) (lift_stack s0))
-                                           (@pair InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue (lift_global_env genv) (fin_to_inf_dvalue res)))))
+                                     (prod store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))
+                                     (lift_MemState ms)
+                                     (@pair store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))
+                                        sid
+                                        (@pair (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)
+                                           (@pair InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack
+                                              (lift_stack_frame lenv) (lift_stack s0))
+                                           (@pair InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue
+                                              (lift_global_env genv) (fin_to_inf_dvalue res)))))
                                     g d
                               end) l l0
                          end) p3 p4
@@ -3995,734 +3988,1108 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           end)
          r
    | @TauF _ _ _ t =>
-       (fun t0 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) =>
-        @go InfLP.Events.L3 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-          (@TauF InfLP.Events.L3
-             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-             (itree InfLP.Events.L3
-                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+       (fun
+          t0 : itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) =>
+        @go (L3 DV1.dvalue DV1.uvalue)
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+          (@TauF (L3 DV1.dvalue DV1.uvalue)
+             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                (prod store_id
+                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+             (itree (L3 DV1.dvalue DV1.uvalue)
+                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                   (prod store_id
+                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
              (get_inf_tree t0)))
          t
    | @VisF _ _ _ X e k =>
-       (fun (X0 : Type) (e0 : L3 X0) (k0 : forall _ : X0, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
+       (fun (X0 : Type) (e0 : L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0)
+          (k0 : forall _ : X0,
+                itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                  (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
         let X1 :
-          itree InfLP.Events.L3
-            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+          itree (L3 DV1.dvalue DV1.uvalue)
+            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+               (prod store_id
+                  (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
           match
             e0
             return
-              (itree InfLP.Events.L3
-                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+              (itree (L3 DV1.dvalue DV1.uvalue)
+                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                    (prod store_id
+                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
           with
           | @inl1 _ _ _ x =>
-              (fun H : ExternalCallE X0 =>
-               (fun H0 : ExternalCallE X0 =>
-                let X1 :
-                  (fun T : Type =>
-                   forall _ : @eq Type T X0,
-                   itree InfLP.Events.L3
-                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                    X0 :=
-                  match
-                    H0 in (ExternalCallE T)
-                    return
-                      (forall _ : @eq Type T X0,
-                       itree InfLP.Events.L3
-                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                  with
-                  | @ExternalCall t f args =>
-                      (fun (t0 : dtyp) (f0 : uvalue) (args0 : list dvalue) (H1 : @eq Type dvalue X0) =>
-                       (fun H2 : @eq Type dvalue X0 =>
-                        let H3 : @eq Type dvalue X0 := H2 in
-                        @eq_rect Type dvalue
-                          (fun _ : Type =>
-                           forall (_ : dtyp) (_ : uvalue) (_ : list dvalue),
-                           itree InfLP.Events.L3
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                          (fun (t1 : dtyp) (f1 : uvalue) (args1 : list dvalue) =>
-                           @eq_rect Type dvalue
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : dvalue, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE dvalue) =>
-                              @go InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L3
-                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L3
-                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                   E1.DV.dvalue
-                                   (@subevent E1.ExternalCallE InfLP.Events.L3
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))))
-                                         (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE))
-                                      E1.DV.dvalue (E1.ExternalCall t1 (fin_to_inf_uvalue f1) (@map DVCFinInf.DV1.dvalue DVCFinInf.DV2.dvalue fin_to_inf_dvalue args1)))
-                                   (fun x0 : E1.DV.dvalue =>
-                                    get_inf_tree
-                                      (let H4 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x0 in
-                                       match H4 return (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
-                                       | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 d0) d
-                                       | @Oom _ s =>
-                                           (fun s0 : string =>
-                                            @raiseOOM L3
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))))) ExternalCallE
-                                                 (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) PickUvalueE
-                                                    (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
-                                              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
-                                             s
-                                       end))))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 t0 f0 args0)
-                        t f args
-                  | @IO_stdout str =>
-                      (fun (str0 : list int8) (H1 : @eq Type unit X0) =>
-                       (fun H2 : @eq Type unit X0 =>
-                        let H3 : @eq Type unit X0 := H2 in
-                        @eq_rect Type unit
-                          (fun _ : Type =>
-                           forall _ : list int8,
-                           itree InfLP.Events.L3
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                          (fun str1 : list int8 =>
-                           @eq_rect Type unit
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : unit, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE unit) =>
-                              @go InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L3
-                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L3
-                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                   unit
-                                   (@subevent E1.ExternalCallE InfLP.Events.L3
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))))
-                                         (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE))
-                                      unit (E1.IO_stdout str1))
-                                   (fun H4 : unit =>
-                                    match
-                                      H4
-                                      return
-                                        (itree InfLP.Events.L3
-                                           (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                    with
-                                    | @tt => get_inf_tree (k1 tt)
-                                    end)))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 str0)
-                        str
-                  | @IO_stderr str =>
-                      (fun (str0 : list int8) (H1 : @eq Type unit X0) =>
-                       (fun H2 : @eq Type unit X0 =>
-                        let H3 : @eq Type unit X0 := H2 in
-                        @eq_rect Type unit
-                          (fun _ : Type =>
-                           forall _ : list int8,
-                           itree InfLP.Events.L3
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                          (fun str1 : list int8 =>
-                           @eq_rect Type unit
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : unit, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE unit) =>
-                              @go InfLP.Events.L3
-                                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L3
-                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L3
-                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                   unit
-                                   (@subevent E1.ExternalCallE InfLP.Events.L3
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))))
-                                         (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE))
-                                      unit (E1.IO_stderr str1))
-                                   (fun H4 : unit =>
-                                    match
-                                      H4
-                                      return
-                                        (itree InfLP.Events.L3
-                                           (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                    with
-                                    | @tt => get_inf_tree (k1 tt)
-                                    end)))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 str0)
-                        str
-                  end in
-                X1 (@eq_refl Type X0)) H) x
+              (fun X1 : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0 =>
+               (fun X2 : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0 =>
+                (let X3 :
+                   (fun T : Type =>
+                    forall _ : @eq Type T X0,
+                    itree (L3 DV1.dvalue DV1.uvalue)
+                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                         (prod store_id
+                            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                     X0 :=
+                   match
+                     X2 in (ExternalCallE _ _ T)
+                     return
+                       (forall _ : @eq Type T X0,
+                        itree (L3 DV1.dvalue DV1.uvalue)
+                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                             (prod store_id
+                                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                   with
+                   | @ExternalCall _ _ t f args =>
+                       (fun (t0 : dtyp) (f0 : DVCInfFin.DV2.uvalue) (args0 : list DVCInfFin.DV2.dvalue) (H : @eq Type DVCInfFin.DV2.dvalue X0) =>
+                        (fun H0 : @eq Type DVCInfFin.DV2.dvalue X0 =>
+                         let H1 : @eq Type DVCInfFin.DV2.dvalue X0 := H0 in
+                         @eq_rect Type DVCInfFin.DV2.dvalue
+                           (fun _ : Type =>
+                            forall (_ : dtyp) (_ : DVCInfFin.DV2.uvalue) (_ : list DVCInfFin.DV2.dvalue),
+                            itree (L3 DV1.dvalue DV1.uvalue)
+                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                 (prod store_id
+                                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                           (fun (t1 : dtyp) (f1 : DVCInfFin.DV2.uvalue) (args1 : list DVCInfFin.DV2.dvalue) =>
+                            @eq_rect Type DVCInfFin.DV2.dvalue
+                              (fun X3 : Type =>
+                               forall
+                                 (_ : forall _ : X3,
+                                      itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X3),
+                               itree (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                              (fun
+                                 (k1 : forall _ : DVCInfFin.DV2.dvalue,
+                                       itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                         (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue DVCInfFin.DV2.dvalue) =>
+                               @go (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                 (@VisF (L3 DV1.dvalue DV1.uvalue)
+                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                    (itree (L3 DV1.dvalue DV1.uvalue)
+                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                          (prod store_id
+                                             (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                    DVCFinInf.DV2.dvalue
+                                    (@subevent (ExternalCallE DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue) (L3 DV1.dvalue DV1.uvalue)
+                                       (@ExternalCallE_L3 DV1.dvalue DV1.uvalue) DVCFinInf.DV2.dvalue
+                                       (@ExternalCall DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue t1 (fin_to_inf_uvalue f1)
+                                          (@map DVCFinInf.DV1.dvalue DVCFinInf.DV2.dvalue fin_to_inf_dvalue args1)))
+                                    (fun x0 : DVCFinInf.DV2.dvalue =>
+                                     get_inf_tree
+                                       (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x0 in
+                                        match
+                                          H2
+                                          return
+                                            (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        with
+                                        | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 d0) d
+                                        | @Oom _ s =>
+                                            (fun s0 : string =>
+                                             @raiseOOM (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue) (@OOME_L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                               s0)
+                                              s
+                                        end))))
+                              X0 H0 k0 X2)
+                           X0 H1)
+                          H t0 f0 args0)
+                         t f args
+                   | @IO_stdout _ _ str =>
+                       (fun (str0 : list int8) (H : @eq Type unit X0) =>
+                        (fun H0 : @eq Type unit X0 =>
+                         let H1 : @eq Type unit X0 := H0 in
+                         @eq_rect Type unit
+                           (fun _ : Type =>
+                            forall _ : list int8,
+                            itree (L3 DV1.dvalue DV1.uvalue)
+                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                 (prod store_id
+                                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                           (fun str1 : list int8 =>
+                            @eq_rect Type unit
+                              (fun X3 : Type =>
+                               forall
+                                 (_ : forall _ : X3,
+                                      itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X3),
+                               itree (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                              (fun
+                                 (k1 : forall _ : unit,
+                                       itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                         (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue unit) =>
+                               @go (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                 (@VisF (L3 DV1.dvalue DV1.uvalue)
+                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                    (itree (L3 DV1.dvalue DV1.uvalue)
+                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                          (prod store_id
+                                             (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                    unit
+                                    (@subevent (ExternalCallE DV1.dvalue DV1.uvalue) (L3 DV1.dvalue DV1.uvalue) (@ExternalCallE_L3 DV1.dvalue DV1.uvalue)
+                                       unit (@IO_stdout DV1.dvalue DV1.uvalue str1))
+                                    (fun H2 : unit =>
+                                     match
+                                       H2
+                                       return
+                                         (itree (L3 DV1.dvalue DV1.uvalue)
+                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                               (prod store_id
+                                                  (prod
+                                                     (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     with
+                                     | @tt => get_inf_tree (k1 tt)
+                                     end)))
+                              X0 H0 k0 X2)
+                           X0 H1)
+                          H str0)
+                         str
+                   | @IO_stderr _ _ str =>
+                       (fun (str0 : list int8) (H : @eq Type unit X0) =>
+                        (fun H0 : @eq Type unit X0 =>
+                         let H1 : @eq Type unit X0 := H0 in
+                         @eq_rect Type unit
+                           (fun _ : Type =>
+                            forall _ : list int8,
+                            itree (L3 DV1.dvalue DV1.uvalue)
+                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                 (prod store_id
+                                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                           (fun str1 : list int8 =>
+                            @eq_rect Type unit
+                              (fun X3 : Type =>
+                               forall
+                                 (_ : forall _ : X3,
+                                      itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X3),
+                               itree (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                              (fun
+                                 (k1 : forall _ : unit,
+                                       itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                         (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                 (_ : ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue unit) =>
+                               @go (L3 DV1.dvalue DV1.uvalue)
+                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                 (@VisF (L3 DV1.dvalue DV1.uvalue)
+                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                    (itree (L3 DV1.dvalue DV1.uvalue)
+                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                          (prod store_id
+                                             (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                    unit
+                                    (@subevent (ExternalCallE DV1.dvalue DV1.uvalue) (L3 DV1.dvalue DV1.uvalue) (@ExternalCallE_L3 DV1.dvalue DV1.uvalue)
+                                       unit (@IO_stderr DV1.dvalue DV1.uvalue str1))
+                                    (fun H2 : unit =>
+                                     match
+                                       H2
+                                       return
+                                         (itree (L3 DV1.dvalue DV1.uvalue)
+                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                               (prod store_id
+                                                  (prod
+                                                     (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     with
+                                     | @tt => get_inf_tree (k1 tt)
+                                     end)))
+                              X0 H0 k0 X2)
+                           X0 H1)
+                          H str0)
+                         str
+                   end in
+                 X3 (@eq_refl Type X0))
+                :
+                itree (L3 DV1.dvalue DV1.uvalue)
+                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                     (prod store_id
+                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                 X1)
+                x
           | @inr1 _ _ _ x =>
-              (fun H : sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) X0 =>
-               (fun H0 : sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) X0 =>
-                let X1 :
-                  itree InfLP.Events.L3
-                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+              (fun
+                 X1 : sum1 (PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                        (sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) X0 =>
+               (fun
+                  X2 : sum1 (PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                         (sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) X0 =>
+                let X3 :
+                  itree (L3 DV1.dvalue DV1.uvalue)
+                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                       (prod store_id
+                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                   match
-                    H0
+                    X2
                     return
-                      (itree InfLP.Events.L3
-                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                      (itree (L3 DV1.dvalue DV1.uvalue)
+                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                            (prod store_id
+                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                   with
                   | @inl1 _ _ _ x0 =>
-                      (fun H1 : PickUvalueE X0 =>
-                       (fun H2 : PickUvalueE X0 =>
-                        let X1 :
+                      (fun X3 : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0 =>
+                       (fun X4 : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X0 =>
+                        let X5 :
                           (fun T : Type =>
                            forall _ : @eq Type T X0,
-                           itree InfLP.Events.L3
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                           itree (L3 DV1.dvalue DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                             X0 :=
                           match
-                            H2 in (@PickE _ _ _ T)
+                            X4 in (@PickE _ _ _ T)
                             return
                               (forall _ : @eq Type T X0,
-                               itree InfLP.Events.L3
+                               itree (L3 DV1.dvalue DV1.uvalue)
                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           with
                           | @pickUnique _ _ _ x1 =>
-                              (fun (x2 : uvalue) (H3 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0) =>
-                               (fun H4 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 =>
-                                let H5 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 := H4 in
-                                @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
+                              (fun (x2 : DVCInfFin.DV2.uvalue) (H : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0) =>
+                               (fun H0 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 =>
+                                let H1 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 := H0 in
+                                @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
                                   (fun _ : Type =>
-                                   forall _ : uvalue,
-                                   itree InfLP.Events.L3
+                                   forall _ : DVCInfFin.DV2.uvalue,
+                                   itree (L3 DV1.dvalue DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                  (fun x3 : uvalue =>
-                                   @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
-                                     (fun X1 : Type =>
-                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE X1),
-                                      itree InfLP.Events.L3
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                  (fun x3 : DVCInfFin.DV2.uvalue =>
+                                   @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
+                                     (fun X5 : Type =>
+                                      forall
+                                        (_ : forall _ : X5,
+                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X5),
+                                      itree (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                     (fun (k1 : forall _ : @sig dvalue (fun _ : dvalue => True), itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE (@sig dvalue (fun _ : dvalue => True))) =>
-                                      @go InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     (fun
+                                        (k1 : forall _ : @sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True),
+                                              itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue
+                                               (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))) =>
+                                      @go (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                        (@VisF InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                        (@VisF (L3 DV1.dvalue DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                           (itree InfLP.Events.L3
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                           (itree (L3 DV1.dvalue DV1.uvalue)
                                               (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                 (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                           (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True))
-                                           (@subevent (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.L3
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True))
-                                                 (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.PickUvalueE
-                                                    (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.PickUvalueE)))
-                                              (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True)) (@E1.pickUnique DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True) (fin_to_inf_uvalue x3)))
-                                           (fun res : @sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True) =>
+                                                 (prod store_id
+                                                    (prod
+                                                       (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                           (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                           (@subevent (@PickE DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True))
+                                              (L3 DV1.dvalue DV1.uvalue) (@PickE_L3 DV1.dvalue DV1.uvalue) (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                              (@pickUnique DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True)
+                                                 (fin_to_inf_uvalue x3)))
+                                           (fun res : @sig DV1.dvalue (fun _ : DV1.dvalue => True) =>
                                             match
                                               res
                                               return
-                                                (itree InfLP.Events.L3
+                                                (itree (L3 DV1.dvalue DV1.uvalue)
                                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                      (prod store_id
+                                                         (prod
+                                                            (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                               InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             with
                                             | @exist _ _ x4 t =>
-                                                (fun (x5 : InfLP.Events.DV.dvalue) (t0 : True) =>
+                                                (fun (x5 : DV1.dvalue) (t0 : True) =>
                                                  get_inf_tree
-                                                   (let H6 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
-                                                    match H6 return (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
-                                                    | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 (@exist dvalue (fun _ : dvalue => True) d0 t0)) d
+                                                   (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
+                                                    match
+                                                      H2
+                                                      return
+                                                        (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                    with
+                                                    | @NoOom _ d =>
+                                                        (fun d0 : DVCInfFin.DV2.dvalue =>
+                                                         k1 (@exist DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True) d0 t0)) d
                                                     | @Oom _ s =>
                                                         (fun s0 : string =>
-                                                         @raiseOOM L3
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))))) ExternalCallE
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) PickUvalueE
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
-                                                           (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
+                                                         @raiseOOM (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (@OOME_L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                                           s0)
                                                           s
                                                     end))
                                                   x4 t
                                             end)))
-                                     X0 H4 k0 H2)
-                                  X0 H5)
-                                 H3 x2)
+                                     X0 H0 k0 X4)
+                                  X0 H1)
+                                 H x2)
                                 x1
                           | @pickNonPoison _ _ _ x1 =>
-                              (fun (x2 : uvalue) (H3 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0) =>
-                               (fun H4 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 =>
-                                let H5 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 := H4 in
-                                @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
+                              (fun (x2 : DVCInfFin.DV2.uvalue) (H : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0) =>
+                               (fun H0 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 =>
+                                let H1 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 := H0 in
+                                @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
                                   (fun _ : Type =>
-                                   forall _ : uvalue,
-                                   itree InfLP.Events.L3
+                                   forall _ : DVCInfFin.DV2.uvalue,
+                                   itree (L3 DV1.dvalue DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                  (fun x3 : uvalue =>
-                                   @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
-                                     (fun X1 : Type =>
-                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE X1),
-                                      itree InfLP.Events.L3
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                  (fun x3 : DVCInfFin.DV2.uvalue =>
+                                   @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
+                                     (fun X5 : Type =>
+                                      forall
+                                        (_ : forall _ : X5,
+                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X5),
+                                      itree (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                     (fun (k1 : forall _ : @sig dvalue (fun _ : dvalue => True), itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE (@sig dvalue (fun _ : dvalue => True))) =>
-                                      @go InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     (fun
+                                        (k1 : forall _ : @sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True),
+                                              itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue
+                                               (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))) =>
+                                      @go (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                        (@VisF InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                        (@VisF (L3 DV1.dvalue DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                           (itree InfLP.Events.L3
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                           (itree (L3 DV1.dvalue DV1.uvalue)
                                               (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                 (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                           (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True))
-                                           (@subevent (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.L3
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True))
-                                                 (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.PickUvalueE
-                                                    (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.PickUvalueE)))
-                                              (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True)) (@E1.pickNonPoison DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True) (fin_to_inf_uvalue x3)))
-                                           (fun res : @sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True) =>
+                                                 (prod store_id
+                                                    (prod
+                                                       (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                           (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                           (@subevent (@PickE DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True))
+                                              (L3 DV1.dvalue DV1.uvalue) (@PickE_L3 DV1.dvalue DV1.uvalue) (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                              (@pickNonPoison DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True)
+                                                 (fin_to_inf_uvalue x3)))
+                                           (fun res : @sig DV1.dvalue (fun _ : DV1.dvalue => True) =>
                                             match
                                               res
                                               return
-                                                (itree InfLP.Events.L3
+                                                (itree (L3 DV1.dvalue DV1.uvalue)
                                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                      (prod store_id
+                                                         (prod
+                                                            (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                               InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             with
                                             | @exist _ _ x4 t =>
-                                                (fun (x5 : InfLP.Events.DV.dvalue) (t0 : True) =>
+                                                (fun (x5 : DV1.dvalue) (t0 : True) =>
                                                  get_inf_tree
-                                                   (let H6 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
-                                                    match H6 return (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
-                                                    | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 (@exist dvalue (fun _ : dvalue => True) d0 t0)) d
+                                                   (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
+                                                    match
+                                                      H2
+                                                      return
+                                                        (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                    with
+                                                    | @NoOom _ d =>
+                                                        (fun d0 : DVCInfFin.DV2.dvalue =>
+                                                         k1 (@exist DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True) d0 t0)) d
                                                     | @Oom _ s =>
                                                         (fun s0 : string =>
-                                                         @raiseOOM L3
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))))) ExternalCallE
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) PickUvalueE
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
-                                                           (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
+                                                         @raiseOOM (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (@OOME_L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                                           s0)
                                                           s
                                                     end))
                                                   x4 t
                                             end)))
-                                     X0 H4 k0 H2)
-                                  X0 H5)
-                                 H3 x2)
+                                     X0 H0 k0 X4)
+                                  X0 H1)
+                                 H x2)
                                 x1
                           | @pick _ _ _ x1 =>
-                              (fun (x2 : uvalue) (H3 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0) =>
-                               (fun H4 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 =>
-                                let H5 : @eq Type (@sig dvalue (fun _ : dvalue => True)) X0 := H4 in
-                                @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
+                              (fun (x2 : DVCInfFin.DV2.uvalue) (H : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0) =>
+                               (fun H0 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 =>
+                                let H1 : @eq Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True)) X0 := H0 in
+                                @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
                                   (fun _ : Type =>
-                                   forall _ : uvalue,
-                                   itree InfLP.Events.L3
+                                   forall _ : DVCInfFin.DV2.uvalue,
+                                   itree (L3 DV1.dvalue DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                  (fun x3 : uvalue =>
-                                   @eq_rect Type (@sig dvalue (fun _ : dvalue => True))
-                                     (fun X1 : Type =>
-                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE X1),
-                                      itree InfLP.Events.L3
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                  (fun x3 : DVCInfFin.DV2.uvalue =>
+                                   @eq_rect Type (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))
+                                     (fun X5 : Type =>
+                                      forall
+                                        (_ : forall _ : X5,
+                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue X5),
+                                      itree (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                     (fun (k1 : forall _ : @sig dvalue (fun _ : dvalue => True), itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : PickUvalueE (@sig dvalue (fun _ : dvalue => True))) =>
-                                      @go InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     (fun
+                                        (k1 : forall _ : @sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True),
+                                              itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : PickUvalueE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue
+                                               (@sig DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True))) =>
+                                      @go (L3 DV1.dvalue DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                        (@VisF InfLP.Events.L3
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                        (@VisF (L3 DV1.dvalue DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                           (itree InfLP.Events.L3
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                           (itree (L3 DV1.dvalue DV1.uvalue)
                                               (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                 (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                           (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True))
-                                           (@subevent (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.L3
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True))
-                                                 (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (@E1.PickE DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True)) InfLP.Events.PickUvalueE
-                                                    (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.PickUvalueE)))
-                                              (@sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True)) (@E1.pick DVCFinInf.DV2.uvalue InfLP.Events.DV.dvalue (fun (_ : InfLP.Events.DV.uvalue) (_ : InfLP.Events.DV.dvalue) => True) (fin_to_inf_uvalue x3)))
-                                           (fun res : @sig InfLP.Events.DV.dvalue (fun _ : InfLP.Events.DV.dvalue => True) =>
+                                                 (prod store_id
+                                                    (prod
+                                                       (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                           (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                           (@subevent (@PickE DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True))
+                                              (L3 DV1.dvalue DV1.uvalue) (@PickE_L3 DV1.dvalue DV1.uvalue) (@sig DV1.dvalue (fun _ : DV1.dvalue => True))
+                                              (@pick DVCFinInf.DV2.uvalue DV1.dvalue (fun (_ : DV1.uvalue) (_ : DV1.dvalue) => True) (fin_to_inf_uvalue x3)))
+                                           (fun res : @sig DV1.dvalue (fun _ : DV1.dvalue => True) =>
                                             match
                                               res
                                               return
-                                                (itree InfLP.Events.L3
+                                                (itree (L3 DV1.dvalue DV1.uvalue)
                                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                      (prod store_id
+                                                         (prod
+                                                            (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                               InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             with
                                             | @exist _ _ x4 t =>
-                                                (fun (x5 : InfLP.Events.DV.dvalue) (t0 : True) =>
+                                                (fun (x5 : DV1.dvalue) (t0 : True) =>
                                                  get_inf_tree
-                                                   (let H6 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
-                                                    match H6 return (itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
-                                                    | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 (@exist dvalue (fun _ : dvalue => True) d0 t0)) d
+                                                   (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x5 in
+                                                    match
+                                                      H2
+                                                      return
+                                                        (itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                    with
+                                                    | @NoOom _ d =>
+                                                        (fun d0 : DVCInfFin.DV2.dvalue =>
+                                                         k1 (@exist DVCInfFin.DV2.dvalue (fun _ : DVCInfFin.DV2.dvalue => True) d0 t0)) d
                                                     | @Oom _ s =>
                                                         (fun s0 : string =>
-                                                         @raiseOOM L3
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 PickUvalueE (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))))) ExternalCallE
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) PickUvalueE
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
-                                                           (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
+                                                         @raiseOOM (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (@OOME_L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                           (prod FinMem.MMEP.MMSP.MemState
+                                                              (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                                           s0)
                                                           s
                                                     end))
                                                   x4 t
                                             end)))
-                                     X0 H4 k0 H2)
-                                  X0 H5)
-                                 H3 x2)
+                                     X0 H0 k0 X4)
+                                  X0 H1)
+                                 H x2)
                                 x1
                           end in
-                        X1 (@eq_refl Type X0)) H1) x0
+                        X5 (@eq_refl Type X0)) X3) x0
                   | @inr1 _ _ _ x0 =>
-                      (fun H1 : sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
-                       (fun H2 : sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
-                        let X1 :
-                          itree InfLP.Events.L3
-                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                      (fun H : sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
+                       (fun H0 : sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
+                        let X3 :
+                          itree (L3 DV1.dvalue DV1.uvalue)
+                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                               (prod store_id
+                                  (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                           match
-                            H2
+                            H0
                             return
-                              (itree InfLP.Events.L3
+                              (itree (L3 DV1.dvalue DV1.uvalue)
                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           with
                           | @inl1 _ _ _ x1 =>
-                              (fun H3 : OOME X0 =>
-                               (fun H4 : OOME X0 =>
-                                let X1 :
+                              (fun H1 : OOME X0 =>
+                               (fun H2 : OOME X0 =>
+                                let X3 :
                                   (fun T : Type =>
                                    forall _ : @eq Type T X0,
-                                   itree InfLP.Events.L3
+                                   itree (L3 DV1.dvalue DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                     X0 :=
                                   match
-                                    H4 in (OOME T)
+                                    H2 in (OOME T)
                                     return
                                       (forall _ : @eq Type T X0,
-                                       itree InfLP.Events.L3
+                                       itree (L3 DV1.dvalue DV1.uvalue)
                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                            (prod store_id
+                                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   with
                                   | @ThrowOOM x2 =>
-                                      (fun (H5 : unit) (H6 : @eq Type Empty_set X0) =>
-                                       (fun H7 : @eq Type Empty_set X0 =>
-                                        let H8 : @eq Type Empty_set X0 := H7 in
+                                      (fun (H3 : unit) (H4 : @eq Type Empty_set X0) =>
+                                       (fun H5 : @eq Type Empty_set X0 =>
+                                        let H6 : @eq Type Empty_set X0 := H5 in
                                         @eq_rect Type Empty_set
                                           (fun _ : Type =>
                                            forall _ : unit,
-                                           itree InfLP.Events.L3
+                                           itree (L3 DV1.dvalue DV1.uvalue)
                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                (prod store_id
+                                                   (prod
+                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           (fun _ : unit =>
                                            @eq_rect Type Empty_set
-                                             (fun X1 : Type =>
-                                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : OOME X1),
-                                              itree InfLP.Events.L3
+                                             (fun X3 : Type =>
+                                              forall
+                                                (_ : forall _ : X3,
+                                                     itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                (_ : OOME X3),
+                                              itree (L3 DV1.dvalue DV1.uvalue)
                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                             (fun (_ : forall _ : Empty_set, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : OOME Empty_set) =>
-                                              @raiseOOM InfLP.Events.L3
-                                                (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                   (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME))))
+                                                   (prod store_id
+                                                      (prod
+                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                             (fun
+                                                (_ : forall _ : Empty_set,
+                                                     itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                (_ : OOME Empty_set) =>
+                                              @raiseOOM (L3 DV1.dvalue DV1.uvalue) (@OOME_L3 DV1.dvalue DV1.uvalue)
                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                                   (prod store_id
+                                                      (prod
+                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                                                 EmptyString)
-                                             X0 H7 k0 H4)
-                                          X0 H8)
-                                         H6 H5)
+                                             X0 H5 k0 H2)
+                                          X0 H6)
+                                         H4 H3)
                                         x2
                                   end in
-                                X1 (@eq_refl Type X0)) H3) x1
+                                X3 (@eq_refl Type X0)) H1) x1
                           | @inr1 _ _ _ x1 =>
-                              (fun H3 : sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
-                               (fun H4 : sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
-                                let X1 :
-                                  itree InfLP.Events.L3
+                              (fun H1 : sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
+                               (fun H2 : sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
+                                let X3 :
+                                  itree (L3 DV1.dvalue DV1.uvalue)
                                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                       (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                   match
-                                    H4
+                                    H2
                                     return
-                                      (itree InfLP.Events.L3
+                                      (itree (L3 DV1.dvalue DV1.uvalue)
                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                            (prod store_id
+                                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   with
                                   | @inl1 _ _ _ x2 =>
-                                      (fun H5 : LLVMExcE uvalue X0 =>
-                                       (fun H6 : LLVMExcE uvalue X0 =>
-                                        let X1 :
+                                      (fun H3 : LLVMExcE DVCInfFin.DV2.uvalue X0 =>
+                                       (fun H4 : LLVMExcE DVCInfFin.DV2.uvalue X0 =>
+                                        let X3 :
                                           (fun T : Type =>
                                            forall _ : @eq Type T X0,
-                                           itree InfLP.Events.L3
+                                           itree (L3 DV1.dvalue DV1.uvalue)
                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                (prod store_id
+                                                   (prod
+                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             X0 :=
                                           match
-                                            H6 in (LLVMExcE _ T)
+                                            H4 in (LLVMExcE _ T)
                                             return
                                               (forall _ : @eq Type T X0,
-                                               itree InfLP.Events.L3
+                                               itree (L3 DV1.dvalue DV1.uvalue)
                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                    (prod store_id
+                                                       (prod
+                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           with
                                           | @LLVMExc _ x3 =>
-                                              (fun (H7 : uvalue) (H8 : @eq Type Empty_set X0) =>
-                                               (fun H9 : @eq Type Empty_set X0 =>
-                                                let H10 : @eq Type Empty_set X0 := H9 in
+                                              (fun (H5 : DVCInfFin.DV2.uvalue) (H6 : @eq Type Empty_set X0) =>
+                                               (fun H7 : @eq Type Empty_set X0 =>
+                                                let H8 : @eq Type Empty_set X0 := H7 in
                                                 @eq_rect Type Empty_set
                                                   (fun _ : Type =>
-                                                   forall _ : uvalue,
-                                                   itree InfLP.Events.L3
+                                                   forall _ : DVCInfFin.DV2.uvalue,
+                                                   itree (L3 DV1.dvalue DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                  (fun H11 : uvalue =>
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                  (fun H9 : DVCInfFin.DV2.uvalue =>
                                                    @eq_rect Type Empty_set
-                                                     (fun X1 : Type =>
-                                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : LLVMExcE uvalue X1),
-                                                      itree InfLP.Events.L3
+                                                     (fun X3 : Type =>
+                                                      forall
+                                                        (_ : forall _ : X3,
+                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                        (_ : LLVMExcE DVCInfFin.DV2.uvalue X3),
+                                                      itree (L3 DV1.dvalue DV1.uvalue)
                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                     (fun (_ : forall _ : Empty_set, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : LLVMExcE uvalue Empty_set) =>
-                                                      @raiseLLVM InfLP.Events.L3 DVCFinInf.DV2.uvalue
+                                                           (prod store_id
+                                                              (prod
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                    InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                     (fun
+                                                        (_ : forall _ : Empty_set,
+                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                        (_ : LLVMExcE DVCInfFin.DV2.uvalue Empty_set) =>
+                                                      @raiseLLVM (L3 DV1.dvalue DV1.uvalue) DVCFinInf.DV2.uvalue
                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                        (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (LLVMExcE InfLP.Events.DV.uvalue))))))
-                                                        (fin_to_inf_uvalue H11))
-                                                     X0 H9 k0 H6)
-                                                  X0 H10)
-                                                 H8 H7)
+                                                           (prod store_id
+                                                              (prod
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                    InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                        (@LLVMExcE_L3 DV1.dvalue DV1.uvalue) (fin_to_inf_uvalue H9))
+                                                     X0 H7 k0 H4)
+                                                  X0 H8)
+                                                 H6 H5)
                                                 x3
                                           end in
-                                        X1 (@eq_refl Type X0)) H5) x2
+                                        X3 (@eq_refl Type X0)) H3) x2
                                   | @inr1 _ _ _ x2 =>
-                                      (fun H5 : sum1 UBE (sum1 DebugE FailureE) X0 =>
-                                       (fun H6 : sum1 UBE (sum1 DebugE FailureE) X0 =>
-                                        let X1 :
-                                          itree InfLP.Events.L3
+                                      (fun H3 : sum1 UBE (sum1 DebugE FailureE) X0 =>
+                                       (fun H4 : sum1 UBE (sum1 DebugE FailureE) X0 =>
+                                        let X3 :
+                                          itree (L3 DV1.dvalue DV1.uvalue)
                                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                               (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                               (prod store_id
+                                                  (prod
+                                                     (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                           match
-                                            H6
+                                            H4
                                             return
-                                              (itree InfLP.Events.L3
+                                              (itree (L3 DV1.dvalue DV1.uvalue)
                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                    (prod store_id
+                                                       (prod
+                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           with
                                           | @inl1 _ _ _ x3 =>
-                                              (fun H7 : UBE X0 =>
-                                               (fun H8 : UBE X0 =>
-                                                let X1 :
+                                              (fun H5 : UBE X0 =>
+                                               (fun H6 : UBE X0 =>
+                                                let X3 :
                                                   (fun T : Type =>
                                                    forall _ : @eq Type T X0,
-                                                   itree InfLP.Events.L3
+                                                   itree (L3 DV1.dvalue DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                     X0 :=
                                                   match
-                                                    H8 in (UBE T)
+                                                    H6 in (UBE T)
                                                     return
                                                       (forall _ : @eq Type T X0,
-                                                       itree InfLP.Events.L3
+                                                       itree (L3 DV1.dvalue DV1.uvalue)
                                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                            (prod store_id
+                                                               (prod
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                     InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                     InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   with
                                                   | @ThrowUB x4 =>
-                                                      (fun (H9 : unit) (H10 : @eq Type Empty_set X0) =>
-                                                       (fun H11 : @eq Type Empty_set X0 =>
-                                                        let H12 : @eq Type Empty_set X0 := H11 in
+                                                      (fun (H7 : unit) (H8 : @eq Type Empty_set X0) =>
+                                                       (fun H9 : @eq Type Empty_set X0 =>
+                                                        let H10 : @eq Type Empty_set X0 := H9 in
                                                         @eq_rect Type Empty_set
                                                           (fun _ : Type =>
                                                            forall _ : unit,
-                                                           itree InfLP.Events.L3
+                                                           itree (L3 DV1.dvalue DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           (fun _ : unit =>
                                                            @eq_rect Type Empty_set
-                                                             (fun X1 : Type =>
-                                                              forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : UBE X1),
-                                                              itree InfLP.Events.L3
+                                                             (fun X3 : Type =>
+                                                              forall
+                                                                (_ : forall _ : X3,
+                                                                     itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : UBE X3),
+                                                              itree (L3 DV1.dvalue DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                             (fun (_ : forall _ : Empty_set, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : UBE Empty_set) =>
-                                                              @raiseUB InfLP.Events.L3
-                                                                (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                                   (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                                      (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                         (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                            (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 UBE UBE (sum1 DebugE FailureE) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun UBE))))))
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                             (fun
+                                                                (_ : forall _ : Empty_set,
+                                                                     itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : UBE Empty_set) =>
+                                                              @raiseUB (L3 DV1.dvalue DV1.uvalue) (@UBE_L3 DV1.dvalue DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue))))
                                                                 EmptyString)
-                                                             X0 H11 k0 H8)
-                                                          X0 H12)
-                                                         H10 H9)
+                                                             X0 H9 k0 H6)
+                                                          X0 H10)
+                                                         H8 H7)
                                                         x4
                                                   end in
-                                                X1 (@eq_refl Type X0)) H7) x3
+                                                X3 (@eq_refl Type X0)) H5) x3
                                           | @inr1 _ _ _ x3 =>
-                                              (fun H7 : sum1 DebugE FailureE X0 =>
-                                               (fun H8 : sum1 DebugE FailureE X0 =>
-                                                let X1 :
-                                                  itree InfLP.Events.L3
+                                              (fun H5 : sum1 DebugE FailureE X0 =>
+                                               (fun H6 : sum1 DebugE FailureE X0 =>
+                                                let X3 :
+                                                  itree (L3 DV1.dvalue DV1.uvalue)
                                                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                       (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                                       (prod store_id
+                                                          (prod
+                                                             (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                                   match
-                                                    H8
+                                                    H6
                                                     return
-                                                      (itree InfLP.Events.L3
+                                                      (itree (L3 DV1.dvalue DV1.uvalue)
                                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                            (prod store_id
+                                                               (prod
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                     InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                     InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   with
                                                   | @inl1 _ _ _ x4 =>
-                                                      (fun H9 : DebugE X0 =>
-                                                       (fun H10 : DebugE X0 =>
-                                                        let X1 :
+                                                      (fun H7 : DebugE X0 =>
+                                                       (fun H8 : DebugE X0 =>
+                                                        let X3 :
                                                           (fun T : Type =>
                                                            forall _ : @eq Type T X0,
-                                                           itree InfLP.Events.L3
+                                                           itree (L3 DV1.dvalue DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                             X0 :=
                                                           match
-                                                            H10 in (DebugE T)
+                                                            H8 in (DebugE T)
                                                             return
                                                               (forall _ : @eq Type T X0,
-                                                               itree InfLP.Events.L3
+                                                               itree (L3 DV1.dvalue DV1.uvalue)
                                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                    (prod store_id
+                                                                       (prod
+                                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                             InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           with
                                                           | @Debug x5 =>
-                                                              (fun (H11 : unit) (H12 : @eq Type unit X0) =>
-                                                               (fun H13 : @eq Type unit X0 =>
-                                                                let H14 : @eq Type unit X0 := H13 in
+                                                              (fun (H9 : unit) (H10 : @eq Type unit X0) =>
+                                                               (fun H11 : @eq Type unit X0 =>
+                                                                let H12 : @eq Type unit X0 := H11 in
                                                                 @eq_rect Type unit
                                                                   (fun _ : Type =>
                                                                    forall _ : unit,
-                                                                   itree InfLP.Events.L3
+                                                                   itree (L3 DV1.dvalue DV1.uvalue)
                                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                                  (fun H15 : unit =>
+                                                                        (prod store_id
+                                                                           (prod
+                                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                 InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                                  (fun H13 : unit =>
                                                                    @eq_rect Type unit
-                                                                     (fun X1 : Type =>
-                                                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : DebugE X1),
-                                                                      itree InfLP.Events.L3
+                                                                     (fun X3 : Type =>
+                                                                      forall
+                                                                        (_ : forall _ : X3,
+                                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                        (_ : DebugE X3),
+                                                                      itree (L3 DV1.dvalue DV1.uvalue)
                                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                                     (fun (k1 : forall _ : unit, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : DebugE unit) =>
-                                                                      @go InfLP.Events.L3
+                                                                           (prod store_id
+                                                                              (prod
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                    InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                                     (fun
+                                                                        (k1 : forall _ : unit,
+                                                                              itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                                (prod FinMem.MMEP.MMSP.MemState
+                                                                                   (prod store_id
+                                                                                      (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                        (_ : DebugE unit) =>
+                                                                      @go (L3 DV1.dvalue DV1.uvalue)
                                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                        (@VisF InfLP.Events.L3
+                                                                           (prod store_id
+                                                                              (prod
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                    InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                        (@VisF (L3 DV1.dvalue DV1.uvalue)
                                                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                           (itree InfLP.Events.L3
+                                                                              (prod store_id
+                                                                                 (prod
+                                                                                    (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                       InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                       InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                           (itree (L3 DV1.dvalue DV1.uvalue)
                                                                               (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                                 (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                                 (prod store_id
+                                                                                    (prod
+                                                                                       (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                          InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                          InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                                            unit
-                                                                           (@subevent DebugE InfLP.Events.L3
-                                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                                                 (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                                                    (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                                       (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                                          (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 DebugE FailureE) UBE
-                                                                                             (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 DebugE DebugE FailureE (@ReSum_id (forall _ : Type, Type) IFun Id_IFun DebugE)))))))
-                                                                              unit (Debug H15))
-                                                                           (fun H16 : unit => get_inf_tree (k1 H16))))
-                                                                     X0 H13 k0 H10)
-                                                                  X0 H14)
-                                                                 H12 H11)
+                                                                           (@subevent DebugE (L3 DV1.dvalue DV1.uvalue) (@DebugE_L3 DV1.dvalue DV1.uvalue)
+                                                                              unit (Debug H13))
+                                                                           (fun H14 : unit => get_inf_tree (k1 H14))))
+                                                                     X0 H11 k0 H8)
+                                                                  X0 H12)
+                                                                 H10 H9)
                                                                 x5
                                                           end in
-                                                        X1 (@eq_refl Type X0)) H9) x4
+                                                        X3 (@eq_refl Type X0)) H7) x4
                                                   | @inr1 _ _ _ x4 =>
-                                                      (fun H9 : FailureE X0 =>
-                                                       (fun H10 : FailureE X0 =>
-                                                        let X1 :
+                                                      (fun H7 : FailureE X0 =>
+                                                       (fun H8 : FailureE X0 =>
+                                                        let X3 :
                                                           (fun T : Type =>
                                                            forall _ : @eq Type T X0,
-                                                           itree InfLP.Events.L3
+                                                           itree (L3 DV1.dvalue DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                             X0 :=
                                                           match
-                                                            H10 in (FailureE T)
+                                                            H8 in (FailureE T)
                                                             return
                                                               (forall _ : @eq Type T X0,
-                                                               itree InfLP.Events.L3
+                                                               itree (L3 DV1.dvalue DV1.uvalue)
                                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                    (prod store_id
+                                                                       (prod
+                                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                             InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           with
                                                           | @Throw x5 =>
-                                                              (fun (H11 : unit) (H12 : @eq Type Empty_set X0) =>
-                                                               (fun H13 : @eq Type Empty_set X0 =>
-                                                                let H14 : @eq Type Empty_set X0 := H13 in
+                                                              (fun (H9 : unit) (H10 : @eq Type Empty_set X0) =>
+                                                               (fun H11 : @eq Type Empty_set X0 =>
+                                                                let H12 : @eq Type Empty_set X0 := H11 in
                                                                 @eq_rect Type Empty_set
                                                                   (fun _ : Type =>
                                                                    forall _ : unit,
-                                                                   itree InfLP.Events.L3
+                                                                   itree (L3 DV1.dvalue DV1.uvalue)
                                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                        (prod store_id
+                                                                           (prod
+                                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                 InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                                   (fun _ : unit =>
                                                                    @eq_rect Type Empty_set
-                                                                     (fun X1 : Type =>
-                                                                      forall (_ : forall _ : X1, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : FailureE X1),
-                                                                      itree InfLP.Events.L3
+                                                                     (fun X3 : Type =>
+                                                                      forall
+                                                                        (_ : forall _ : X3,
+                                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                        (_ : FailureE X3),
+                                                                      itree (L3 DV1.dvalue DV1.uvalue)
                                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                                     (fun (_ : forall _ : Empty_set, itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : FailureE Empty_set) =>
-                                                                      @LLVMEvents.raise InfLP.Events.L3
+                                                                           (prod store_id
+                                                                              (prod
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                    InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                                     (fun
+                                                                        (_ : forall _ : Empty_set,
+                                                                             itree (L3 DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+                                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                        (_ : FailureE Empty_set) =>
+                                                                      @LLVMEvents.raise (L3 DV1.dvalue DV1.uvalue)
                                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                        (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 InfLP.Events.PickUvalueE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) InfLP.Events.ExternalCallE
-                                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.PickUvalueE
-                                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                                 (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                                    (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 DebugE FailureE) UBE
-                                                                                       (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE FailureE DebugE (@ReSum_id (forall _ : Type, Type) IFun Id_IFun FailureE)))))))
-                                                                        EmptyString)
-                                                                     X0 H13 k0 H10)
-                                                                  X0 H14)
-                                                                 H12 H11)
+                                                                           (prod store_id
+                                                                              (prod
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                    InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                        (@FailureE_L3 DV1.dvalue DV1.uvalue) EmptyString)
+                                                                     X0 H11 k0 H8)
+                                                                  X0 H12)
+                                                                 H10 H9)
                                                                 x5
                                                           end in
-                                                        X1 (@eq_refl Type X0)) H9) x4
+                                                        X3 (@eq_refl Type X0)) H7) x4
                                                   end in
-                                                X1) H7) x3
+                                                X3) H5) x3
                                           end in
-                                        X1) H5) x2
+                                        X3) H3) x2
                                   end in
-                                X1) H3) x1
+                                X3) H1) x1
                           end in
-                        X1) H1) x0
+                        X3) H) x0
                   end in
-                X1) H) x
+                X3) X1) x
           end in
         X1) X e k
    end.
 
+(* COPED TO Utils/ITreeExtra.v ---------------------- *)
   (* TODO: Move this, possibly to itrees library? *)
   Lemma paco2_eqit_RR_refl : forall E R RR `{REFL: Reflexive _ RR} r (t : itree E R), paco2 (eqit_ RR true true id) r t t.
   Proof.
@@ -4752,7 +5119,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
     intros x.
     apply paco2_eqit_b1b2_RR_refl; eauto.
   Qed.
-
+(* COPED TO Utils/ITreeExtra.v ---------------------- *)
+  
   Import Stdlib.Classes.RelationClasses.
 
   Lemma get_inf_tree_equation :
@@ -5872,8 +6240,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
         pstep; red; cbn.
 
         change (inr1 (inr1 (inl1 (ThrowOOM u)))) with (@subevent _ _ (ReSum_inr IFun sum1 OOME
-                                                                        (PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
-                                                                        ExternalCallE) _ (ThrowOOM u)).
+                                                                        (@PickUvalueE DVC1.DV2.dvalue DVC1.DV2.uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                                                                        (@ExternalCallE DVC1.DV2.dvalue DVC1.DV2.uvalue)) _ (ThrowOOM u)).
 
         apply EqVisOOM.
       }
@@ -6266,7 +6634,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                    inr
                      (LLVMParams64BitIntptr.ITOP.int_to_ptr
                         (LLVMParams64BitIntptr.PTOI.ptr_to_int a +
-                           Z.of_N (LLVMParams64BitIntptr.SIZEOF.sizeof_dtyp (DTYPE_I 8)) *
+                           Z.of_N (LLVMParams64BitIntptr.SZ.sizeof_dtyp (DTYPE_I 8)) *
                              LLVMParams64BitIntptr.IP.to_Z ix)
                         (LLVMParams64BitIntptr.PROV.address_provenance a))) l) eqn:HMAPM; cbn in *; try contradiction.
 
@@ -6278,7 +6646,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                    @inr string (OOM LLVMParamsBigIntptr.ADDR.addr)
                      (@NoOom (Z * Prov)
                         ((LLVMParamsBigIntptr.PTOI.ptr_to_int a' +
-                            Z.of_N (LLVMParamsBigIntptr.SIZEOF.sizeof_dtyp (DTYPE_I 8)) *
+                            Z.of_N (LLVMParamsBigIntptr.SZ.sizeof_dtyp (DTYPE_I 8)) *
                               LLVMParamsBigIntptr.IP.to_Z ix)%Z, LLVMParamsBigIntptr.PROV.address_provenance a')))
                 lb) eqn:HMAPM'.
     { (* Should be a contradiction *)
@@ -6384,8 +6752,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
         }
         rewrite <- X''Y''.
 
-        rewrite LLVMParamsBigIntptr.SIZEOF.sizeof_dtyp_i8.
-        rewrite LLVMParams64BitIntptr.SIZEOF.sizeof_dtyp_i8 in H2.
+        rewrite LLVMParamsBigIntptr.SZ.sizeof_dtyp_i8.
+        rewrite LLVMParams64BitIntptr.SZ.sizeof_dtyp_i8 in H2.
 
         pose proof ADDRS.
         inversion H1; subst.
@@ -6422,7 +6790,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           }
 
           replace (LLVMParams64BitIntptr.PTOI.ptr_to_int a +
-                     Z.of_N (LLVMParams64BitIntptr.SIZEOF.sizeof_dtyp (DTYPE_I 8)) * 0)%Z with (LLVMParams64BitIntptr.PTOI.ptr_to_int a) in H6 by lia.
+                     Z.of_N (LLVMParams64BitIntptr.SZ.sizeof_dtyp (DTYPE_I 8)) * 0)%Z with (LLVMParams64BitIntptr.PTOI.ptr_to_int a) in H6 by lia.
 
           pose proof LLVMParams64BitIntptr.ITOP.int_to_ptr_ptr_to_int a (LLVMParams64BitIntptr.PROV.address_provenance a) eq_refl.
           rewrite H6 in H5.
@@ -6538,7 +6906,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
          @inr string (OOM LLVMParamsBigIntptr.ADDR.addr)
            (@NoOom (Z * Prov)
               ((LLVMParamsBigIntptr.PTOI.ptr_to_int a_inf +
-                  Z.of_N (LLVMParamsBigIntptr.SIZEOF.sizeof_dtyp (DTYPE_I 8)) *
+                  Z.of_N (LLVMParamsBigIntptr.SZ.sizeof_dtyp (DTYPE_I 8)) *
                     LLVMParamsBigIntptr.IP.to_Z ix)%Z, LLVMParamsBigIntptr.PROV.address_provenance a_inf)))
       ips as ADDRS_INF.
     forward ADDRS_INF.
@@ -6619,7 +6987,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                          inr
                            (LLVMParams64BitIntptr.ITOP.int_to_ptr
                               (LLVMParams64BitIntptr.PTOI.ptr_to_int a_fin +
-                                 Z.of_N (LLVMParams64BitIntptr.SIZEOF.sizeof_dtyp (DTYPE_I 8)) *
+                                 Z.of_N (LLVMParams64BitIntptr.SZ.sizeof_dtyp (DTYPE_I 8)) *
                                    LLVMParams64BitIntptr.IP.to_Z ix)
                               (LLVMParams64BitIntptr.PROV.address_provenance a_fin))) l) eqn:HMAPM; cbn in GCP; try contradiction.
           destruct GCP; subst.
@@ -6802,7 +7170,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                          inr
                            (LLVMParams64BitIntptr.ITOP.int_to_ptr
                               (LLVMParams64BitIntptr.PTOI.ptr_to_int a_fin +
-                                 Z.of_N (LLVMParams64BitIntptr.SIZEOF.sizeof_dtyp (DTYPE_I 8)) *
+                                 Z.of_N (LLVMParams64BitIntptr.SZ.sizeof_dtyp (DTYPE_I 8)) *
                                    LLVMParams64BitIntptr.IP.to_Z ix)
                               (LLVMParams64BitIntptr.PROV.address_provenance a_fin))) l) eqn:HMAPM; cbn in GCP; try contradiction.
           destruct GCP; subst.
@@ -6838,7 +7206,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       rewrite IP in GEP.
 
       replace (LLVMParamsBigIntptr.PTOI.ptr_to_int a_inf +
-                 Z.of_N (LLVMParamsBigIntptr.SIZEOF.sizeof_dtyp (DTYPE_I 8)) * Z.of_nat i)%Z with (PTOI.ptr_to_int ptr_fin).
+                 Z.of_N (LLVMParamsBigIntptr.SZ.sizeof_dtyp (DTYPE_I 8)) * Z.of_nat i)%Z with (PTOI.ptr_to_int ptr_fin).
       2: {
         rewrite GEP.
         erewrite fin_inf_ptoi; eauto.
@@ -12684,8 +13052,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
   Lemma fin_inf_sbyte_to_extractbyte :
     forall byte uv dt idx sid,
-      FinMem.MP.BYTE_IMPL.sbyte_to_extractbyte byte = LLVMParams64BitIntptr.Events.DV.UVALUE_ExtractByte uv dt idx sid ->
-      InfMem.MP.BYTE_IMPL.sbyte_to_extractbyte (lift_SByte byte) = LLVMParamsBigIntptr.Events.DV.UVALUE_ExtractByte (fin_to_inf_uvalue uv) dt idx sid.
+      FinMem.MP.BYTE_IMPL.sbyte_to_extractbyte byte = LLVMParams64BitIntptr.DV.UVALUE_ExtractByte uv dt idx sid ->
+      InfMem.MP.BYTE_IMPL.sbyte_to_extractbyte (lift_SByte byte) = LLVMParamsBigIntptr.DV.UVALUE_ExtractByte (fin_to_inf_uvalue uv) dt idx sid.
   Proof.
     intros byte uv dt idx sid H.
     unfold FinMem.MP.BYTE_IMPL.sbyte_to_extractbyte in H.
@@ -12994,7 +13362,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       MemoryBigIntptr.MMEP.MemSpec.MemHelpers.generate_num_undef_bytes_h start_ix (N.succ sz) t sid = NoOom bytes_inf ->
       exists byte bytes_inf',
         MemoryBigIntptr.MMEP.MemSpec.MemHelpers.generate_num_undef_bytes_h (N.succ start_ix) sz t sid = NoOom bytes_inf' /\
-          (MemoryBigIntptr.Byte.uvalue_sbyte (LLVMParamsBigIntptr.Events.DV.UVALUE_Undef t) t
+          (MemoryBigIntptr.Byte.uvalue_sbyte (LLVMParamsBigIntptr.DV.UVALUE_Undef t) t
              start_ix sid) = byte /\
           bytes_inf = byte :: bytes_inf'.
   Proof.
@@ -13009,7 +13377,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       pose proof @N.recursion_succ (N -> OOM (list InfMem.MP.BYTE_IMPL.SByte)) eq (fun _ : N => ret [])
         (fun (_ : N) (mf : N -> OOM (list InfMem.MP.BYTE_IMPL.SByte)) (x : N) =>
            rest_bytes <- mf (N.succ x);;
-           ret (MemoryBigIntptr.Byte.uvalue_sbyte (LLVMParamsBigIntptr.Events.DV.UVALUE_Undef t) t
+           ret (MemoryBigIntptr.Byte.uvalue_sbyte (LLVMParamsBigIntptr.DV.UVALUE_Undef t) t
                   x sid :: rest_bytes))
         eq_refl.
       forward H.
@@ -13056,7 +13424,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       cbn in *.
 
       specialize (IHsz _ t sid bytes_fin' GEN') as (bytes_inf&GEN_INF&BYTES_REF).
-      exists (MemoryBigIntptr.Byte.uvalue_sbyte (LLVMParamsBigIntptr.Events.DV.UVALUE_Undef t) t start_ix sid :: bytes_inf).
+      exists (MemoryBigIntptr.Byte.uvalue_sbyte (LLVMParamsBigIntptr.DV.UVALUE_Undef t) t start_ix sid :: bytes_inf).
       split.
       + setoid_rewrite MemoryBigIntptrInfiniteSpecHelpers.generate_num_undef_bytes_h_cons.
         cbn.
@@ -14876,11 +15244,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
     forall {t num_elements align ms_fin_start ms_fin_final ms_inf_start d},
       MemState_refine_prop ms_inf_start ms_fin_start ->
       Memory64BitIntptr.MMEP.MemSpec.handle_memory_prop
-        LLVMParams64BitIntptr.Events.DV.dvalue
-        (LLVMParams64BitIntptr.Events.Alloca t num_elements align) ms_fin_start (ret (ms_fin_final, d)) ->
+        LLVMParams64BitIntptr.DV.dvalue
+        (Alloca t num_elements align) ms_fin_start (ret (ms_fin_final, d)) ->
       exists d_inf ms_inf_final,
         MemoryBigIntptr.MMEP.MemSpec.handle_memory_prop DVCInfFin.DV1.dvalue
-          (InterpreterStackBigIntptr.LP.Events.Alloca t num_elements align) ms_inf_start
+          (Alloca t num_elements align) ms_inf_start
           (ret (ms_inf_final, d_inf)) /\
           DVC1.dvalue_refine_strict d_inf d /\
           MemState_refine_prop ms_inf_final ms_fin_final.
@@ -15672,7 +16040,6 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       split; cbn; eauto.
   Qed.
 
-  (* SAZ: Look at this one too *)
   Lemma extend_heap_fin_inf :
     forall {ms_inf_start ms_fin_start ms_inf_final ms_fin_final addrs_fin addrs_inf},
       MemState_refine_prop ms_inf_start ms_fin_start ->
@@ -16702,11 +17069,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       (ARGS: Forall2 DVCInfFin.dvalue_refine_strict args0 args),
       MemState_refine_prop ms_inf ms_fin ->
       Memory64BitIntptr.MMEP.MemSpec.handle_intrinsic_prop
-        (LLVMParams64BitIntptr.Events.DV.uvalue + LLVMParams64BitIntptr.Events.DV.dvalue)
-        (LLVMParams64BitIntptr.Events.Intrinsic t f args) ms_fin (ret (ms_fin', d_fin)) ->
+        (LLVMParams64BitIntptr.DV.uvalue + LLVMParams64BitIntptr.DV.dvalue)
+        (Intrinsic t f args) ms_fin (ret (ms_fin', d_fin)) ->
       exists d_inf ms_inf',
         MemoryBigIntptr.MMEP.MemSpec.handle_intrinsic_prop (DVCInfFin.DV1.uvalue + DVCInfFin.DV1.dvalue)
-          (InterpreterStackBigIntptr.LP.Events.Intrinsic t f args0) ms_inf
+          (Intrinsic t f args0) ms_inf
           (ret (ms_inf', d_inf)) /\
           sum_rel DVC1.uvalue_refine_strict DVC1.dvalue_refine_strict d_inf d_fin /\
           MemState_refine_prop ms_inf' ms_fin'.
@@ -16731,7 +17098,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       destruct EQV; subst.
 
       cbn.
-      exists (inr LLVMParamsBigIntptr.Events.DV.DVALUE_None).
+      exists (inr LLVMParamsBigIntptr.DV.DVALUE_None).
       exists ms_inf0.
       split; auto.
       split; auto.
@@ -16880,8 +17247,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
     unfold MemoryBigIntptr.MMEP.MMSP.MemByte.to_ubytes,
       Memory64BitIntptr.MMEP.MMSP.MemByte.to_ubytes in *.
 
-    unfold LLVMParams64BitIntptr.SIZEOF.sizeof_dtyp,
-      LLVMParamsBigIntptr.SIZEOF.sizeof_dtyp in *.
+    unfold LLVMParams64BitIntptr.SZ.sizeof_dtyp,
+      LLVMParamsBigIntptr.SZ.sizeof_dtyp in *.
 
     eapply to_ubytes_fin_inf_helper; eauto.
   Qed.
@@ -16897,8 +17264,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       Memory64BitIntptr.MMEP.MMSP.MemByte.to_ubytes in *.
 
     red.
-    unfold LLVMParams64BitIntptr.SIZEOF.sizeof_dtyp,
-      LLVMParamsBigIntptr.SIZEOF.sizeof_dtyp in *.
+    unfold LLVMParams64BitIntptr.SZ.sizeof_dtyp,
+      LLVMParamsBigIntptr.SZ.sizeof_dtyp in *.
 
     remember (Nseq 0 (N.to_nat (FiniteSizeof.FinSizeof.sizeof_dtyp t))) as l.
     clear Heql.
@@ -18854,10 +19221,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       DVC1.dvalue_refine_strict addr_inf addr_fin ->
       DVC1.uvalue_refine_strict uv_inf uv_fin ->
       Memory64BitIntptr.MMEP.MemSpec.handle_memory_prop unit
-        (LLVMParams64BitIntptr.Events.Store t addr_fin uv_fin) ms_fin_start (ret (ms_fin_final, res_fin)) ->
+        (Store t addr_fin uv_fin) ms_fin_start (ret (ms_fin_final, res_fin)) ->
       exists res_inf ms_inf_final,
         MemoryBigIntptr.MMEP.MemSpec.handle_memory_prop unit
-          (LLVMParamsBigIntptr.Events.Store t addr_inf uv_inf) ms_inf_start (ret (ms_inf_final, res_inf)) /\
+          (Store t addr_inf uv_inf) ms_inf_start (ret (ms_inf_final, res_inf)) /\
           res_inf = res_fin /\
           MemState_refine_prop ms_inf_final ms_fin_final.
   Proof.
@@ -18916,9 +19283,9 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       DVC1.dvalue_refine_strict addr_inf addr_fin ->
       DVC1.uvalue_refine_strict uv_inf uv_fin ->
       Memory64BitIntptr.MMEP.MemSpec.handle_memory_prop unit
-        (LLVMParams64BitIntptr.Events.Store t addr_fin uv_fin) ms_fin_start (raise_ub msg) ->
+        (Store t addr_fin uv_fin) ms_fin_start (raise_ub msg) ->
       MemoryBigIntptr.MMEP.MemSpec.handle_memory_prop unit
-        (LLVMParamsBigIntptr.Events.Store t addr_inf uv_inf) ms_inf_start (raise_ub msg).
+        (Store t addr_inf uv_inf) ms_inf_start (raise_ub msg).
   Proof.
     intros t addr_fin addr_inf uv_fin uv_inf ms_fin_start ms_inf_start msg MSR ADDR_REF VALUE_REF HANDLE.
 
@@ -18974,9 +19341,9 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   (* TODO: Move this *)
   Lemma all_bytes_from_uvalue_helper_has_dtyp :
     forall {bytes idx sid parent t uv},
-      E1.DV.uvalue_has_dtyp parent t ->
+      DV1.uvalue_has_dtyp parent t ->
       MemoryBigIntptr.MMEP.MMSP.MemByte.all_bytes_from_uvalue_helper idx sid parent bytes = Some uv ->
-      E1.DV.uvalue_has_dtyp uv t.
+      DV1.uvalue_has_dtyp uv t.
   Proof.
     induction bytes; intros idx sid parent t uv TYP ALL.
     - cbn in *.
@@ -18994,7 +19361,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   Lemma all_bytes_from_uvalue_has_dtyp :
     forall {bytes t uv},
       MemoryBigIntptr.MMEP.MMSP.MemByte.all_bytes_from_uvalue t bytes = Some uv ->
-      E1.DV.uvalue_has_dtyp uv t.
+      DV1.uvalue_has_dtyp uv t.
   Proof.
     intros bytes t uv ALL.
     unfold MemoryBigIntptr.MMEP.MMSP.MemByte.all_bytes_from_uvalue in ALL.
@@ -19009,7 +19376,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
     eapply all_bytes_from_uvalue_helper_has_dtyp; eauto.
     destruct (dtyp_eqb t dt) eqn:HDTYP;
       cbn in Heqo; inv Heqo.
-    destruct (Rocqlib.proj_sumbool LLVMParamsBigIntptr.Events.DV.uvalue_has_dtyp_dec) eqn:HUVT;
+    destruct (Rocqlib.proj_sumbool LLVMParamsBigIntptr.DV.uvalue_has_dtyp_dec) eqn:HUVT;
       cbn in Heqo0; inv Heqo0.
     unfold Rocqlib.proj_sumbool in HUVT.
     break_match_hyp_inv.
@@ -19021,8 +19388,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   Lemma from_ubytes_dtyp :
     forall {bytes t uv},
       MemoryBigIntptr.MMEP.MMSP.MemByte.from_ubytes bytes t = uv ->
-      N.of_nat (Datatypes.length bytes) = LLVMParamsBigIntptr.SIZEOF.sizeof_dtyp t ->
-      E1.DV.uvalue_has_dtyp uv t.
+      N.of_nat (Datatypes.length bytes) = LLVMParamsBigIntptr.SZ.sizeof_dtyp t ->
+      DV1.uvalue_has_dtyp uv t.
   Proof.
     intros bytes t uv UBYTES SIZE.
     unfold MemoryBigIntptr.MMEP.MMSP.MemByte.from_ubytes in *.
@@ -19141,7 +19508,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
     exists uv.
     split; eauto.
 
-    destruct (Rocqlib.proj_sumbool LLVMParamsBigIntptr.Events.DV.uvalue_has_dtyp_dec) eqn:HUVT;
+    destruct (Rocqlib.proj_sumbool LLVMParamsBigIntptr.DV.uvalue_has_dtyp_dec) eqn:HUVT;
       cbn in Heqo0; inv Heqo0;
       unfold Rocqlib.proj_sumbool in HUVT;
       break_match_hyp_inv.
@@ -19365,6 +19732,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
     - destruct amount; cbn; auto.
   Qed.
 
+(* COPIED TO: Utils/ListUtils.v -------------------- *)
   (* TODO: Move this to listutils or something *)
   Lemma Forall2_between :
     forall {X Y} (xs : list X) (ys : list Y) P start finish,
@@ -19433,7 +19801,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
     pose proof drop_length xs start as DROP.
     forward DROP; lia.
   Qed.
-
+  (* COPIED TO: Utils/ListUtils.v -------------------- *)
+  
   Lemma monad_fold_right_deserialize_sbytes_fin_inf :
     forall {t : dtyp} {bytes_fin bytes_inf}
       (start seq_len : N)
@@ -19441,23 +19810,23 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       (IHt :
         forall (bytes_fin : list Memory64BitIntptr.MP.BYTE_IMPL.SByte)
           (bytes_inf : list MemoryBigIntptr.MP.BYTE_IMPL.SByte)
-          (res_fin : LLVMParams64BitIntptr.Events.DV.uvalue),
+          (res_fin : LLVMParams64BitIntptr.DV.uvalue),
           sbytes_refine bytes_inf bytes_fin ->
           Memory64BitIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes bytes_fin t = inr res_fin ->
-          exists res_inf : LLVMParamsBigIntptr.Events.DV.uvalue,
+          exists res_inf : LLVMParamsBigIntptr.DV.uvalue,
             MemoryBigIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes bytes_inf t = inr res_inf /\
               DVC1.uvalue_refine_strict res_inf res_fin)
-      (uv_fins : list LLVMParams64BitIntptr.Events.DV.uvalue),
+      (uv_fins : list LLVMParams64BitIntptr.DV.uvalue),
       monad_fold_right
-        (fun (acc : list LLVMParams64BitIntptr.Events.DV.uvalue) (idx : N) =>
+        (fun (acc : list LLVMParams64BitIntptr.DV.uvalue) (idx : N) =>
            uv <-
              Memory64BitIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes
                (between (idx * FiniteSizeof.FinSizeof.sizeof_dtyp t)
                   ((idx + 1) * FiniteSizeof.FinSizeof.sizeof_dtyp t) bytes_fin) t;;
            @ret err _ _ (uv :: acc)) (Nseq start (N.to_nat seq_len)) [] = inr uv_fins ->
-      exists (uv_infs : list LLVMParamsBigIntptr.Events.DV.uvalue),
+      exists (uv_infs : list LLVMParamsBigIntptr.DV.uvalue),
         (monad_fold_right
-           (fun (acc : list LLVMParamsBigIntptr.Events.DV.uvalue) (idx : N) =>
+           (fun (acc : list LLVMParamsBigIntptr.DV.uvalue) (idx : N) =>
               uv <-
                 MemoryBigIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes
                   (between (idx * FiniteSizeof.FinSizeof.sizeof_dtyp t)
@@ -19482,7 +19851,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       rewrite <- cons_Nseq in HFOLDR.
       destruct
         (monad_fold_right
-           (fun (acc : list LLVMParams64BitIntptr.Events.DV.uvalue) (idx : N) =>
+           (fun (acc : list LLVMParams64BitIntptr.DV.uvalue) (idx : N) =>
               uv <-
                 Memory64BitIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes
                   (between (idx * FiniteSizeof.FinSizeof.sizeof_dtyp t) ((idx + 1) * FiniteSizeof.FinSizeof.sizeof_dtyp t) bytes_fin) t;;
@@ -19540,14 +19909,14 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           Memory64BitIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes bytes_fin t = inl s ->
           MemoryBigIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes bytes_inf t = inl s),
       monad_fold_right
-        (fun (acc : list LLVMParams64BitIntptr.Events.DV.uvalue) (idx : N) =>
+        (fun (acc : list LLVMParams64BitIntptr.DV.uvalue) (idx : N) =>
            uv <-
              Memory64BitIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes
                (between (idx * FiniteSizeof.FinSizeof.sizeof_dtyp t)
                   ((idx + 1) * FiniteSizeof.FinSizeof.sizeof_dtyp t) bytes_fin) t;;
            @ret err _ _ (uv :: acc)) (Nseq start (N.to_nat seq_len)) [] = inl s ->
       (monad_fold_right
-         (fun (acc : list LLVMParamsBigIntptr.Events.DV.uvalue) (idx : N) =>
+         (fun (acc : list LLVMParamsBigIntptr.DV.uvalue) (idx : N) =>
             uv <-
               MemoryBigIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes
                 (between (idx * FiniteSizeof.FinSizeof.sizeof_dtyp t)
@@ -19567,7 +19936,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       rewrite <- cons_Nseq.
       rewrite monad_fold_right_equation.
       destruct (monad_fold_right
-                  (fun (acc : list LLVMParams64BitIntptr.Events.DV.uvalue) (idx : N) =>
+                  (fun (acc : list LLVMParams64BitIntptr.DV.uvalue) (idx : N) =>
                      uv <-
                        Memory64BitIntptr.MMEP.MemSpec.MemHelpers.deserialize_sbytes
                          (between (idx * FiniteSizeof.FinSizeof.sizeof_dtyp t)
@@ -19647,10 +20016,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       MemState_refine_prop ms_inf_start ms_fin_start ->
       DVC1.dvalue_refine_strict addr_inf addr_fin ->
       Memory64BitIntptr.MMEP.MemSpec.handle_memory_prop _
-        (LLVMParams64BitIntptr.Events.Load t addr_fin) ms_fin_start (ret (ms_fin_final, res_fin)) ->
+        (Load t addr_fin) ms_fin_start (ret (ms_fin_final, res_fin)) ->
       exists res_inf ms_inf_final,
         MemoryBigIntptr.MMEP.MemSpec.handle_memory_prop _
-          (LLVMParamsBigIntptr.Events.Load t addr_inf) ms_inf_start (ret (ms_inf_final, res_inf)) /\
+          (Load t addr_inf) ms_inf_start (ret (ms_inf_final, res_inf)) /\
           DVC1.uvalue_refine_strict res_inf res_fin /\
           MemState_refine_prop ms_inf_final ms_fin_final.
   Proof.
@@ -19721,9 +20090,9 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       MemState_refine_prop ms_inf_start ms_fin_start ->
       DVC1.dvalue_refine_strict addr_inf addr_fin ->
       Memory64BitIntptr.MMEP.MemSpec.handle_memory_prop _
-        (LLVMParams64BitIntptr.Events.Load t addr_fin) ms_fin_start (raise_ub msg) ->
+        (Load t addr_fin) ms_fin_start (raise_ub msg) ->
       MemoryBigIntptr.MMEP.MemSpec.handle_memory_prop _
-        (LLVMParamsBigIntptr.Events.Load t addr_inf) ms_inf_start (raise_ub msg).
+        (Load t addr_inf) ms_inf_start (raise_ub msg).
   Proof.
     intros t addr_fin addr_inf ms_fin_start ms_inf_start msg MSR ADDR_REF HANDLE.
 
@@ -19918,8 +20287,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   (* TODO: Move into memory model. Likely near MEM_EXEC_INTERP.MemTheory.allocate_bytes_spec_MemPropT_no_err *)
   Lemma handle_alloca_no_error :
     forall t num_elements align ms msg,
-      Memory64BitIntptr.MMEP.MemSpec.handle_memory_prop LLVMParams64BitIntptr.Events.DV.dvalue
-        (LLVMParams64BitIntptr.Events.Alloca t num_elements align) ms (raise_error msg) ->
+      Memory64BitIntptr.MMEP.MemSpec.handle_memory_prop LLVMParams64BitIntptr.DV.dvalue
+        (Alloca t num_elements align) ms (raise_error msg) ->
       False.
   Proof.
     intros t num_elements align ms msg HANDLE.
@@ -21245,11 +21614,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       (ARGS: Forall2 DVCInfFin.dvalue_refine_strict args0 args),
       MemState_refine_prop ms_inf ms_fin ->
       Memory64BitIntptr.MMEP.MemSpec.handle_intrinsic_prop
-        (LLVMParams64BitIntptr.Events.DV.uvalue + LLVMParams64BitIntptr.Events.DV.dvalue)
-        (LLVMParams64BitIntptr.Events.Intrinsic t f args) ms_fin (raise_error msg_fin) ->
+        (LLVMParams64BitIntptr.DV.uvalue + LLVMParams64BitIntptr.DV.dvalue)
+        (Intrinsic t f args) ms_fin (raise_error msg_fin) ->
       exists msg_inf,
         MemoryBigIntptr.MMEP.MemSpec.handle_intrinsic_prop (DVCInfFin.DV1.uvalue + DVCInfFin.DV1.dvalue)
-          (InterpreterStackBigIntptr.LP.Events.Intrinsic t f args0) ms_inf
+          (Intrinsic t f args0) ms_inf
           (raise_error msg_inf).
   Proof.
     intros t f args args0 ms_fin ms_inf msg_fin ARGS MSR INTRINSIC.
@@ -22372,7 +22741,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
                       (* Need to figure out how k0 and k5 are related *)
                       (*
-                      REL : forall v : InterpreterStackBigIntptr.LP.Events.DV.dvalue,
+                      REL : forall v : InterpreterStackBigIntptr.LP.DV.dvalue,
                           id (upaco2 (eqit_ eq true true id) bot2) (k0 v) (k3 v)
 
                       REL0 : forall v : dvalue,
@@ -22387,7 +22756,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                           (fun (x : res_L2) '(_, (_, y)) => TLR_FIN.R.refine_res2 x y) true true) bot2
                           (k1 a) (k2 b)
 
-                      K_RUTT : forall (v1 : InterpreterStackBigIntptr.LP.Events.DV.dvalue) (v2 : dvalue),
+                      K_RUTT : forall (v1 : InterpreterStackBigIntptr.LP.DV.dvalue) (v2 : dvalue),
                          t = t /\
                          DVCInfFin.uvalue_refine_strict f0 f /\
                          Forall2 DVCInfFin.dvalue_refine_strict args0 args /\ DVCInfFin.dvalue_refine_strict v1 v2 ->
@@ -22763,11 +23132,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                         x
                                         return
                                         (itree
-                                           (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                                 LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' LLVMExcE LLVMParamsBigIntptr.Events.DV.uvalue +' UBE +' DebugE +' FailureE)
+                                           ((@ExternalCallE LLVMParamsBigIntptr.DV.dvalue LLVMParamsBigIntptr.DV.uvalue) +'
+                                            (@PickUvalueE LLVMParamsBigIntptr.DV.dvalue LLVMParamsBigIntptr.DV.uvalue) +' OOME +' LLVMExcE LLVMParamsBigIntptr.DV.uvalue +' UBE +' DebugE +' FailureE)
                                            (MemoryBigIntptr.MMEP.MMSP.MemState *
-                                              (store_id * (InterpreterStackBigIntptr.LP.Events.DV.uvalue +
-           InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                              (store_id * (InterpreterStackBigIntptr.LP.DV.uvalue +
+           InterpreterStackBigIntptr.LP.DV.dvalue))))
                                       with
                                       end)).
 
@@ -22825,11 +23194,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                         x
                                         return
                                         (itree
-                                           (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                                 LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' LLVMExcE InterpreterStackBigIntptr.LP.Events.DV.uvalue +' UBE +' DebugE +' FailureE)
+                                           ((@ExternalCallE InterpreterStackBigIntptr.LP.DV.dvalue InterpreterStackBigIntptr.LP.DV.uvalue) +'
+                                                                                                 (@PickUvalueE InterpreterStackBigIntptr.LP.DV.dvalue InterpreterStackBigIntptr.LP.DV.uvalue) +' OOME +' LLVMExcE InterpreterStackBigIntptr.LP.DV.uvalue +' UBE +' DebugE +' FailureE)
                                            (MemoryBigIntptr.MMEP.MMSP.MemState *
-                                              (store_id * (InterpreterStackBigIntptr.LP.Events.DV.uvalue +
-           InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                              (store_id * (InterpreterStackBigIntptr.LP.DV.uvalue +
+           InterpreterStackBigIntptr.LP.DV.dvalue))))
                                       with
                                       end)).
 
@@ -22952,11 +23321,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                         x
                                         return
                                         (itree
-                                           (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                                 LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
+                                           ((@ExternalCallE InterpreterStackBigIntptr.LP.DV.dvalue InterpreterStackBigIntptr.LP.DV.uvalue) +'
+                                                                                                 (@PickUvalueE InterpreterStackBigIntptr.LP.DV.dvalue InterpreterStackBigIntptr.LP.DV.uvalue) +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
                                            (MemoryBigIntptr.MMEP.MMSP.MemState *
-                                              (store_id * (InterpreterStackBigIntptr.LP.Events.DV.uvalue +
-           InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                              (store_id * (InterpreterStackBigIntptr.LP.DV.uvalue +
+           InterpreterStackBigIntptr.LP.DV.dvalue))))
                                       with
                                       end)).
 
@@ -23014,12 +23383,12 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                       match
                                         x
                                         return
-                                        (itree
-                                           (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                                 LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
+                                        (itree                                           
+                                           ((@ExternalCallE InterpreterStackBigIntptr.LP.DV.dvalue InterpreterStackBigIntptr.LP.DV.uvalue) +'
+                                                                                                 (@PickUvalueE InterpreterStackBigIntptr.LP.DV.dvalue InterpreterStackBigIntptr.LP.DV.uvalue) +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
                                            (MemoryBigIntptr.MMEP.MMSP.MemState *
-                                              (store_id * (InterpreterStackBigIntptr.LP.Events.DV.uvalue +
-                                                             InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                              (store_id * (InterpreterStackBigIntptr.LP.DV.uvalue +
+           InterpreterStackBigIntptr.LP.DV.dvalue))))
                                       with
                                       end)).
 
@@ -23465,10 +23834,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                                     x
                                                                     return
                                                                     (itree
-                                                                       (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                                                             LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)
-                                                                       (MemoryBigIntptr.MMEP.MMSP.MemState *
-                                                                          (store_id * _)))
+                                           ((@ExternalCallE InterpreterStackBigIntptr.LP.DV.dvalue InterpreterStackBigIntptr.LP.DV.uvalue) +'
+                                                                                                 (@PickUvalueE InterpreterStackBigIntptr.LP.DV.dvalue InterpreterStackBigIntptr.LP.DV.uvalue) +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
+                                           (MemoryBigIntptr.MMEP.MMSP.MemState *
+                                              (store_id * (InterpreterStackBigIntptr.LP.DV.uvalue +
+                                                             InterpreterStackBigIntptr.LP.DV.dvalue))))
                                                                   with
                                                                   end))
                       .
@@ -23658,8 +24028,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     { (* Handler raises OOM *)
                       destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
                       rewrite TA_OOM in VIS_HANDLED.
-                      pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                                 LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
+                      pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                                 (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
                       rewrite RAISE in VIS_HANDLED.
                       destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
                       { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -23802,8 +24172,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                        *)
 
                       rewrite TA in VIS_HANDLED.
-                      pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                                 LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k2 msg) as RAISE.
+                      pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                                 (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k2 msg) as RAISE.
                       rewrite RAISE in VIS_HANDLED.
 
                       destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
@@ -23857,8 +24227,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     { (* Handler raises OOM *)
                       destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
                       rewrite TA_OOM in VIS_HANDLED.
-                      pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                                 LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
+                      pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                                 (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
                       rewrite RAISE in VIS_HANDLED.
                       destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
                       { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -24035,8 +24405,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     { (* Handler raises OOM *)
                       destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
                       rewrite TA_OOM in VIS_HANDLED.
-                      pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                                 LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
+                      pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                                 (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
                       rewrite RAISE in VIS_HANDLED.
                       destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
                       { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -24192,8 +24562,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                       destruct EV_REL as (?&?); subst.
 
                       rewrite TA in VIS_HANDLED.
-                      pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                                 LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k2 msg) as RAISE.
+                      pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                                 (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k2 msg) as RAISE.
                       rewrite RAISE in VIS_HANDLED.
                       destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
                       { eapply contains_UB_Extra_raise_error in VIS_HANDLED; try contradiction.
@@ -24349,8 +24719,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     { (* Handler raises OOM *)
                       destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
                       rewrite TA_OOM in VIS_HANDLED.
-                      pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                                 LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
+                      pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                                 (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
                       rewrite RAISE in VIS_HANDLED.
                       destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
                       { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -24508,8 +24878,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                       destruct EV_REL as (?&?&?); subst.
 
                       rewrite TA in VIS_HANDLED.
-                      pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                                 LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k2 msg) as RAISE.
+                      pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                                 (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k2 msg) as RAISE.
                       rewrite RAISE in VIS_HANDLED.
                       destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
                       { eapply contains_UB_Extra_raise_error in VIS_HANDLED; try contradiction.
@@ -24623,8 +24993,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     { (* Handler raises OOM *)
                       destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
                       rewrite TA_OOM in VIS_HANDLED.
-                      pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                                 LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
+                      pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                                 (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k2 oom_msg) as RAISE.
                       rewrite RAISE in VIS_HANDLED.
                       destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
                       { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -24890,7 +25260,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                       }
 
                       repeat rewrite <- itree_eta.
-                      specialize (REL (exist (fun _ : InterpreterStackBigIntptr.LP.Events.DV.dvalue => True) x1 I)).
+                      specialize (REL (exist (fun _ : InterpreterStackBigIntptr.LP.DV.dvalue => True) x1 I)).
                       red in REL.
                       pclearbot.
                       eapply orutt_Proper_R3; eauto.
@@ -25054,7 +25424,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                       }
 
                       repeat rewrite <- itree_eta.
-                      specialize (REL (exist (fun _ : InterpreterStackBigIntptr.LP.Events.DV.dvalue => True) x1 I)).
+                      specialize (REL (exist (fun _ : InterpreterStackBigIntptr.LP.DV.dvalue => True) x1 I)).
                       red in REL.
                       pclearbot.
                       eapply orutt_Proper_R3; eauto; try reflexivity.
@@ -25216,7 +25586,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                       }
 
                       repeat rewrite <- itree_eta.
-                      specialize (REL (exist (fun _ : InterpreterStackBigIntptr.LP.Events.DV.dvalue => True) x1 I)).
+                      specialize (REL (exist (fun _ : InterpreterStackBigIntptr.LP.DV.dvalue => True) x1 I)).
                       red in REL.
                       pclearbot.
                       eapply orutt_Proper_R3; eauto; try reflexivity.
@@ -25642,13 +26012,13 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           change (VisF (subevent void (ThrowOOM tt))
                     (fun x : void =>
                        ITree.subst
-                         (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                         (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                        end) (Ret x)))
             with
             (observe (Vis (subevent void (ThrowOOM tt))
                         (fun x : void =>
                            ITree.subst
-                             (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                             (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                            end) (Ret x)))).
           eapply Interp_Memory_PropT_Vis_OOM.
           reflexivity.
@@ -25709,10 +26079,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             eapply Interp_Memory_PropT_Vis with
               (s1:=s1)
               (s2:=lift_MemState s2)
-              (ta:=(vis (InterpreterStackBigIntptr.LP.Events.ExternalCall t0 f args)
-                      (fun x : InterpreterStackBigIntptr.LP.Events.DV.dvalue =>
+              (ta:=(vis (ExternalCall t0 f args)
+                      (fun x : InterpreterStackBigIntptr.LP.DV.dvalue =>
                          ITree.subst
-                           (fun r0 : InterpreterStackBigIntptr.LP.Events.DV.dvalue =>
+                           (fun r0 : InterpreterStackBigIntptr.LP.DV.dvalue =>
                               SemNotations.Ret2 s1 (lift_MemState s2) r0) (Ret x))))
               (k2:=(fun '(ms_inf, (sid', dv_inf)) =>
                       match DVCInfFin.dvalue_convert_strict dv_inf with
@@ -25858,11 +26228,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             clear t2 Heqot2.
             dependent induction KS.
             { pstep; red; cbn.
-              change (VisF (subevent unit (E1.IO_stdout str0))
+              change (VisF (subevent unit (IO_stdout str0))
        (fun H5 : unit => match H5 with
                          | tt => get_inf_tree (k1 tt)
                       end)) with
-                (observe (Vis (subevent unit (E1.IO_stdout str0))
+                (observe (Vis (subevent unit (IO_stdout str0))
        (fun H5 : unit => match H5 with
                          | tt => get_inf_tree (k1 tt)
                          end))).
@@ -25954,15 +26324,15 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               constructor; eauto.
               assert (paco2
                         (interp_memory_PropT_ (OOMF:=(@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 OOME
-             (LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
-             InterpreterStackBigIntptr.LP.Events.ExternalCallE
+             ((@PickUvalueE _ _) +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
+             (@ExternalCallE _ _)
              (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 OOME
-                (OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE) LLVMParamsBigIntptr.Events.PickUvalueE
+                (OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE) (@PickUvalueE _ _)
                 (@ReSum_inl (Type -> Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME
                    (LLVMExcE _ +' UBE +' DebugE +' FailureE) (@ReSum_id (Type -> Type) IFun Id_IFun OOME))))) InfMemInterp.interp_memory_spec_h
                            (fun (x : TopLevelBigIntptr.res_L2) '(_, (_, y)) => TLR_INF.R.refine_res2 x y)
-                           (@InfMemInterp.memory_k_spec InterpreterStackBigIntptr.LP.Events.ExternalCallE) true
-                           true) r (Vis (inl1 (InterpreterStackBigIntptr.LP.Events.IO_stdout str0)) k1)
+                           (@InfMemInterp.memory_k_spec (@ExternalCallE _ _)) true
+                           true) r (Vis (inl1 (IO_stdout str0)) k1)
                         (get_inf_tree {| _observe := observe t1 |})) as H.
               { eapply IHKS; eauto.
               }
@@ -26004,11 +26374,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             clear t2 Heqot2.
             dependent induction KS.
             { pstep; red; cbn.
-              change (VisF (subevent unit (E1.IO_stderr str0))
+              change (VisF (subevent unit (IO_stderr str0))
        (fun H5 : unit => match H5 with
                          | tt => get_inf_tree (k1 tt)
                       end)) with
-                (observe (Vis (subevent unit (E1.IO_stderr str0))
+                (observe (Vis (subevent unit (IO_stderr str0))
        (fun H5 : unit => match H5 with
                          | tt => get_inf_tree (k1 tt)
                          end))).
@@ -26100,15 +26470,15 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               constructor; eauto.
               assert (paco2
                         (interp_memory_PropT_ (OOMF:=(@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 OOME
-             (LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
-             InterpreterStackBigIntptr.LP.Events.ExternalCallE
+             ((@PickUvalueE _ _) +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
+             (@ExternalCallE _ _)
              (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 OOME
-                (OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE) LLVMParamsBigIntptr.Events.PickUvalueE
+                (OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE) (@PickUvalueE _ _)
                 (@ReSum_inl (Type -> Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME
                    (LLVMExcE _ +' UBE +' DebugE +' FailureE) (@ReSum_id (Type -> Type) IFun Id_IFun OOME))))) InfMemInterp.interp_memory_spec_h
                            (fun (x : TopLevelBigIntptr.res_L2) '(_, (_, y)) => TLR_INF.R.refine_res2 x y)
-                           (@InfMemInterp.memory_k_spec InterpreterStackBigIntptr.LP.Events.ExternalCallE) true
-                           true) r (Vis (inl1 (InterpreterStackBigIntptr.LP.Events.IO_stderr str0)) k1)
+                           (@InfMemInterp.memory_k_spec (@ExternalCallE _ _)) true
+                           true) r (Vis (inl1 (IO_stderr str0)) k1)
                         (get_inf_tree {| _observe := observe t1 |})) as H.
               { eapply IHKS; eauto.
               }
@@ -26164,10 +26534,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 x
                                 return
                                 (itree
-                                   (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                         LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)
+                                   ((@ExternalCallE _ _) +'
+                                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)
                                    (MemoryBigIntptr.MMEP.MMSP.MemState *
-                                      (store_id * (LLVMParamsBigIntptr.Events.DV.uvalue + LLVMParamsBigIntptr.Events.DV.dvalue))))
+                                      (store_id * (LLVMParamsBigIntptr.DV.uvalue + LLVMParamsBigIntptr.DV.dvalue))))
                               with
                               end)).
 
@@ -26212,10 +26582,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 x
                                 return
                                 (itree
-                                   (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                         LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)
+                                   ((@ExternalCallE _ _) +'
+                                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)
                                    (MemoryBigIntptr.MMEP.MMSP.MemState *
-                                      (store_id * (LLVMParamsBigIntptr.Events.DV.uvalue + LLVMParamsBigIntptr.Events.DV.dvalue))))
+                                      (store_id * (LLVMParamsBigIntptr.DV.uvalue + LLVMParamsBigIntptr.DV.dvalue))))
                               with
                               end)).
 
@@ -26339,8 +26709,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 x
                                 return
                                 (itree
-                                   (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                         LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)
+                                   ((@ExternalCallE _ _) +'
+                                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)
                                    (MemoryBigIntptr.MMEP.MMSP.MemState *
                                       (store_id * _)))
                               with
@@ -26388,8 +26758,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 x
                                 return
                                 (itree
-                                   (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                         LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)
+                                   ((@ExternalCallE _ _) +'
+                                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)
                                    (MemoryBigIntptr.MMEP.MMSP.MemState *
                                       (store_id * _)))
                               with
@@ -26840,8 +27210,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                             x
                                                             return
                                                             (itree
-                                                               (InterpreterStackBigIntptr.LP.Events.ExternalCallE +'
-                                                                                                                     LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)
+                                                               ((@ExternalCallE _ _) +'
+                                                                                                                     (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)
                                                                (MemoryBigIntptr.MMEP.MMSP.MemState *
                                                                   (store_id * _)))
                                                           with
@@ -26925,18 +27295,18 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
-                                (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                               end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
-                                                                                    (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                                                                    (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                                                                                   end) (Ret x)))).
                 eapply Interp_Memory_PropT_Vis_OOM.
                 reflexivity.
               }
 
               apply k1.
-              apply (inr InterpreterStackBigIntptr.LP.Events.DV.DVALUE_None).
+              apply (inr InterpreterStackBigIntptr.LP.DV.DVALUE_None).
             }
 
             (* Handler succeeds *)
@@ -27050,8 +27420,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             { (* Handler raises OOM *)
               destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
               rewrite TA_OOM in VIS_HANDLED.
-              pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                         LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
+              pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
               rewrite RAISE in VIS_HANDLED.
               destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
               { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -27084,11 +27454,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
-                                (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                               end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
-                                                                                    (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                                                                    (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                                                                                   end) (Ret x)))).
                 eapply Interp_Memory_PropT_Vis_OOM.
                 reflexivity.
@@ -27216,8 +27586,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                *)
 
               rewrite TA in VIS_HANDLED.
-              pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                         LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k3 msg) as RAISE.
+              pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k3 msg) as RAISE.
               rewrite RAISE in VIS_HANDLED.
               destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
               { eapply contains_UB_Extra_raise_error in VIS_HANDLED; try contradiction.
@@ -27267,8 +27637,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             { (* Handler raises OOM *)
               destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
               rewrite TA_OOM in VIS_HANDLED.
-              pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                         LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
+              pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _)+'
+                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
               rewrite RAISE in VIS_HANDLED.
               destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
               { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -27302,11 +27672,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
-                                (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                               end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
-                                                                                    (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                                                                    (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                                                                                   end) (Ret x)))).
                 eapply Interp_Memory_PropT_Vis_OOM.
                 reflexivity.
@@ -27468,8 +27838,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             { (* Handler raises OOM *)
               destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
               rewrite TA_OOM in VIS_HANDLED.
-              pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                         LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
+              pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _)+'
+                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
               rewrite RAISE in VIS_HANDLED.
               destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
               { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -27503,18 +27873,18 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
-                                (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                               end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
-                                                                                    (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                                                                    (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                                                                                   end) (Ret x)))).
                 eapply Interp_Memory_PropT_Vis_OOM.
                 reflexivity.
               }
 
               apply k1.
-              apply InterpreterStackBigIntptr.LP.Events.DV.DVALUE_None.
+              apply InterpreterStackBigIntptr.LP.DV.DVALUE_None.
             }
 
             (* Handler succeeds *)
@@ -27658,8 +28028,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               destruct EV_REL as (?&?); subst.
 
               rewrite TA in VIS_HANDLED.
-              pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                         LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k3 msg) as RAISE.
+              pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k3 msg) as RAISE.
               rewrite RAISE in VIS_HANDLED.
               destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
               { eapply contains_UB_Extra_raise_error in VIS_HANDLED; try contradiction.
@@ -27815,8 +28185,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             { (* Handler raises OOM *)
               destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
               rewrite TA_OOM in VIS_HANDLED.
-              pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                         LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
+              pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
               rewrite RAISE in VIS_HANDLED.
               destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
               { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -27850,18 +28220,18 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
-                                (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                               end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
-                                                                                    (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                                                                    (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                                                                                   end) (Ret x)))).
                 eapply Interp_Memory_PropT_Vis_OOM.
                 reflexivity.
               }
 
               apply k1.
-              apply InterpreterStackBigIntptr.LP.Events.DV.UVALUE_None.
+              apply InterpreterStackBigIntptr.LP.DV.UVALUE_None.
             }
 
             (* Handler succeeds *)
@@ -28007,8 +28377,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               destruct EV_REL as (?&?&?); subst.
 
               rewrite TA in VIS_HANDLED.
-              pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                         LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k3 msg) as RAISE.
+              pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_error _ _) _ _ _ k3 msg) as RAISE.
               rewrite RAISE in VIS_HANDLED.
               destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
               { eapply contains_UB_Extra_raise_error in VIS_HANDLED; try contradiction.
@@ -28042,22 +28412,22 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 change ((VisF (subevent void (raise ""))
                            (fun x : void =>
                               ITree.subst
-                                (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                               end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
-                                                                                    (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                                                                    (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                                                                                   end) (Ret x)))).
               change (VisF (subevent void (Throw tt))
        (fun x : void =>
         ITree.subst
-          (fun v1 : void => match v1 return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+          (fun v1 : void => match v1 return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                          end) (Ret x)))
                 with
                 (observe (Vis (subevent void (Throw tt))
        (fun x : void =>
         ITree.subst
-          (fun v1 : void => match v1 return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+          (fun v1 : void => match v1 return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                             end) (Ret x)))).
 
               eapply Interp_Memory_PropT_Vis with
@@ -28166,8 +28536,8 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             { (* Handler raises OOM *)
               destruct OOM as (oom_msg&TA_OOM&(oom_spec_msg&HANDLE_OOM)).
               rewrite TA_OOM in VIS_HANDLED.
-              pose proof (@Raise.rbm_raise_bind (itree (ExternalCallE +'
-                                                                         LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
+              pose proof (@Raise.rbm_raise_bind (itree ((@ExternalCallE _ _) +'
+                                                                         (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)) _ _ string (@raise_oom _ _) _ _ _ k3 oom_msg) as RAISE.
               rewrite RAISE in VIS_HANDLED.
               destruct VIS_HANDLED as [VIS_HANDLED | VIS_HANDLED].
               { eapply contains_UB_Extra_raiseOOM in VIS_HANDLED; try contradiction.
@@ -28201,11 +28571,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 change ((VisF (subevent void (ThrowOOM tt))
                            (fun x : void =>
                               ITree.subst
-                                (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                               end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                                (fun x : void =>
                                                                                   ITree.subst
-                                                                                    (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                                                                    (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                                                                                   end) (Ret x)))).
                 eapply Interp_Memory_PropT_Vis_OOM.
                 reflexivity.
@@ -28467,7 +28837,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
 
               repeat rewrite <- itree_eta.
-              specialize (REL0 (exist (fun _ : InterpreterStackBigIntptr.LP.Events.DV.dvalue => True) x1 I)
+              specialize (REL0 (exist (fun _ : InterpreterStackBigIntptr.LP.DV.dvalue => True) x1 I)
                             (exist (fun _ : DVCInfFin.DV2.dvalue => True) d I)).
               cbn in REL0.
               forward REL0.
@@ -28632,7 +29002,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
 
               repeat rewrite <- itree_eta.
-              specialize (REL0 (exist (fun _ : InterpreterStackBigIntptr.LP.Events.DV.dvalue => True) x1 I)
+              specialize (REL0 (exist (fun _ : InterpreterStackBigIntptr.LP.DV.dvalue => True) x1 I)
                             (exist (fun _ : DVCInfFin.DV2.dvalue => True) d I)).
               cbn in REL0.
               forward REL0.
@@ -28797,7 +29167,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               }
 
               repeat rewrite <- itree_eta.
-              specialize (REL0 (exist (fun _ : InterpreterStackBigIntptr.LP.Events.DV.dvalue => True) x1 I)
+              specialize (REL0 (exist (fun _ : InterpreterStackBigIntptr.LP.DV.dvalue => True) x1 I)
                             (exist (fun _ : DVCInfFin.DV2.dvalue => True) d I)).
               cbn in REL0.
               forward REL0.
@@ -29225,11 +29595,11 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             change ((VisF (subevent void (ThrowOOM tt))
                        (fun x : void =>
                           ITree.subst
-                            (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                            (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                           end) (Ret x)))) with (observe (Vis (subevent void (ThrowOOM tt))
                                                                            (fun x : void =>
                                                                               ITree.subst
-                                                                                (fun v : void => match v return (itree InfLP.Events.L3 TopLevelBigIntptr.res_L6) with
+                                                                                (fun v : void => match v return (itree ECInfFin.L31 TopLevelBigIntptr.res_L6) with
                                                                                               end) (Ret x)))).
             eapply Interp_Memory_PropT_Vis_OOM.
             reflexivity.
@@ -29271,10 +29641,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
              constructor; [|constructor];
              [ exact Memory64BitIntptr.MMEP.MMSP.initial_memory_state
              | exact sidX
-             | first [ exact (inr LLVMParams64BitIntptr.Events.DV.DVALUE_None)
-                     | exact (inr LLVMParams64BitIntptr.Events.DV.UVALUE_None)
-                     | exact LLVMParams64BitIntptr.Events.DV.DVALUE_None
-                     | exact LLVMParams64BitIntptr.Events.DV.UVALUE_None
+             | first [ exact (inr LLVMParams64BitIntptr.DV.DVALUE_None)
+                     | exact (inr LLVMParams64BitIntptr.DV.UVALUE_None)
+                     | exact LLVMParams64BitIntptr.DV.DVALUE_None
+                     | exact LLVMParams64BitIntptr.DV.UVALUE_None
                      | auto]]
            ].
   Qed.
@@ -29298,10 +29668,10 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   Qed.
 
   Definition L4_E1E2_orutt_strict
-    (t1 : PropT InfLP.Events.L4 (InfMemMMSP.MemState *
-                                   (store_id * (InfLLVM.Stack.lstack_frame * InfLLVM.Stack.lstack * (InfLLVM.Global.global_env * InfLP.Events.DV.dvalue)))))
-    (t2 : PropT FinLP.Events.L4 (FinMemMMSP.MemState *
-                                   (store_id * (FinLLVM.Stack.lstack_frame * FinLLVM.Stack.lstack * (FinLLVM.Global.global_env * FinLP.Events.DV.dvalue)))))
+    (t1 : PropT ECInfFin.L41 (InfMemMMSP.MemState *
+                                   (store_id * (InfLLVM.Stack.lstack_frame * InfLLVM.Stack.lstack * (InfLLVM.Global.global_env * InfLP.DV.dvalue)))))
+    (t2 : PropT ECFinInf.L41 (FinMemMMSP.MemState *
+                                   (store_id * (FinLLVM.Stack.lstack_frame * FinLLVM.Stack.lstack * (FinLLVM.Global.global_env * FinLP.DV.dvalue)))))
     : Prop :=
     forall t', t2 t' ->
                exists t, t1 t /\
@@ -29317,7 +29687,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       (TopLevel64BitIntptr.model_oom_L4 TLR_FIN.R.refine_res2 TLR_FIN.R.refine_res3 args2 p2).
 
   Definition get_inf_tree_L4' :
-    forall (t_fin2 : itree L4 (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))), itree InfLP.Events.L4 TopLevelBigIntptr.res_L4.
+    forall (t_fin2 : itree ECFinInf.L41 (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))), itree ECInfFin.L41 TopLevelBigIntptr.res_L4.
   Proof.
     cofix CIH.
     intros t_fin2.
@@ -29348,16 +29718,16 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
     - (* Vis *)
       inversion e; clear e; subst.
       { (* ExternalCallE *)
-        inversion H; subst.
+        inversion X0; subst.
         { apply go.
-          apply (VisF (subevent _ (E1.ExternalCall t (fin_to_inf_uvalue f) (map fin_to_inf_dvalue args)))).
+          apply (VisF (subevent _ (ExternalCall t (fin_to_inf_uvalue f) (map fin_to_inf_dvalue args)))).
 
           (* Continuation *)
           intros x.
           apply CIH.
 
           pose proof (DVCInfFin.dvalue_convert_strict x).
-          destruct H0.
+          destruct H.
           - exact (k d).
           - (* OOM -- somewhat worried about this case *)
             exact (raiseOOM s).
@@ -29365,7 +29735,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
         { (* Stdout *)
           apply go.
-          apply (VisF (subevent _ (E1.IO_stdout str))).
+          apply (VisF (subevent _ (IO_stdout str))).
           intros [].
           apply CIH.
           apply k. apply tt.
@@ -29373,7 +29743,7 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
         { (* Stderr *)
           apply go.
-          apply (VisF (subevent _ (E1.IO_stderr str))).
+          apply (VisF (subevent _ (IO_stderr str))).
           intros [].
           apply CIH.
           apply k. apply tt.
@@ -29424,33 +29794,63 @@ cofix CIH (t_fin2 : itree L3 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   (* Unset Printing Implicit. *)
 
   Definition get_inf_tree_L4 :
-    forall (t_fin2 : itree L4 (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))), itree InfLP.Events.L4 TopLevelBigIntptr.res_L4 :=
-cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) :
-    itree InfLP.Events.L4 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
-  (fun _observe : itreeF L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) (itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
+    forall (t_fin2 : itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue) (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))), itree ECInfFin.L41 TopLevelBigIntptr.res_L4 :=
+cofix CIH
+  (t_fin2 : itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) :
+    itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+         (prod store_id
+            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
+  (fun
+     _observe : itreeF (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                  (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                  (itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                     (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
    match
      _observe
      return
-       (itree InfLP.Events.L4
-          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+       (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
    with
    | @RetF _ _ _ r =>
        (fun r0 : prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))) =>
-        @ret (itree InfLP.Events.L4) (@Monad_itree InfLP.Events.L4)
-          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+        @ret (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)) (@Monad_itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue))
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
           match
-            r0 return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+            r0
+            return
+              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                 (prod store_id
+                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
           with
           | @pair _ _ m p =>
               (fun (ms : FinMem.MMEP.MMSP.MemState) (p0 : prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))) =>
                match
-                 p0 return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                 p0
+                 return
+                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                      (prod store_id
+                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                with
                | @pair _ _ s p1 =>
                    (fun (sid : store_id) (p2 : prod (prod lstack_frame lstack) (prod global_env dvalue)) =>
                     match
                       p2
-                      return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                      return
+                        (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                           (prod store_id
+                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                     with
                     | @pair _ _ p3 p4 =>
                         (fun p5 : prod lstack_frame lstack =>
@@ -29458,7 +29858,10 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                            p5
                            return
                              (forall _ : prod global_env dvalue,
-                              prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                              prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                          with
                          | @pair _ _ l l0 =>
                              (fun (lenv : lstack_frame) (s0 : lstack) (p6 : prod global_env dvalue) =>
@@ -29466,16 +29869,27 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 p6
                                 return
                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                     (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                     (prod store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                               with
                               | @pair _ _ g d =>
                                   (fun (genv : global_env) (res : dvalue) =>
                                    @pair InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                     (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))) (lift_MemState ms)
-                                     (@pair store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)) sid
-                                        (@pair (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)
-                                           (@pair InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack (lift_stack_frame lenv) (lift_stack s0))
-                                           (@pair InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue (lift_global_env genv) (fin_to_inf_dvalue res)))))
+                                     (prod store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))
+                                     (lift_MemState ms)
+                                     (@pair store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))
+                                        sid
+                                        (@pair (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)
+                                           (@pair InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack
+                                              (lift_stack_frame lenv) (lift_stack s0))
+                                           (@pair InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue
+                                              (lift_global_env genv) (fin_to_inf_dvalue res)))))
                                     g d
                               end) l l0
                          end) p3 p4
@@ -29484,189 +29898,288 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           end)
          r
    | @TauF _ _ _ t =>
-       (fun t0 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) =>
-        @go InfLP.Events.L4 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-          (@TauF InfLP.Events.L4
-             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-             (itree InfLP.Events.L4
-                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+       (fun
+          t0 : itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) =>
+        @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+          (@TauF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                (prod store_id
+                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+             (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                   (prod store_id
+                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
              (CIH t0)))
          t
    | @VisF _ _ _ X e k =>
-       (fun (X0 : Type) (e0 : L4 X0) (k0 : forall _ : X0, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
+       (fun (X0 : Type) (e0 : L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X0)
+          (k0 : forall _ : X0,
+                itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                  (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
         let X1 :
-          itree InfLP.Events.L4
-            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+          itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+               (prod store_id
+                  (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
           match
             e0
             return
-              (itree InfLP.Events.L4
-                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+              (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                    (prod store_id
+                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
           with
           | @inl1 _ _ _ x =>
-              (fun H : ExternalCallE X0 =>
-               (fun H0 : ExternalCallE X0 =>
-                let X1 :
+              (fun X1 : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X0 =>
+               (fun X2 : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X0 =>
+                let X3 :
                   (fun T : Type =>
                    forall _ : @eq Type T X0,
-                   itree InfLP.Events.L4
-                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                        (prod store_id
+                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                     X0 :=
                   match
-                    H0 in (ExternalCallE T)
+                    X2 in (ExternalCallE _ _ T)
                     return
                       (forall _ : @eq Type T X0,
-                       itree InfLP.Events.L4
-                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                       itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                            (prod store_id
+                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                   with
-                  | @ExternalCall t f args =>
-                      (fun (t0 : dtyp) (f0 : uvalue) (args0 : list dvalue) (H1 : @eq Type dvalue X0) =>
-                       (fun H2 : @eq Type dvalue X0 =>
-                        let H3 : @eq Type dvalue X0 := H2 in
-                        @eq_rect Type dvalue
+                  | @ExternalCall _ _ t f args =>
+                      (fun (t0 : dtyp) (f0 : ECFinInf.DV1.uvalue) (args0 : list ECFinInf.DV1.dvalue) (H : @eq Type ECFinInf.DV1.dvalue X0) =>
+                       (fun H0 : @eq Type ECFinInf.DV1.dvalue X0 =>
+                        let H1 : @eq Type ECFinInf.DV1.dvalue X0 := H0 in
+                        @eq_rect Type ECFinInf.DV1.dvalue
                           (fun _ : Type =>
-                           forall (_ : dtyp) (_ : uvalue) (_ : list dvalue),
-                           itree InfLP.Events.L4
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                          (fun (t1 : dtyp) (f1 : uvalue) (args1 : list dvalue) =>
-                           @eq_rect Type dvalue
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L4
+                           forall (_ : dtyp) (_ : ECFinInf.DV1.uvalue) (_ : list ECFinInf.DV1.dvalue),
+                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                          (fun (t1 : dtyp) (f1 : ECFinInf.DV1.uvalue) (args1 : list ECFinInf.DV1.dvalue) =>
+                           @eq_rect Type ECFinInf.DV1.dvalue
+                             (fun X3 : Type =>
+                              forall
+                                (_ : forall _ : X3,
+                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                       (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X3),
+                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : dvalue, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE dvalue) =>
-                              @go InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                             (fun
+                                (k1 : forall _ : ECFinInf.DV1.dvalue,
+                                      itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue ECFinInf.DV1.dvalue) =>
+                              @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                (@VisF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L4
+                                      (prod store_id
+                                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                   (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                   E1.DV.dvalue
-                                   (@subevent E1.ExternalCallE InfLP.Events.L4
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE))
-                                      E1.DV.dvalue (E1.ExternalCall t1 (fin_to_inf_uvalue f1) (@map DVCFinInf.DV1.dvalue DVCFinInf.DV2.dvalue fin_to_inf_dvalue args1)))
-                                   (fun x0 : E1.DV.dvalue =>
+                                         (prod store_id
+                                            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                   DVCFinInf.DV2.dvalue
+                                   (@subevent (ExternalCallE DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue) (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                      (@ExternalCallE_L4 DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue) DVCFinInf.DV2.dvalue
+                                      (@ExternalCall DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue t1 (fin_to_inf_uvalue f1)
+                                         (@map DVCFinInf.DV1.dvalue DVCFinInf.DV2.dvalue fin_to_inf_dvalue args1)))
+                                   (fun x0 : DVCFinInf.DV2.dvalue =>
                                     CIH
-                                      (let H4 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x0 in
-                                       match H4 return (itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
+                                      (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x0 in
+                                       match
+                                         H2
+                                         return
+                                           (itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                       with
                                        | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 d0) d
                                        | @Oom _ s =>
                                            (fun s0 : string =>
-                                            @raiseOOM L4
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) ExternalCallE
-                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME)))
-                                              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
+                                            @raiseOOM (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue) (@OOME_L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                              s0)
                                              s
                                        end))))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 t0 f0 args0)
+                             X0 H0 k0 X2)
+                          X0 H1)
+                         H t0 f0 args0)
                         t f args
-                  | @IO_stdout str =>
-                      (fun (str0 : list int8) (H1 : @eq Type unit X0) =>
-                       (fun H2 : @eq Type unit X0 =>
-                        let H3 : @eq Type unit X0 := H2 in
+                  | @IO_stdout _ _ str =>
+                      (fun (str0 : list int8) (H : @eq Type unit X0) =>
+                       (fun H0 : @eq Type unit X0 =>
+                        let H1 : @eq Type unit X0 := H0 in
                         @eq_rect Type unit
                           (fun _ : Type =>
                            forall _ : list int8,
-                           itree InfLP.Events.L4
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           (fun str1 : list int8 =>
                            @eq_rect Type unit
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L4
+                             (fun X3 : Type =>
+                              forall
+                                (_ : forall _ : X3,
+                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                       (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X3),
+                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : unit, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE unit) =>
-                              @go InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                             (fun
+                                (k1 : forall _ : unit,
+                                      itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue unit) =>
+                              @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                (@VisF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L4
+                                      (prod store_id
+                                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                   (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                         (prod store_id
+                                            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                    unit
-                                   (@subevent E1.ExternalCallE InfLP.Events.L4
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE)) unit
-                                      (E1.IO_stdout str1))
-                                   (fun H4 : unit =>
+                                   (@subevent (ExternalCallE ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                      (@ExternalCallE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) unit
+                                      (@IO_stdout ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue str1))
+                                   (fun H2 : unit =>
                                     match
-                                      H4
+                                      H2
                                       return
-                                        (itree InfLP.Events.L4
+                                        (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                     with
                                     | @tt => CIH (k1 tt)
                                     end)))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 str0)
+                             X0 H0 k0 X2)
+                          X0 H1)
+                         H str0)
                         str
-                  | @IO_stderr str =>
-                      (fun (str0 : list int8) (H1 : @eq Type unit X0) =>
-                       (fun H2 : @eq Type unit X0 =>
-                        let H3 : @eq Type unit X0 := H2 in
+                  | @IO_stderr _ _ str =>
+                      (fun (str0 : list int8) (H : @eq Type unit X0) =>
+                       (fun H0 : @eq Type unit X0 =>
+                        let H1 : @eq Type unit X0 := H0 in
                         @eq_rect Type unit
                           (fun _ : Type =>
                            forall _ : list int8,
-                           itree InfLP.Events.L4
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           (fun str1 : list int8 =>
                            @eq_rect Type unit
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L4
+                             (fun X3 : Type =>
+                              forall
+                                (_ : forall _ : X3,
+                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                       (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X3),
+                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : unit, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE unit) =>
-                              @go InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                             (fun
+                                (k1 : forall _ : unit,
+                                      itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue unit) =>
+                              @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                (@VisF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L4
+                                      (prod store_id
+                                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                   (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                         (prod store_id
+                                            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                    unit
-                                   (@subevent E1.ExternalCallE InfLP.Events.L4
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE)) unit
-                                      (E1.IO_stderr str1))
-                                   (fun H4 : unit =>
+                                   (@subevent (ExternalCallE ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                      (@ExternalCallE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) unit
+                                      (@IO_stderr ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue str1))
+                                   (fun H2 : unit =>
                                     match
-                                      H4
+                                      H2
                                       return
-                                        (itree InfLP.Events.L4
+                                        (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                     with
                                     | @tt => CIH (k1 tt)
                                     end)))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 str0)
+                             X0 H0 k0 X2)
+                          X0 H1)
+                         H str0)
                         str
                   end in
-                X1 (@eq_refl Type X0)) H) x
+                X3 (@eq_refl Type X0)) X1) x
           | @inr1 _ _ _ x =>
-              (fun H : sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
-               (fun H0 : sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
+              (fun H : sum1 OOME (sum1 (LLVMExcE ECFinInf.DV1.uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
+               (fun H0 : sum1 OOME (sum1 (LLVMExcE ECFinInf.DV1.uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
                 let X1 :
-                  itree InfLP.Events.L4
-                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                  itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                       (prod store_id
+                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                   match
                     H0
                     return
-                      (itree InfLP.Events.L4
-                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                      (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                            (prod store_id
+                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                   with
                   | @inl1 _ _ _ x0 =>
                       (fun H1 : OOME X0 =>
@@ -29674,16 +30187,21 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                         let X1 :
                           (fun T : Type =>
                            forall _ : @eq Type T X0,
-                           itree InfLP.Events.L4
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                             X0 :=
                           match
                             H2 in (OOME T)
                             return
                               (forall _ : @eq Type T X0,
-                               itree InfLP.Events.L4
+                               itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           with
                           | @ThrowOOM x1 =>
                               (fun (H3 : unit) (H4 : @eq Type Empty_set X0) =>
@@ -29692,22 +30210,34 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 @eq_rect Type Empty_set
                                   (fun _ : Type =>
                                    forall _ : unit,
-                                   itree InfLP.Events.L4
+                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   (fun _ : unit =>
                                    @eq_rect Type Empty_set
                                      (fun X1 : Type =>
-                                      forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : OOME X1),
-                                      itree InfLP.Events.L4
+                                      forall
+                                        (_ : forall _ : X1,
+                                             itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : OOME X1),
+                                      itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                     (fun (_ : forall _ : Empty_set, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : OOME Empty_set) =>
-                                      @raiseOOM InfLP.Events.L4
-                                        (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                           (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME)))
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     (fun
+                                        (_ : forall _ : Empty_set,
+                                             itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : OOME Empty_set) =>
+                                      @raiseOOM (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) (@OOME_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                                         EmptyString)
                                      X0 H5 k0 H2)
                                   X0 H6)
@@ -29716,61 +30246,88 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                           end in
                         X1 (@eq_refl Type X0)) H1) x0
                   | @inr1 _ _ _ x0 =>
-                      (fun H1 : sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
-                       (fun H2 : sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
+                      (fun H1 : sum1 (LLVMExcE ECFinInf.DV1.uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
+                       (fun H2 : sum1 (LLVMExcE ECFinInf.DV1.uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
                         let X1 :
-                          itree InfLP.Events.L4
-                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                          itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                               (prod store_id
+                                  (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                           match
                             H2
                             return
-                              (itree InfLP.Events.L4
+                              (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           with
                           | @inl1 _ _ _ x1 =>
-                              (fun H3 : LLVMExcE uvalue X0 =>
-                               (fun H4 : LLVMExcE uvalue X0 =>
+                              (fun H3 : LLVMExcE ECFinInf.DV1.uvalue X0 =>
+                               (fun H4 : LLVMExcE ECFinInf.DV1.uvalue X0 =>
                                 let X1 :
                                   (fun T : Type =>
                                    forall _ : @eq Type T X0,
-                                   itree InfLP.Events.L4
+                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                     X0 :=
                                   match
                                     H4 in (LLVMExcE _ T)
                                     return
                                       (forall _ : @eq Type T X0,
-                                       itree InfLP.Events.L4
+                                       itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                            (prod store_id
+                                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   with
                                   | @LLVMExc _ x2 =>
-                                      (fun (H5 : uvalue) (H6 : @eq Type Empty_set X0) =>
+                                      (fun (H5 : ECFinInf.DV1.uvalue) (H6 : @eq Type Empty_set X0) =>
                                        (fun H7 : @eq Type Empty_set X0 =>
                                         let H8 : @eq Type Empty_set X0 := H7 in
                                         @eq_rect Type Empty_set
                                           (fun _ : Type =>
-                                           forall _ : uvalue,
-                                           itree InfLP.Events.L4
+                                           forall _ : ECFinInf.DV1.uvalue,
+                                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                          (fun H9 : uvalue =>
+                                                (prod store_id
+                                                   (prod
+                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                          (fun H9 : ECFinInf.DV1.uvalue =>
                                            @eq_rect Type Empty_set
                                              (fun X1 : Type =>
-                                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : LLVMExcE uvalue X1),
-                                              itree InfLP.Events.L4
+                                              forall
+                                                (_ : forall _ : X1,
+                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                (_ : LLVMExcE ECFinInf.DV1.uvalue X1),
+                                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                             (fun (_ : forall _ : Empty_set, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : LLVMExcE uvalue Empty_set) =>
-                                              @raiseLLVM InfLP.Events.L4 DVCFinInf.DV2.uvalue
+                                                   (prod store_id
+                                                      (prod
+                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                             (fun
+                                                (_ : forall _ : Empty_set,
+                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                (_ : LLVMExcE ECFinInf.DV1.uvalue Empty_set) =>
+                                              @raiseLLVM (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) DVCFinInf.DV2.uvalue
                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                                   (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (LLVMExcE InfLP.Events.DV.uvalue)))))
-                                                (fin_to_inf_uvalue H9))
+                                                   (prod store_id
+                                                      (prod
+                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                (@LLVMExcE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) (fin_to_inf_uvalue H9))
                                              X0 H7 k0 H4)
                                           X0 H8)
                                          H6 H5)
@@ -29781,15 +30338,19 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                               (fun H3 : sum1 UBE (sum1 DebugE FailureE) X0 =>
                                (fun H4 : sum1 UBE (sum1 DebugE FailureE) X0 =>
                                 let X1 :
-                                  itree InfLP.Events.L4
+                                  itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                       (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                   match
                                     H4
                                     return
-                                      (itree InfLP.Events.L4
+                                      (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                            (prod store_id
+                                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   with
                                   | @inl1 _ _ _ x2 =>
                                       (fun H5 : UBE X0 =>
@@ -29797,17 +30358,24 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                         let X1 :
                                           (fun T : Type =>
                                            forall _ : @eq Type T X0,
-                                           itree InfLP.Events.L4
+                                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                (prod store_id
+                                                   (prod
+                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             X0 :=
                                           match
                                             H6 in (UBE T)
                                             return
                                               (forall _ : @eq Type T X0,
-                                               itree InfLP.Events.L4
+                                               itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                    (prod store_id
+                                                       (prod
+                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           with
                                           | @ThrowUB x3 =>
                                               (fun (H7 : unit) (H8 : @eq Type Empty_set X0) =>
@@ -29816,24 +30384,45 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                 @eq_rect Type Empty_set
                                                   (fun _ : Type =>
                                                    forall _ : unit,
-                                                   itree InfLP.Events.L4
+                                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   (fun _ : unit =>
                                                    @eq_rect Type Empty_set
                                                      (fun X1 : Type =>
-                                                      forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : UBE X1),
-                                                      itree InfLP.Events.L4
+                                                      forall
+                                                        (_ : forall _ : X1,
+                                                             itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                        (_ : UBE X1),
+                                                      itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                     (fun (_ : forall _ : Empty_set, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : UBE Empty_set) =>
-                                                      @raiseUB InfLP.Events.L4
-                                                        (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 UBE UBE (sum1 DebugE FailureE) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun UBE)))))
+                                                           (prod store_id
+                                                              (prod
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                    InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                     (fun
+                                                        (_ : forall _ : Empty_set,
+                                                             itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                        (_ : UBE Empty_set) =>
+                                                      @raiseUB (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                                        (@UBE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                                           (prod store_id
+                                                              (prod
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                    InterpreterStackBigIntptr.LP.DV.dvalue))))
                                                         EmptyString)
                                                      X0 H9 k0 H6)
                                                   X0 H10)
@@ -29845,15 +30434,22 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                       (fun H5 : sum1 DebugE FailureE X0 =>
                                        (fun H6 : sum1 DebugE FailureE X0 =>
                                         let X1 :
-                                          itree InfLP.Events.L4
+                                          itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                               (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                               (prod store_id
+                                                  (prod
+                                                     (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                           match
                                             H6
                                             return
-                                              (itree InfLP.Events.L4
+                                              (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                    (prod store_id
+                                                       (prod
+                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           with
                                           | @inl1 _ _ _ x3 =>
                                               (fun H7 : DebugE X0 =>
@@ -29861,17 +30457,26 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                 let X1 :
                                                   (fun T : Type =>
                                                    forall _ : @eq Type T X0,
-                                                   itree InfLP.Events.L4
+                                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                     X0 :=
                                                   match
                                                     H8 in (DebugE T)
                                                     return
                                                       (forall _ : @eq Type T X0,
-                                                       itree InfLP.Events.L4
+                                                       itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                            (prod store_id
+                                                               (prod
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                     InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                     InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   with
                                                   | @Debug x4 =>
                                                       (fun (H9 : unit) (H10 : @eq Type unit X0) =>
@@ -29880,34 +30485,65 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                         @eq_rect Type unit
                                                           (fun _ : Type =>
                                                            forall _ : unit,
-                                                           itree InfLP.Events.L4
+                                                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           (fun H13 : unit =>
                                                            @eq_rect Type unit
                                                              (fun X1 : Type =>
-                                                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : DebugE X1),
-                                                              itree InfLP.Events.L4
+                                                              forall
+                                                                (_ : forall _ : X1,
+                                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : DebugE X1),
+                                                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                             (fun (k1 : forall _ : unit, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : DebugE unit) =>
-                                                              @go InfLP.Events.L4
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                             (fun
+                                                                (k1 : forall _ : unit,
+                                                                      itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                                        (prod FinMem.MMEP.MMSP.MemState
+                                                                           (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : DebugE unit) =>
+                                                              @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                (@VisF InfLP.Events.L4
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                (@VisF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                   (itree InfLP.Events.L4
+                                                                      (prod store_id
+                                                                         (prod
+                                                                            (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                               InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                               InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                   (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                         (prod store_id
+                                                                            (prod
+                                                                               (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                  InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                  InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                                    unit
-                                                                   (@subevent DebugE InfLP.Events.L4
-                                                                      (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                                                         (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                            (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                               (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 DebugE FailureE) UBE
-                                                                                  (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 DebugE DebugE FailureE (@ReSum_id (forall _ : Type, Type) IFun Id_IFun DebugE))))))
-                                                                      unit (Debug H13))
+                                                                   (@subevent DebugE (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                                                      (@DebugE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) unit 
+                                                                      (Debug H13))
                                                                    (fun H14 : unit => CIH (k1 H14))))
                                                              X0 H11 k0 H8)
                                                           X0 H12)
@@ -29921,17 +30557,26 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                 let X1 :
                                                   (fun T : Type =>
                                                    forall _ : @eq Type T X0,
-                                                   itree InfLP.Events.L4
+                                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                     X0 :=
                                                   match
                                                     H8 in (FailureE T)
                                                     return
                                                       (forall _ : @eq Type T X0,
-                                                       itree InfLP.Events.L4
+                                                       itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                            (prod store_id
+                                                               (prod
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                     InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                     InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   with
                                                   | @Throw x4 =>
                                                       (fun (H9 : unit) (H10 : @eq Type Empty_set X0) =>
@@ -29940,26 +30585,46 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                         @eq_rect Type Empty_set
                                                           (fun _ : Type =>
                                                            forall _ : unit,
-                                                           itree InfLP.Events.L4
+                                                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           (fun _ : unit =>
                                                            @eq_rect Type Empty_set
                                                              (fun X1 : Type =>
-                                                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : FailureE X1),
-                                                              itree InfLP.Events.L4
+                                                              forall
+                                                                (_ : forall _ : X1,
+                                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : FailureE X1),
+                                                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                             (fun (_ : forall _ : Empty_set, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : FailureE Empty_set) =>
-                                                              @LLVMEvents.raise InfLP.Events.L4
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                             (fun
+                                                                (_ : forall _ : Empty_set,
+                                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : FailureE Empty_set) =>
+                                                              @LLVMEvents.raise (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                                                   (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                      (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                         (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 DebugE FailureE) UBE
-                                                                            (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE FailureE DebugE (@ReSum_id (forall _ : Type, Type) IFun Id_IFun FailureE))))))
-                                                                EmptyString)
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                (@FailureE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) EmptyString)
                                                              X0 H11 k0 H8)
                                                           X0 H12)
                                                          H10 H9)
@@ -29978,30 +30643,51 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
         X1) X e k
    end) (@_observe _ _ t_fin2).
 
-  Definition _get_inf_tree_L4 (t_fin2 : itree' L4 (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))) : itree InfLP.Events.L4 TopLevelBigIntptr.res_L4 :=
+
+  Definition _get_inf_tree_L4 (t_fin2 : itree' (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue) (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))) : itree ECInfFin.L41 TopLevelBigIntptr.res_L4 :=
    match
      t_fin2
      return
-       (itree InfLP.Events.L4
-          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+       (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
    with
    | @RetF _ _ _ r =>
        (fun r0 : prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))) =>
-        @ret (itree InfLP.Events.L4) (@Monad_itree InfLP.Events.L4)
-          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+        @ret (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)) (@Monad_itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue))
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
           match
-            r0 return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+            r0
+            return
+              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                 (prod store_id
+                    (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                       (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
           with
           | @pair _ _ m p =>
               (fun (ms : FinMem.MMEP.MMSP.MemState) (p0 : prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))) =>
                match
-                 p0 return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                 p0
+                 return
+                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                      (prod store_id
+                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                with
                | @pair _ _ s p1 =>
                    (fun (sid : store_id) (p2 : prod (prod lstack_frame lstack) (prod global_env dvalue)) =>
                     match
                       p2
-                      return (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                      return
+                        (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                           (prod store_id
+                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                     with
                     | @pair _ _ p3 p4 =>
                         (fun p5 : prod lstack_frame lstack =>
@@ -30009,7 +30695,10 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                            p5
                            return
                              (forall _ : prod global_env dvalue,
-                              prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                              prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                          with
                          | @pair _ _ l l0 =>
                              (fun (lenv : lstack_frame) (s0 : lstack) (p6 : prod global_env dvalue) =>
@@ -30017,16 +30706,27 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 p6
                                 return
                                   (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                     (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                     (prod store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                               with
                               | @pair _ _ g d =>
                                   (fun (genv : global_env) (res : dvalue) =>
                                    @pair InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                     (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))) (lift_MemState ms)
-                                     (@pair store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)) sid
-                                        (@pair (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)
-                                           (@pair InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack (lift_stack_frame lenv) (lift_stack s0))
-                                           (@pair InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue (lift_global_env genv) (fin_to_inf_dvalue res)))))
+                                     (prod store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))
+                                     (lift_MemState ms)
+                                     (@pair store_id
+                                        (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))
+                                        sid
+                                        (@pair (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                           (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)
+                                           (@pair InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack
+                                              (lift_stack_frame lenv) (lift_stack s0))
+                                           (@pair InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue
+                                              (lift_global_env genv) (fin_to_inf_dvalue res)))))
                                     g d
                               end) l l0
                          end) p3 p4
@@ -30035,189 +30735,288 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           end)
          r
    | @TauF _ _ _ t =>
-       (fun t0 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) =>
-        @go InfLP.Events.L4 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-          (@TauF InfLP.Events.L4
-             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-             (itree InfLP.Events.L4
-                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+       (fun
+          t0 : itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) =>
+        @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+             (prod store_id
+                (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                   (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+          (@TauF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                (prod store_id
+                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+             (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                   (prod store_id
+                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
              (get_inf_tree_L4 t0)))
          t
    | @VisF _ _ _ X e k =>
-       (fun (X0 : Type) (e0 : L4 X0) (k0 : forall _ : X0, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
+       (fun (X0 : Type) (e0 : L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X0)
+          (k0 : forall _ : X0,
+                itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                  (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) =>
         let X1 :
-          itree InfLP.Events.L4
-            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+          itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+               (prod store_id
+                  (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
           match
             e0
             return
-              (itree InfLP.Events.L4
-                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+              (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                    (prod store_id
+                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
           with
           | @inl1 _ _ _ x =>
-              (fun H : ExternalCallE X0 =>
-               (fun H0 : ExternalCallE X0 =>
-                let X1 :
+              (fun X1 : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X0 =>
+               (fun X2 : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X0 =>
+                let X3 :
                   (fun T : Type =>
                    forall _ : @eq Type T X0,
-                   itree InfLP.Events.L4
-                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                        (prod store_id
+                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                     X0 :=
                   match
-                    H0 in (ExternalCallE T)
+                    X2 in (ExternalCallE _ _ T)
                     return
                       (forall _ : @eq Type T X0,
-                       itree InfLP.Events.L4
-                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                       itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                            (prod store_id
+                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                   with
-                  | @ExternalCall t f args =>
-                      (fun (t0 : dtyp) (f0 : uvalue) (args0 : list dvalue) (H1 : @eq Type dvalue X0) =>
-                       (fun H2 : @eq Type dvalue X0 =>
-                        let H3 : @eq Type dvalue X0 := H2 in
-                        @eq_rect Type dvalue
+                  | @ExternalCall _ _ t f args =>
+                      (fun (t0 : dtyp) (f0 : ECFinInf.DV1.uvalue) (args0 : list ECFinInf.DV1.dvalue) (H : @eq Type ECFinInf.DV1.dvalue X0) =>
+                       (fun H0 : @eq Type ECFinInf.DV1.dvalue X0 =>
+                        let H1 : @eq Type ECFinInf.DV1.dvalue X0 := H0 in
+                        @eq_rect Type ECFinInf.DV1.dvalue
                           (fun _ : Type =>
-                           forall (_ : dtyp) (_ : uvalue) (_ : list dvalue),
-                           itree InfLP.Events.L4
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                          (fun (t1 : dtyp) (f1 : uvalue) (args1 : list dvalue) =>
-                           @eq_rect Type dvalue
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L4
+                           forall (_ : dtyp) (_ : ECFinInf.DV1.uvalue) (_ : list ECFinInf.DV1.dvalue),
+                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                          (fun (t1 : dtyp) (f1 : ECFinInf.DV1.uvalue) (args1 : list ECFinInf.DV1.dvalue) =>
+                           @eq_rect Type ECFinInf.DV1.dvalue
+                             (fun X3 : Type =>
+                              forall
+                                (_ : forall _ : X3,
+                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                       (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X3),
+                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : dvalue, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE dvalue) =>
-                              @go InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                             (fun
+                                (k1 : forall _ : ECFinInf.DV1.dvalue,
+                                      itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue ECFinInf.DV1.dvalue) =>
+                              @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                (@VisF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L4
+                                      (prod store_id
+                                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                   (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                   E1.DV.dvalue
-                                   (@subevent E1.ExternalCallE InfLP.Events.L4
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE))
-                                      E1.DV.dvalue (E1.ExternalCall t1 (fin_to_inf_uvalue f1) (@map DVCFinInf.DV1.dvalue DVCFinInf.DV2.dvalue fin_to_inf_dvalue args1)))
-                                   (fun x0 : E1.DV.dvalue =>
+                                         (prod store_id
+                                            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                   DVCFinInf.DV2.dvalue
+                                   (@subevent (ExternalCallE DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue) (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                      (@ExternalCallE_L4 DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue) DVCFinInf.DV2.dvalue
+                                      (@ExternalCall DVCFinInf.DV2.dvalue DVCFinInf.DV2.uvalue t1 (fin_to_inf_uvalue f1)
+                                         (@map DVCFinInf.DV1.dvalue DVCFinInf.DV2.dvalue fin_to_inf_dvalue args1)))
+                                   (fun x0 : DVCFinInf.DV2.dvalue =>
                                     get_inf_tree_L4
-                                      (let H4 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x0 in
-                                       match H4 return (itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) with
+                                      (let H2 : OOM DVCInfFin.DV2.dvalue := DVCInfFin.dvalue_convert_strict x0 in
+                                       match
+                                         H2
+                                         return
+                                           (itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                       with
                                        | @NoOom _ d => (fun d0 : DVCInfFin.DV2.dvalue => k1 d0) d
                                        | @Oom _ s =>
                                            (fun s0 : string =>
-                                            @raiseOOM L4
-                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)))) ExternalCallE
-                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME)))
-                                              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))) s0)
+                                            @raiseOOM (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue) (@OOME_L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                              (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))
+                                              s0)
                                              s
                                        end))))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 t0 f0 args0)
+                             X0 H0 k0 X2)
+                          X0 H1)
+                         H t0 f0 args0)
                         t f args
-                  | @IO_stdout str =>
-                      (fun (str0 : list int8) (H1 : @eq Type unit X0) =>
-                       (fun H2 : @eq Type unit X0 =>
-                        let H3 : @eq Type unit X0 := H2 in
+                  | @IO_stdout _ _ str =>
+                      (fun (str0 : list int8) (H : @eq Type unit X0) =>
+                       (fun H0 : @eq Type unit X0 =>
+                        let H1 : @eq Type unit X0 := H0 in
                         @eq_rect Type unit
                           (fun _ : Type =>
                            forall _ : list int8,
-                           itree InfLP.Events.L4
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           (fun str1 : list int8 =>
                            @eq_rect Type unit
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L4
+                             (fun X3 : Type =>
+                              forall
+                                (_ : forall _ : X3,
+                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                       (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X3),
+                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : unit, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE unit) =>
-                              @go InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                             (fun
+                                (k1 : forall _ : unit,
+                                      itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue unit) =>
+                              @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                (@VisF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L4
+                                      (prod store_id
+                                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                   (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                         (prod store_id
+                                            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                    unit
-                                   (@subevent E1.ExternalCallE InfLP.Events.L4
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE)) unit
-                                      (E1.IO_stdout str1))
-                                   (fun H4 : unit =>
+                                   (@subevent (ExternalCallE ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                      (@ExternalCallE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) unit
+                                      (@IO_stdout ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue str1))
+                                   (fun H2 : unit =>
                                     match
-                                      H4
+                                      H2
                                       return
-                                        (itree InfLP.Events.L4
+                                        (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                     with
                                     | @tt => get_inf_tree_L4 (k1 tt)
                                     end)))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 str0)
+                             X0 H0 k0 X2)
+                          X0 H1)
+                         H str0)
                         str
-                  | @IO_stderr str =>
-                      (fun (str0 : list int8) (H1 : @eq Type unit X0) =>
-                       (fun H2 : @eq Type unit X0 =>
-                        let H3 : @eq Type unit X0 := H2 in
+                  | @IO_stderr _ _ str =>
+                      (fun (str0 : list int8) (H : @eq Type unit X0) =>
+                       (fun H0 : @eq Type unit X0 =>
+                        let H1 : @eq Type unit X0 := H0 in
                         @eq_rect Type unit
                           (fun _ : Type =>
                            forall _ : list int8,
-                           itree InfLP.Events.L4
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           (fun str1 : list int8 =>
                            @eq_rect Type unit
-                             (fun X1 : Type =>
-                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE X1),
-                              itree InfLP.Events.L4
+                             (fun X3 : Type =>
+                              forall
+                                (_ : forall _ : X3,
+                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                       (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue X3),
+                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                             (fun (k1 : forall _ : unit, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : ExternalCallE unit) =>
-                              @go InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                             (fun
+                                (k1 : forall _ : unit,
+                                      itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                        (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                (_ : ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue unit) =>
+                              @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                (@VisF InfLP.Events.L4
+                                   (prod store_id
+                                      (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                (@VisF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                   (itree InfLP.Events.L4
+                                      (prod store_id
+                                         (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                   (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                         (prod store_id
+                                            (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                    unit
-                                   (@subevent E1.ExternalCallE InfLP.Events.L4
-                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 E1.ExternalCallE InfLP.Events.ExternalCallE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InfLP.Events.ExternalCallE)) unit
-                                      (E1.IO_stderr str1))
-                                   (fun H4 : unit =>
+                                   (@subevent (ExternalCallE ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                      (@ExternalCallE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) unit
+                                      (@IO_stderr ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue str1))
+                                   (fun H2 : unit =>
                                     match
-                                      H4
+                                      H2
                                       return
-                                        (itree InfLP.Events.L4
+                                        (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                              (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                              (prod store_id
+                                                 (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                    (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                     with
                                     | @tt => get_inf_tree_L4 (k1 tt)
                                     end)))
-                             X0 H2 k0 H0)
-                          X0 H3)
-                         H1 str0)
+                             X0 H0 k0 X2)
+                          X0 H1)
+                         H str0)
                         str
                   end in
-                X1 (@eq_refl Type X0)) H) x
+                X3 (@eq_refl Type X0)) X1) x
           | @inr1 _ _ _ x =>
-              (fun H : sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
-               (fun H0 : sum1 OOME (sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
+              (fun H : sum1 OOME (sum1 (LLVMExcE ECFinInf.DV1.uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
+               (fun H0 : sum1 OOME (sum1 (LLVMExcE ECFinInf.DV1.uvalue) (sum1 UBE (sum1 DebugE FailureE))) X0 =>
                 let X1 :
-                  itree InfLP.Events.L4
-                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                  itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                       (prod store_id
+                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                   match
                     H0
                     return
-                      (itree InfLP.Events.L4
-                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                      (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                            (prod store_id
+                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                   with
                   | @inl1 _ _ _ x0 =>
                       (fun H1 : OOME X0 =>
@@ -30225,16 +31024,21 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                         let X1 :
                           (fun T : Type =>
                            forall _ : @eq Type T X0,
-                           itree InfLP.Events.L4
-                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                                (prod store_id
+                                   (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                             X0 :=
                           match
                             H2 in (OOME T)
                             return
                               (forall _ : @eq Type T X0,
-                               itree InfLP.Events.L4
+                               itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           with
                           | @ThrowOOM x1 =>
                               (fun (H3 : unit) (H4 : @eq Type Empty_set X0) =>
@@ -30243,22 +31047,34 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 @eq_rect Type Empty_set
                                   (fun _ : Type =>
                                    forall _ : unit,
-                                   itree InfLP.Events.L4
+                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   (fun _ : unit =>
                                    @eq_rect Type Empty_set
                                      (fun X1 : Type =>
-                                      forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : OOME X1),
-                                      itree InfLP.Events.L4
+                                      forall
+                                        (_ : forall _ : X1,
+                                             itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : OOME X1),
+                                      itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                     (fun (_ : forall _ : Empty_set, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : OOME Empty_set) =>
-                                      @raiseOOM InfLP.Events.L4
-                                        (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 OOME (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                           (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun OOME)))
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                     (fun
+                                        (_ : forall _ : Empty_set,
+                                             itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                               (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                        (_ : OOME Empty_set) =>
+                                      @raiseOOM (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) (@OOME_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                           (prod store_id
+                                              (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
                                         EmptyString)
                                      X0 H5 k0 H2)
                                   X0 H6)
@@ -30267,61 +31083,88 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                           end in
                         X1 (@eq_refl Type X0)) H1) x0
                   | @inr1 _ _ _ x0 =>
-                      (fun H1 : sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
-                       (fun H2 : sum1 (LLVMExcE uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
+                      (fun H1 : sum1 (LLVMExcE ECFinInf.DV1.uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
+                       (fun H2 : sum1 (LLVMExcE ECFinInf.DV1.uvalue) (sum1 UBE (sum1 DebugE FailureE)) X0 =>
                         let X1 :
-                          itree InfLP.Events.L4
-                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                          itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                            (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
+                               (prod store_id
+                                  (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                           match
                             H2
                             return
-                              (itree InfLP.Events.L4
+                              (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                    (prod store_id
+                                       (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                           with
                           | @inl1 _ _ _ x1 =>
-                              (fun H3 : LLVMExcE uvalue X0 =>
-                               (fun H4 : LLVMExcE uvalue X0 =>
+                              (fun H3 : LLVMExcE ECFinInf.DV1.uvalue X0 =>
+                               (fun H4 : LLVMExcE ECFinInf.DV1.uvalue X0 =>
                                 let X1 :
                                   (fun T : Type =>
                                    forall _ : @eq Type T X0,
-                                   itree InfLP.Events.L4
+                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                        (prod store_id
+                                           (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                     X0 :=
                                   match
                                     H4 in (LLVMExcE _ T)
                                     return
                                       (forall _ : @eq Type T X0,
-                                       itree InfLP.Events.L4
+                                       itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                            (prod store_id
+                                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   with
                                   | @LLVMExc _ x2 =>
-                                      (fun (H5 : uvalue) (H6 : @eq Type Empty_set X0) =>
+                                      (fun (H5 : ECFinInf.DV1.uvalue) (H6 : @eq Type Empty_set X0) =>
                                        (fun H7 : @eq Type Empty_set X0 =>
                                         let H8 : @eq Type Empty_set X0 := H7 in
                                         @eq_rect Type Empty_set
                                           (fun _ : Type =>
-                                           forall _ : uvalue,
-                                           itree InfLP.Events.L4
+                                           forall _ : ECFinInf.DV1.uvalue,
+                                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                          (fun H9 : uvalue =>
+                                                (prod store_id
+                                                   (prod
+                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                          (fun H9 : ECFinInf.DV1.uvalue =>
                                            @eq_rect Type Empty_set
                                              (fun X1 : Type =>
-                                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : LLVMExcE uvalue X1),
-                                              itree InfLP.Events.L4
+                                              forall
+                                                (_ : forall _ : X1,
+                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                (_ : LLVMExcE ECFinInf.DV1.uvalue X1),
+                                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                             (fun (_ : forall _ : Empty_set, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : LLVMExcE uvalue Empty_set) =>
-                                              @raiseLLVM InfLP.Events.L4 DVCFinInf.DV2.uvalue
+                                                   (prod store_id
+                                                      (prod
+                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                             (fun
+                                                (_ : forall _ : Empty_set,
+                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                (_ : LLVMExcE ECFinInf.DV1.uvalue Empty_set) =>
+                                              @raiseLLVM (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) DVCFinInf.DV2.uvalue
                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                                   (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                      (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 (LLVMExcE DVCFinInf.DV2.uvalue) (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (LLVMExcE InfLP.Events.DV.uvalue)))))
-                                                (fin_to_inf_uvalue H9))
+                                                   (prod store_id
+                                                      (prod
+                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                (@LLVMExcE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) (fin_to_inf_uvalue H9))
                                              X0 H7 k0 H4)
                                           X0 H8)
                                          H6 H5)
@@ -30332,15 +31175,19 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                               (fun H3 : sum1 UBE (sum1 DebugE FailureE) X0 =>
                                (fun H4 : sum1 UBE (sum1 DebugE FailureE) X0 =>
                                 let X1 :
-                                  itree InfLP.Events.L4
+                                  itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                     (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                       (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                       (prod store_id
+                                          (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                             (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                   match
                                     H4
                                     return
-                                      (itree InfLP.Events.L4
+                                      (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                            (prod store_id
+                                               (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                   with
                                   | @inl1 _ _ _ x2 =>
                                       (fun H5 : UBE X0 =>
@@ -30348,17 +31195,24 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                         let X1 :
                                           (fun T : Type =>
                                            forall _ : @eq Type T X0,
-                                           itree InfLP.Events.L4
+                                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                (prod store_id
+                                                   (prod
+                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                             X0 :=
                                           match
                                             H6 in (UBE T)
                                             return
                                               (forall _ : @eq Type T X0,
-                                               itree InfLP.Events.L4
+                                               itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                    (prod store_id
+                                                       (prod
+                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           with
                                           | @ThrowUB x3 =>
                                               (fun (H7 : unit) (H8 : @eq Type Empty_set X0) =>
@@ -30367,24 +31221,45 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                 @eq_rect Type Empty_set
                                                   (fun _ : Type =>
                                                    forall _ : unit,
-                                                   itree InfLP.Events.L4
+                                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   (fun _ : unit =>
                                                    @eq_rect Type Empty_set
                                                      (fun X1 : Type =>
-                                                      forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : UBE X1),
-                                                      itree InfLP.Events.L4
+                                                      forall
+                                                        (_ : forall _ : X1,
+                                                             itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                        (_ : UBE X1),
+                                                      itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                     (fun (_ : forall _ : Empty_set, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : UBE Empty_set) =>
-                                                      @raiseUB InfLP.Events.L4
-                                                        (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                                           (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                              (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 UBE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                 (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 UBE UBE (sum1 DebugE FailureE) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun UBE)))))
+                                                           (prod store_id
+                                                              (prod
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                    InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                     (fun
+                                                        (_ : forall _ : Empty_set,
+                                                             itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                               (prod FinMem.MMEP.MMSP.MemState
+                                                                  (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                        (_ : UBE Empty_set) =>
+                                                      @raiseUB (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                                        (@UBE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                         (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                           (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
+                                                           (prod store_id
+                                                              (prod
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                    InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                 (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                    InterpreterStackBigIntptr.LP.DV.dvalue))))
                                                         EmptyString)
                                                      X0 H9 k0 H6)
                                                   X0 H10)
@@ -30396,15 +31271,22 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                       (fun H5 : sum1 DebugE FailureE X0 =>
                                        (fun H6 : sum1 DebugE FailureE X0 =>
                                         let X1 :
-                                          itree InfLP.Events.L4
+                                          itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                             (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                               (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))) :=
+                                               (prod store_id
+                                                  (prod
+                                                     (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                     (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))) :=
                                           match
                                             H6
                                             return
-                                              (itree InfLP.Events.L4
+                                              (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                  (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                    (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                    (prod store_id
+                                                       (prod
+                                                          (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                             InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                          (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                           with
                                           | @inl1 _ _ _ x3 =>
                                               (fun H7 : DebugE X0 =>
@@ -30412,17 +31294,26 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                 let X1 :
                                                   (fun T : Type =>
                                                    forall _ : @eq Type T X0,
-                                                   itree InfLP.Events.L4
+                                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                     X0 :=
                                                   match
                                                     H8 in (DebugE T)
                                                     return
                                                       (forall _ : @eq Type T X0,
-                                                       itree InfLP.Events.L4
+                                                       itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                            (prod store_id
+                                                               (prod
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                     InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                     InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   with
                                                   | @Debug x4 =>
                                                       (fun (H9 : unit) (H10 : @eq Type unit X0) =>
@@ -30431,34 +31322,65 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                         @eq_rect Type unit
                                                           (fun _ : Type =>
                                                            forall _ : unit,
-                                                           itree InfLP.Events.L4
+                                                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           (fun H13 : unit =>
                                                            @eq_rect Type unit
                                                              (fun X1 : Type =>
-                                                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : DebugE X1),
-                                                              itree InfLP.Events.L4
+                                                              forall
+                                                                (_ : forall _ : X1,
+                                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : DebugE X1),
+                                                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                             (fun (k1 : forall _ : unit, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : DebugE unit) =>
-                                                              @go InfLP.Events.L4
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                             (fun
+                                                                (k1 : forall _ : unit,
+                                                                      itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                                        (prod FinMem.MMEP.MMSP.MemState
+                                                                           (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : DebugE unit) =>
+                                                              @go (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                (@VisF InfLP.Events.L4
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                (@VisF (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                    (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                      (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                   (itree InfLP.Events.L4
+                                                                      (prod store_id
+                                                                         (prod
+                                                                            (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                               InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                            (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                               InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                   (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                       (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                         (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                         (prod store_id
+                                                                            (prod
+                                                                               (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                                  InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                               (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                                  InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                                    unit
-                                                                   (@subevent DebugE InfLP.Events.L4
-                                                                      (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                                                         (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                            (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                               (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 DebugE (sum1 DebugE FailureE) UBE
-                                                                                  (@ReSum_inl (forall _ : Type, Type) IFun sum1 Cat_IFun Inl_sum1 DebugE DebugE FailureE (@ReSum_id (forall _ : Type, Type) IFun Id_IFun DebugE))))))
-                                                                      unit (Debug H13))
+                                                                   (@subevent DebugE (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
+                                                                      (@DebugE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) unit 
+                                                                      (Debug H13))
                                                                    (fun H14 : unit => get_inf_tree_L4 (k1 H14))))
                                                              X0 H11 k0 H8)
                                                           X0 H12)
@@ -30472,17 +31394,26 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                 let X1 :
                                                   (fun T : Type =>
                                                    forall _ : @eq Type T X0,
-                                                   itree InfLP.Events.L4
+                                                   itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                      (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                        (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                        (prod store_id
+                                                           (prod
+                                                              (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                 InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                              (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                     X0 :=
                                                   match
                                                     H8 in (FailureE T)
                                                     return
                                                       (forall _ : @eq Type T X0,
-                                                       itree InfLP.Events.L4
+                                                       itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                          (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                            (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                            (prod store_id
+                                                               (prod
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                     InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                  (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                     InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                   with
                                                   | @Throw x4 =>
                                                       (fun (H9 : unit) (H10 : @eq Type Empty_set X0) =>
@@ -30491,26 +31422,46 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                                         @eq_rect Type Empty_set
                                                           (fun _ : Type =>
                                                            forall _ : unit,
-                                                           itree InfLP.Events.L4
+                                                           itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                              (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
+                                                                (prod store_id
+                                                                   (prod
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                         InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                      (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                         InterpreterStackBigIntptr.LP.DV.dvalue)))))
                                                           (fun _ : unit =>
                                                            @eq_rect Type Empty_set
                                                              (fun X1 : Type =>
-                                                              forall (_ : forall _ : X1, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : FailureE X1),
-                                                              itree InfLP.Events.L4
+                                                              forall
+                                                                (_ : forall _ : X1,
+                                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : FailureE X1),
+                                                              itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue)))))
-                                                             (fun (_ : forall _ : Empty_set, itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue))))) (_ : FailureE Empty_set) =>
-                                                              @LLVMEvents.raise InfLP.Events.L4
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue)))))
+                                                             (fun
+                                                                (_ : forall _ : Empty_set,
+                                                                     itree (L4 ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)
+                                                                       (prod FinMem.MMEP.MMSP.MemState
+                                                                          (prod store_id (prod (prod lstack_frame lstack) (prod global_env dvalue)))))
+                                                                (_ : FailureE Empty_set) =>
+                                                              @LLVMEvents.raise (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
                                                                 (prod InterpreterStackBigIntptr.LLVM.MEM.MMEP.MMSP.MemState
-                                                                   (prod store_id (prod (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame InterpreterStackBigIntptr.LLVM.Stack.lstack) (prod InterpreterStackBigIntptr.LLVM.Global.global_env InterpreterStackBigIntptr.LP.Events.DV.dvalue))))
-                                                                (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 OOME (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) InfLP.Events.ExternalCallE
-                                                                   (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 (LLVMExcE InfLP.Events.DV.uvalue) (sum1 UBE (sum1 DebugE FailureE))) OOME
-                                                                      (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 UBE (sum1 DebugE FailureE)) (LLVMExcE InfLP.Events.DV.uvalue)
-                                                                         (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE (sum1 DebugE FailureE) UBE
-                                                                            (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE FailureE DebugE (@ReSum_id (forall _ : Type, Type) IFun Id_IFun FailureE))))))
-                                                                EmptyString)
+                                                                   (prod store_id
+                                                                      (prod
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Stack.lstack_frame
+                                                                            InterpreterStackBigIntptr.LLVM.Stack.lstack)
+                                                                         (prod InterpreterStackBigIntptr.LLVM.Global.global_env
+                                                                            InterpreterStackBigIntptr.LP.DV.dvalue))))
+                                                                (@FailureE_L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) EmptyString)
                                                              X0 H11 k0 H8)
                                                           X0 H12)
                                                          H10 H9)
@@ -30528,7 +31479,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           end in
         X1) X e k
    end.
-
+    
   Lemma get_inf_tree_L4_equation :
     forall t_fin2,
       get_inf_tree_L4 t_fin2 ≅ _get_inf_tree_L4 (observe t_fin2).
@@ -30735,8 +31686,8 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
         pstep; red; cbn.
 
         change (inr1 (inl1 (ThrowOOM u))) with (@subevent _ _ (ReSum_inr IFun sum1 OOME
-                                                                 (OOME +' LLVMExcE uvalue  +' UBE +' DebugE +' FailureE)
-                                                                 ExternalCallE) _ (ThrowOOM u)).
+                                                                 (OOME +' LLVMExcE ECFinInf.DV1.uvalue +' UBE +' DebugE +' FailureE)
+                                                                 (@ExternalCallE ECFinInf.DV1.dvalue ECFinInf.DV1.uvalue)) _ (ThrowOOM u)).
 
         apply EqVisOOM.
       }
@@ -31501,10 +32452,10 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   Qed.
 
   Lemma model_undef_h_fin_inf :
-    forall (t_fin : itree (FinLP.Events.ExternalCallE +' PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE)
+    forall (t_fin : itree ((@ExternalCallE _ _) +' (@PickUvalueE _ _) +' OOME +' _ +' UBE +' DebugE +' FailureE)
                  (MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1))))
-      (t_inf : itree InfLP.Events.L3 TopLevelBigIntptr.res_L6)
-      (t_fin' : itree L4 (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1))))
+      (t_inf : itree ECInfFin.L31 TopLevelBigIntptr.res_L6)
+      (t_fin' : itree (@L4 _ _) (FinMem.MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1))))
       (REL: orutt (OOM:=OOME) L3_refine_strict L3_res_refine_strict
               (MemState_refine_prop
                  × (eq
@@ -31653,9 +32604,9 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                             (case_ InfLLVM.Pick.PickUvalue_handler
                                (InfLLVM.Pick.F_trigger_prop (F:=OOME +' _ +' UBE +' DebugE +' FailureE))))
                          TLR_INF.R.refine_res3
-                         (@InfLLVM.Pick.model_undef_k_spec InfLP.Events.ExternalCallE
+                         (@InfLLVM.Pick.model_undef_k_spec (@ExternalCallE _ _)
                             (OOME +' _ +' UBE +' DebugE +' FailureE)
-                            (ReSum_inr IFun sum1 UBE (OOME +' _ +' UBE +' DebugE +' FailureE) InfLP.Events.ExternalCallE))
+                            (ReSum_inr IFun sum1 UBE (OOME +' _ +' UBE +' DebugE +' FailureE) (@ExternalCallE _ _)))
                          true true false true) r (Vis e1 k1) (get_inf_tree_L4 (Tau t0))) by eauto.
             pstep; red; cbn.
             constructor; eauto.
@@ -31908,11 +32859,11 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                  (case_ InfLLVM.Pick.PickUvalue_handler
                     (InfLLVM.Pick.F_trigger_prop (F:=OOME +' _ +' UBE +' DebugE +' FailureE))))
               TLR_INF.R.refine_res3
-              (@InfLLVM.Pick.model_undef_k_spec InfLP.Events.ExternalCallE
+              (@InfLLVM.Pick.model_undef_k_spec (@ExternalCallE _ _)
                  (OOME +' _ +' UBE +' DebugE +' FailureE)
                  (ReSum_inr IFun sum1 UBE (OOME +' _ +' UBE +' DebugE +' FailureE)
-                    InfLP.Events.ExternalCallE)) true true false true) r
-           (Vis (inl1 (InterpreterStackBigIntptr.LP.Events.IO_stdout str0)) k1)
+                    (@ExternalCallE _ _))) true true false true) r
+           (Vis (inl1 (IO_stdout str0)) k1)
            (get_inf_tree_L4 (Tau {| _observe := observe t1 |}))).
                   { inv H. eapply IHKS; eauto.
                     constructor.
@@ -32022,11 +32973,11 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                  (case_ InfLLVM.Pick.PickUvalue_handler
                     (InfLLVM.Pick.F_trigger_prop (F:=OOME +' _ +' UBE +' DebugE +' FailureE))))
               TLR_INF.R.refine_res3
-              (@InfLLVM.Pick.model_undef_k_spec InfLP.Events.ExternalCallE
+              (@InfLLVM.Pick.model_undef_k_spec (@ExternalCallE _ _)
                  (OOME +' _ +' UBE +' DebugE +' FailureE)
                  (ReSum_inr IFun sum1 UBE (OOME +' _ +' UBE +' DebugE +' FailureE)
-                    InfLP.Events.ExternalCallE)) true true false true) r
-           (Vis (inl1 (InterpreterStackBigIntptr.LP.Events.IO_stderr str0)) k1)
+                    (@ExternalCallE _ _))) true true false true) r
+           (Vis (inl1 (IO_stderr str0)) k1)
            (get_inf_tree_L4 (Tau {| _observe := observe t1 |}))).
                   { inv H.
                     eapply IHKS; eauto.
@@ -32086,7 +33037,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                         eapply ContainsUB.FindUB
                           with (s:=tt)
                                (k:=(fun x2 : void =>
-                                      match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                                      match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                                       end)).
                         rewrite subevent_subevent.
                         unfold print_msg.
@@ -32170,7 +33121,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     eapply Interp_Prop_OomT_Vis
                       with (ta:=Ret
                                   (exist
-                                     (fun _ : LLVMParamsBigIntptr.Events.DV.dvalue => True)
+                                     (fun _ : LLVMParamsBigIntptr.DV.dvalue => True)
                                      (fin_to_inf_dvalue res0) I))
                            (k2:=(fun dv_inf =>
                                    match DVCInfFin.dvalue_convert_strict (proj1_sig dv_inf) with
@@ -32252,7 +33203,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     eapply ContainsUB.FindUB
                       with (s:=tt)
                            (k:=(fun x2 : void =>
-                                  match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                                  match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                                   end)).
                     rewrite subevent_subevent.
                     reflexivity.
@@ -32301,7 +33252,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 eapply ContainsUB.FindUB
                   with (s:=tt)
                        (k:=(fun x2 : void =>
-                              match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                              match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                               end)).
                 rewrite subevent_subevent.
                 reflexivity.
@@ -32348,7 +33299,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                         eapply ContainsUB.FindUB
                           with (s:=tt)
                                (k:=(fun x2 : void =>
-                                      match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                                      match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                                       end)).
                         rewrite subevent_subevent.
                         reflexivity.
@@ -32431,7 +33382,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     eapply Interp_Prop_OomT_Vis
                       with (ta:=Ret
                                   (exist
-                                     (fun _ : LLVMParamsBigIntptr.Events.DV.dvalue => True)
+                                     (fun _ : LLVMParamsBigIntptr.DV.dvalue => True)
                                      (fin_to_inf_dvalue res0) I))
                            (k2:=(fun dv_inf =>
                                    match DVCInfFin.dvalue_convert_strict (proj1_sig dv_inf) with
@@ -32513,7 +33464,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     eapply ContainsUB.FindUB
                       with (s:=tt)
                            (k:=(fun x2 : void =>
-                                  match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                                  match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                                   end)).
                     rewrite subevent_subevent.
                     reflexivity.
@@ -32562,12 +33513,11 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 eapply ContainsUB.FindUB
                   with (s:=tt)
                        (k:=(fun x2 : void =>
-                              match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                              match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                               end)).
                 rewrite subevent_subevent.
                 reflexivity.
               }
-
               { (* Pick *)
                 inv HSPEC; subst_existT.
                 red in KS.
@@ -32607,7 +33557,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                       eapply ContainsUB.FindUB
                         with (s:=tt)
                              (k:=(fun x2 : void =>
-                                    match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                                    match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                                     end)).
                       rewrite subevent_subevent.
                       reflexivity.
@@ -32675,7 +33625,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                     eapply ContainsUB.FindUB
                       with (s:=tt)
                            (k:=(fun x2 : void =>
-                                  match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                                  match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                                   end)).
                     rewrite subevent_subevent.
                     reflexivity.
@@ -32766,7 +33716,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                   eapply Interp_Prop_OomT_Vis
                     with (ta:=Ret
                                 (exist
-                                   (fun _ : LLVMParamsBigIntptr.Events.DV.dvalue => True)
+                                   (fun _ : LLVMParamsBigIntptr.DV.dvalue => True)
                                    (fin_to_inf_dvalue res0) I))
                          (k2:=(fun dv_inf =>
                                  match DVCInfFin.dvalue_convert_strict (proj1_sig dv_inf) with
@@ -32915,12 +33865,13 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               cbn.
 
               eapply Interp_Prop_OomT_Vis with
-                (ta:=(vis (inr1 (inl1 (ThrowUB tt))) (fun x : void => ret x)))
-                (k2:=(fun x1 : void => match x1 return (itree InfLP.Events.L4 TopLevelBigIntptr.res_L6) with
+                (ta:=(vis (inr1 (inr1 (inl1 (ThrowUB tt)))) (fun x : void => ret x)))
+                (k2:=(fun x1 : void => match x1 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) TopLevelBigIntptr.res_L6) with
                                     end)).
               2: {
                 repeat red.
                 setoid_rewrite bind_trigger.
+                cbn. 
                 eapply paco2_eqit_refl.
               }
 
@@ -33064,9 +34015,9 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 (case_ InfLLVM.Pick.PickUvalue_handler
                                    (InfLLVM.Pick.F_trigger_prop (F:=OOME +' _ +' UBE +' DebugE +' FailureE))))
                              TLR_INF.R.refine_res3
-                             (@InfLLVM.Pick.model_undef_k_spec InfLP.Events.ExternalCallE
+                             (@InfLLVM.Pick.model_undef_k_spec (@ExternalCallE _ _)
                                 (OOME +' _ +' UBE +' DebugE +' FailureE)
-                                (ReSum_inr IFun sum1 UBE (OOME +' _ +' UBE +' DebugE +' FailureE) InfLP.Events.ExternalCallE))
+                                (ReSum_inr IFun sum1 UBE (OOME +' _ +' UBE +' DebugE +' FailureE) (@ExternalCallE _ _)))
                              true true false true)
                           r
                           (Vis (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 (Debug tt))))))) k1) (get_inf_tree_L4 (Tau t1))).
@@ -33117,8 +34068,8 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 cbn.
                 observe_vis_r.
                 eapply Interp_Prop_OomT_Vis with
-                  (ta:=(vis (inr1 (inr1 (inr1 (Throw tt)))) (fun x1 : void => Ret x1)))
-                  (k2:=(fun x1 : void => match x1 return (itree InfLP.Events.L4 TopLevelBigIntptr.res_L6) with
+                  (ta:=(vis (inr1 (inr1 (inr1 (inr1 (Throw tt))))) (fun x1 : void => Ret x1)))
+                  (k2:=(fun x1 : void => match x1 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) TopLevelBigIntptr.res_L6) with
                                          end)).
                 2: {
                   repeat red.
@@ -33147,9 +34098,9 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                                 (case_ InfLLVM.Pick.PickUvalue_handler
                                    (InfLLVM.Pick.F_trigger_prop (F:=OOME +' _ +' UBE +' DebugE +' FailureE))))
                              TLR_INF.R.refine_res3
-                             (@InfLLVM.Pick.model_undef_k_spec InfLP.Events.ExternalCallE
+                             (@InfLLVM.Pick.model_undef_k_spec (@ExternalCallE _ _)
                                 (OOME +' _ +' UBE +' DebugE +' FailureE)
-                                (ReSum_inr IFun sum1 UBE (OOME +' _ +' UBE +' DebugE +' FailureE) InfLP.Events.ExternalCallE))
+                                (ReSum_inr IFun sum1 UBE (OOME +' _ +' UBE +' DebugE +' FailureE) (@ExternalCallE _ _)))
                              true true false true)  r
                           (Vis (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (Throw u))))))) k1) (get_inf_tree_L4 (Tau t1))).
                 { eapply IHKS; eauto.
@@ -33200,9 +34151,9 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                (@ReSum_id (Type -> Type) IFun Id_IFun OOME))
             A e);;
        @ret
-         (itree (FinLP.Events.ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE))
+         (itree ((@ExternalCallE _ _) +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE))
          (@Monad_itree
-            (FinLP.Events.ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE))
+            ((@ExternalCallE _ _) +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE))
          A r)).
             apply HSPEC.
             clear HSPEC. rename H into HSPEC.
@@ -33300,7 +34251,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 repeat subst_existT.
               subst.
               exfalso.
-              remember (FinLP.Events.DV.DVALUE_None).
+              remember (FinLP.DV.DVALUE_None).
               clear Heqd.
               rewrite H4 in d.
               destruct d.
@@ -33336,8 +34287,8 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             + pstep; red; cbn.
               observe_vis_r.
               eapply Interp_Prop_OomT_Vis with
-                (ta:= trigger (E1.ExternalCall t (fin_to_inf_uvalue f) (map fin_to_inf_dvalue args)))
-                (k2:=(fun x3 : E1.DV.dvalue =>
+                (ta:= trigger ((@ExternalCall _ _) t (fin_to_inf_uvalue f) (map fin_to_inf_dvalue args)))
+                (k2:=(fun x3 : DV1.dvalue =>
                         get_inf_tree_L4
                           match DVCInfFin.dvalue_convert_strict x3 with
                           | NoOom a => k0 a
@@ -33496,7 +34447,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             + pstep; red; cbn.
               observe_vis_r.
               eapply Interp_Prop_OomT_Vis with
-                (ta:=trigger (E1.IO_stdout str))
+                (ta:=trigger (IO_stdout str))
                 (k2:=
                    (fun H5 : unit => match H5 with
                                   | tt => get_inf_tree_L4 (k0 tt)
@@ -33626,7 +34577,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             + pstep; red; cbn.
               observe_vis_r.
               eapply Interp_Prop_OomT_Vis with
-                (ta:=trigger (E1.IO_stderr str))
+                (ta:=trigger (IO_stderr str))
                 (k2:=
                    (fun H5 : unit => match H5 with
                                   | tt => get_inf_tree_L4 (k0 tt)
@@ -33787,7 +34738,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 eapply Interp_Prop_OomT_Vis
                   with (ta:=Ret
                               (exist
-                                 (fun _ : LLVMParamsBigIntptr.Events.DV.dvalue => True)
+                                 (fun _ : LLVMParamsBigIntptr.DV.dvalue => True)
                                  (fin_to_inf_dvalue res0) I))
                        (k2:=(fun dv_inf =>
                                match DVCInfFin.dvalue_convert_strict (proj1_sig dv_inf) with
@@ -33895,7 +34846,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               eapply ContainsUB.FindUB
                 with (s:=tt)
                      (k:=(fun x2 : void =>
-                            match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                            match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                             end)).
               rewrite subevent_subevent.
               reflexivity.
@@ -33943,7 +34894,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           eapply ContainsUB.FindUB
             with (s:=tt)
                  (k:=(fun x2 : void =>
-                        match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                        match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                         end)).
           rewrite subevent_subevent.
           reflexivity.
@@ -34035,7 +34986,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 eapply Interp_Prop_OomT_Vis
                   with (ta:=Ret
                               (exist
-                                 (fun _ : LLVMParamsBigIntptr.Events.DV.dvalue => True)
+                                 (fun _ : LLVMParamsBigIntptr.DV.dvalue => True)
                                  (fin_to_inf_dvalue res0) I))
                        (k2:=(fun dv_inf =>
                                match DVCInfFin.dvalue_convert_strict (proj1_sig dv_inf) with
@@ -34143,7 +35094,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               eapply ContainsUB.FindUB
                 with (s:=tt)
                      (k:=(fun x2 : void =>
-                            match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                            match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                             end)).
               rewrite subevent_subevent.
               reflexivity.
@@ -34191,7 +35142,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           eapply ContainsUB.FindUB
             with (s:=tt)
                  (k:=(fun x2 : void =>
-                        match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                        match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                         end)).
           rewrite subevent_subevent.
           reflexivity.
@@ -34255,7 +35206,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
                 eapply ContainsUB.FindUB
                   with (s:=tt)
                        (k:=(fun x2 : void =>
-                              match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                              match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                               end)).
                 rewrite subevent_subevent.
                 reflexivity.
@@ -34342,7 +35293,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
               eapply ContainsUB.FindUB
                 with (s:=tt)
                      (k:=(fun x2 : void =>
-                            match x2 return (itree InfLP.Events.L4 {_ : DVCInfFin.DV1.dvalue | True}) with
+                            match x2 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) {_ : DVCInfFin.DV1.dvalue | True}) with
                             end)).
               rewrite subevent_subevent.
               reflexivity.
@@ -34473,7 +35424,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             eapply Interp_Prop_OomT_Vis
               with (ta:=Ret
                           (exist
-                             (fun _ : LLVMParamsBigIntptr.Events.DV.dvalue => True)
+                             (fun _ : LLVMParamsBigIntptr.DV.dvalue => True)
                              (fin_to_inf_dvalue res0) I))
                    (k2:=(fun dv_inf =>
                            match DVCInfFin.dvalue_convert_strict (proj1_sig dv_inf) with
@@ -34607,7 +35558,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
         pstep; red; cbn.
         eapply Interp_Prop_OomT_Vis with
-          (k2:=(fun x1 : void => match x1 return (itree InfLP.Events.L4 TopLevelBigIntptr.res_L6) with
+          (k2:=(fun x1 : void => match x1 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) TopLevelBigIntptr.res_L6) with
                               end)).
         2: {
           repeat red.
@@ -34663,8 +35614,8 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
         pstep; red; cbn.
         eapply Interp_Prop_OomT_Vis with
-          (ta:=(vis (inr1 (inl1 (ThrowUB tt))) (fun x : void => ret x)))
-          (k2:=(fun x1 : void => match x1 return (itree InfLP.Events.L4 TopLevelBigIntptr.res_L6) with
+          (ta:=(vis (inr1 (inr1 (inl1 (ThrowUB tt)))) (fun x : void => ret x)))
+          (k2:=(fun x1 : void => match x1 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) TopLevelBigIntptr.res_L6) with
                               end)).
         2: {
           repeat red.
@@ -34829,7 +35780,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
         pstep; red; cbn.
         eapply Interp_Prop_OomT_Vis with
-          (k2:=(fun x1 : void => match x1 return (itree InfLP.Events.L4 TopLevelBigIntptr.res_L6) with
+          (k2:=(fun x1 : void => match x1 return (itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) TopLevelBigIntptr.res_L6) with
                               end)).
         2: {
           repeat red.
@@ -34902,10 +35853,10 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   (** Model UB *)
 
   Definition L5_E1E2_orutt_strict
-    (t1 : PropT InfLP.Events.L5 (InfMemMMSP.MemState *
-                                   (store_id * (InfLLVM.Stack.lstack_frame * InfLLVM.Stack.lstack * (InfLLVM.Global.global_env * InfLP.Events.DV.dvalue)))))
-    (t2 : PropT FinLP.Events.L5 (FinMemMMSP.MemState *
-                                   (store_id * (FinLLVM.Stack.lstack_frame * FinLLVM.Stack.lstack * (FinLLVM.Global.global_env * FinLP.Events.DV.dvalue)))))
+    (t1 : PropT (@L5 _ _) (InfMemMMSP.MemState *
+                                   (store_id * (InfLLVM.Stack.lstack_frame * InfLLVM.Stack.lstack * (InfLLVM.Global.global_env * InfLP.DV.dvalue)))))
+    (t2 : PropT (@L5 _ _) (FinMemMMSP.MemState *
+                                   (store_id * (FinLLVM.Stack.lstack_frame * FinLLVM.Stack.lstack * (FinLLVM.Global.global_env * FinLP.DV.dvalue)))))
     : Prop :=
     forall t', t2 t' ->
           (exists t, t1 t /\
@@ -34922,7 +35873,7 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
       (TopLevel64BitIntptr.model_oom_L5 TLR_FIN.R.refine_res2 TLR_FIN.R.refine_res3 args2 p2).
 
   Lemma orutt_L4_contains_UB :
-    forall (t_inf_ub : itree InfLP.Events.L4 TopLevelBigIntptr.res_L6) (t_fin_ub : itree FinLP.Events.L4 res_L6),
+    forall (t_inf_ub : itree (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue) TopLevelBigIntptr.res_L6) (t_fin_ub : itree (@L4 _ _) res_L6),
       orutt (OOM:=OOME) L4_refine_strict L4_res_refine_strict (MemState_refine_prop × (eq × (stack_frame_refine_strict × stack_refine_strict × (global_refine_strict × DVC1.dvalue_refine_strict)))) t_inf_ub t_fin_ub ->
       ContainsUB.contains_UB t_fin_ub ->
       ContainsUB.contains_UB t_inf_ub.
@@ -34961,13 +35912,13 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
             
             eapply ContainsUB.CrawlVis with (k:=k1).
             change 
-              (@inl1 InterpreterStackBigIntptr.LP.Events.ExternalCallE (OOME +' _ +' UBE +' DebugE +' FailureE)
-                 InterpreterStackBigIntptr.LP.Events.DV.dvalue
-                 (InterpreterStackBigIntptr.LP.Events.ExternalCall t f args))
+              (@inl1 (@ExternalCallE _ _) (OOME +' _ +' UBE +' DebugE +' FailureE)
+                 InterpreterStackBigIntptr.LP.DV.dvalue
+                 ((@ExternalCall _ _) t f args))
               with
-              (@subevent InterpreterStackBigIntptr.LP.Events.L4 InterpreterStackBigIntptr.LP.Events.L4
-                 (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InterpreterStackBigIntptr.LP.Events.L4)
-                 InterpreterStackBigIntptr.LP.Events.DV.dvalue (inl1 (InterpreterStackBigIntptr.LP.Events.ExternalCall t f args))).
+              (@subevent (@L4 _ _) (@L4 _ _)
+                 (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (@L4 _ _))
+                 InterpreterStackBigIntptr.LP.DV.dvalue (inl1 ((@ExternalCall _ _) t f args))).
             reflexivity.
 
             eapply IHUB.
@@ -34986,12 +35937,12 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
             eapply ContainsUB.CrawlVis with (x:=tt) (k:=k1).
             change 
-              (@inl1 InterpreterStackBigIntptr.LP.Events.ExternalCallE (OOME +' _ +' UBE +' DebugE +' FailureE) unit
-                 (InterpreterStackBigIntptr.LP.Events.IO_stdout str))
+              (@inl1 (@ExternalCallE _ _) (OOME +' _ +' UBE +' DebugE +' FailureE) unit
+                 (IO_stdout str))
               with
-              (@subevent InterpreterStackBigIntptr.LP.Events.L4 InterpreterStackBigIntptr.LP.Events.L4
-                 (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InterpreterStackBigIntptr.LP.Events.L4)
-                 unit (inl1 (InterpreterStackBigIntptr.LP.Events.IO_stdout str))).
+              (@subevent (@L4 _ _) (@L4 _ _)
+                 (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (@L4 DV1.dvalue DV1.uvalue))
+                 unit (inl1 (IO_stdout str))).
             reflexivity.
 
             eapply IHUB.
@@ -35010,12 +35961,12 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
             eapply ContainsUB.CrawlVis with (x:=tt) (k:=k1).
             change 
-              (@inl1 InterpreterStackBigIntptr.LP.Events.ExternalCallE (OOME +' _ +' UBE +' DebugE +' FailureE) unit
-                 (InterpreterStackBigIntptr.LP.Events.IO_stderr str))
+              (@inl1 (@ExternalCallE _ _) (OOME +' _ +' UBE +' DebugE +' FailureE) unit
+                 (IO_stderr str))
               with
-              (@subevent InterpreterStackBigIntptr.LP.Events.L4 InterpreterStackBigIntptr.LP.Events.L4
-                 (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InterpreterStackBigIntptr.LP.Events.L4)
-                 unit (inl1 (InterpreterStackBigIntptr.LP.Events.IO_stderr str))).
+              (@subevent (@L4 _ _) (@L4 _ _)
+                 (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (@L4 DV1.dvalue DV1.uvalue))
+                 unit (inl1 (IO_stderr str))).
             reflexivity.
 
             eapply IHUB.
@@ -35062,11 +36013,11 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
           eapply ContainsUB.CrawlVis with (k:=k1).
           change 
-            (@inr1 InterpreterStackBigIntptr.LP.Events.ExternalCallE (OOME +' LLVMExcE InterpreterStackBigIntptr.LP.Events.DV.uvalue +' UBE +' DebugE +' FailureE) unit
-               (@inr1 OOME (LLVMExcE InterpreterStackBigIntptr.LP.Events.DV.uvalue +' UBE +' DebugE +' FailureE) unit (@inr1 (LLVMExcE InterpreterStackBigIntptr.LP.Events.DV.uvalue) (UBE +' DebugE +' FailureE) unit (@inr1 UBE (DebugE +' FailureE) unit (@inl1 DebugE FailureE unit (Debug u0))))))
+            (@inr1 (@ExternalCallE _ _) (OOME +' LLVMExcE InterpreterStackBigIntptr.LP.DV.uvalue +' UBE +' DebugE +' FailureE) unit
+               (@inr1 OOME (LLVMExcE InterpreterStackBigIntptr.LP.DV.uvalue +' UBE +' DebugE +' FailureE) unit (@inr1 (LLVMExcE InterpreterStackBigIntptr.LP.DV.uvalue) (UBE +' DebugE +' FailureE) unit (@inr1 UBE (DebugE +' FailureE) unit (@inl1 DebugE FailureE unit (Debug u0))))))
             with
-            (@subevent InterpreterStackBigIntptr.LP.Events.L4 InterpreterStackBigIntptr.LP.Events.L4
-             (@ReSum_id (forall _ : Type, Type) IFun Id_IFun InterpreterStackBigIntptr.LP.Events.L4)
+            (@subevent (@L4 _ _) (@L4 _ _)
+             (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (@L4 DV1.dvalue DV1.uvalue))
              unit
              (inr1 (inr1 (inr1 (inr1 (inl1 (Debug u0))))))).
           reflexivity.
@@ -35102,14 +36053,14 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
         setoid_rewrite <- x.
         rewrite subevent_subevent.
         change 
-          (@inr1 InterpreterStackBigIntptr.LP.Events.ExternalCallE
-             (OOME +' LLVMExcE InterpreterStackBigIntptr.LP.Events.DV.uvalue +' UBE +' DebugE +' FailureE) void
+          (@inr1 (@ExternalCallE _ _)
+             (OOME +' LLVMExcE InterpreterStackBigIntptr.LP.DV.uvalue +' UBE +' DebugE +' FailureE) void
              (@inr1 OOME
-                (LLVMExcE InterpreterStackBigIntptr.LP.Events.DV.uvalue +' UBE +' DebugE +' FailureE) void
-                (@inr1 (LLVMExcE InterpreterStackBigIntptr.LP.Events.DV.uvalue) 
+                (LLVMExcE InterpreterStackBigIntptr.LP.DV.uvalue +' UBE +' DebugE +' FailureE) void
+                (@inr1 (LLVMExcE InterpreterStackBigIntptr.LP.DV.uvalue) 
                    (UBE +' DebugE +' FailureE) void (@inl1 UBE (DebugE +' FailureE) void (ThrowUB tt)))))
           with
-          (@subevent UBE InfLP.Events.L4
+          (@subevent UBE (L4 ECInfFin.DV1.dvalue ECInfFin.DV1.uvalue)
              _ _ (ThrowUB tt)).
         reflexivity.
       + rewrite itree_eta.
@@ -35165,8 +36116,8 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
   Qed.
 
   Definition L6_E1E2_orutt_strict
-    (t1 : PropT InfLP.Events.L6 (InfMemMMSP.MemState *
-                                   (store_id * (InfLLVM.Stack.lstack_frame * InfLLVM.Stack.lstack * (InfLLVM.Global.global_env * InfLP.Events.DV.dvalue)))))
+    (t1 : PropT (@L6 _ _)(InfMemMMSP.MemState *
+                                   (store_id * (InfLLVM.Stack.lstack_frame * InfLLVM.Stack.lstack * (InfLLVM.Global.global_env * InfLP.DV.dvalue)))))
     t2
     : Prop :=
     forall t', t2 t' ->
@@ -35185,11 +36136,11 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
 
   Lemma refine_OOM_h_orutt :
     forall
-      (t : itree InterpreterStackBigIntptr.LP.Events.L4
+      (t : itree (@L4 _ _)
              (InfMem.MMEP.MMSP.MemState *
                 (store_id *
                    (InterpreterStackBigIntptr.LLVM.Stack.lstack_frame * InterpreterStackBigIntptr.LLVM.Stack.lstack * TopLevelBigIntptr.res_L1))))
-      (t1 t2 : itree L4 (MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))),
+      (t1 t2 : itree (@L4 _ _) (MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1)))),
       refine_OOM_h eq t1 t2 ->
       orutt (OOM:=OOME) L4_refine_strict L4_res_refine_strict
         (MemState_refine_prop
@@ -35337,17 +36288,15 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
           destruct OOM.
           destruct e; inv H.
           change
-            (@inr1 ExternalCallE (OOME +' _ +' UBE +' DebugE +' FailureE) A
-               (@resum (Type -> Type) IFun OOME (OOME +' _ +' UBE +' DebugE +' FailureE)
-                  (@ReSum_inl (Type -> Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME
-                     (_ +' UBE +' DebugE +' FailureE) (@ReSum_id (Type -> Type) IFun Id_IFun OOME)) A x))
- with
-            (@subevent OOME L4
-         (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 OOME
-            (OOME +' _ +' UBE +' DebugE +' FailureE) ExternalCallE
+            (@inr1 (ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+               (sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) A
+               (@inl1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))) A x))
+            with
+            (@subevent OOME (@L4 DV2.dvalue DV2.uvalue)            
+               (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 OOME
+            (OOME +' _ +' UBE +' DebugE +' FailureE) (@ExternalCallE _ _)
             (@ReSum_inl (Type -> Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME
                (_ +' UBE +' DebugE +' FailureE) (@ReSum_id (Type -> Type) IFun Id_IFun OOME))) A x).
-
           pstep; red; cbn.
           constructor.
         }
@@ -35480,18 +36429,16 @@ cofix CIH (t_fin2 : itree L4 (prod FinMem.MMEP.MMSP.MemState (prod store_id (pro
         pinversion KS; repeat subst_existT.
         pstep; red; cbn.
         destruct e0; inv H4.
-        change
-          (@inr1 ExternalCallE (OOME +' _ +' UBE +' DebugE +' FailureE) A0
-             (@resum (Type -> Type) IFun OOME (OOME +' _ +' UBE +' DebugE +' FailureE)
-                (@ReSum_inl (Type -> Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME
-                   (_ +' UBE +' DebugE +' FailureE) (@ReSum_id (Type -> Type) IFun Id_IFun OOME)) A0 e))
-          with
-          (@subevent OOME L4
-             (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 OOME
-                (OOME +' _ +' UBE +' DebugE +' FailureE) ExternalCallE
-                (@ReSum_inl (Type -> Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME
-                   (_ +' UBE +' DebugE +' FailureE) (@ReSum_id (Type -> Type) IFun Id_IFun OOME))) A0 e).
-
+          change
+            (@inr1 (ExternalCallE DVCInfFin.DV2.dvalue DVCInfFin.DV2.uvalue)
+               (sum1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) A0
+               (@inl1 OOME (sum1 (LLVMExcE DVCInfFin.DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))) A0 e))
+            with
+            (@subevent OOME (@L4 DV2.dvalue DV2.uvalue)            
+               (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 OOME
+            (OOME +' _ +' UBE +' DebugE +' FailureE) (@ExternalCallE _ _)
+            (@ReSum_inl (Type -> Type) IFun sum1 Cat_IFun Inl_sum1 OOME OOME
+               (_ +' UBE +' DebugE +' FailureE) (@ReSum_id (Type -> Type) IFun Id_IFun OOME))) A0 e).
         apply OOMRutt.EqVisOOM.
     - (* EqTauL *)
       specialize (IHEQV REF).

--- a/src/rocq/Semantics/InfiniteToFinite/Conversions/DvalueConversions.v
+++ b/src/rocq/Semantics/InfiniteToFinite/Conversions/DvalueConversions.v
@@ -60,11 +60,11 @@ Import MonadNotation.
 Import ListNotations.
 
 
-Module Type DVConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) (Events1 : LLVM_INTERACTIONS LP1.ADDR LP1.IP LP1.SIZEOF) (Events2 : LLVM_INTERACTIONS LP2.ADDR LP2.IP LP2.SIZEOF).
+Module Type DVConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI).
   Import AC.
 
-  Module DV1 := Events1.DV.
-  Module DV2 := Events2.DV.
+  Module DV1 := LP1.DV.
+  Module DV2 := LP2.DV.
 
 (* TODO: Move into Dvalue *)
   Ltac solve_dvalue_measure :=
@@ -1039,12 +1039,12 @@ Module Type DVConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP
    *)
 End DVConvert.
 
-Module DVConvertMake (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) (Events1 : LLVM_INTERACTIONS LP1.ADDR LP1.IP LP1.SIZEOF) (Events2 : LLVM_INTERACTIONS LP2.ADDR LP2.IP LP2.SIZEOF) : DVConvert LP1 LP2 AC Events1 Events2
-with Module DV1 := Events1.DV
-with Module DV2 := Events2.DV.
+Module DVConvertMake (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) : DVConvert LP1 LP2 AC 
+with Module DV1 := LP1.DV
+with Module DV2 := LP2.DV.
   Import AC.
-  Module DV1 := Events1.DV.
-  Module DV2 := Events2.DV.
+  Module DV1 := LP1.DV.
+  Module DV2 := LP2.DV.
 
   (* TODO: Move into Dvalue *)
   Ltac solve_dvalue_measure :=
@@ -4442,16 +4442,15 @@ Lemma dvalue_refine_lazy_dvalue_convert_lazy :
 
 End DVConvertMake.
 
-Module DVCFinInf := DVConvertMake InterpreterStack64BitIntptr.LP InterpreterStackBigIntptr.LP FinToInfAddrConvert InterpreterStack64BitIntptr.LP.Events InterpreterStackBigIntptr.LP.Events.
-Module DVCInfFin := DVConvertMake InterpreterStackBigIntptr.LP InterpreterStack64BitIntptr.LP InfToFinAddrConvert InterpreterStackBigIntptr.LP.Events InterpreterStack64BitIntptr.LP.Events.
+Module DVCFinInf := DVConvertMake InterpreterStack64BitIntptr.LP InterpreterStackBigIntptr.LP FinToInfAddrConvert.
+Module DVCInfFin := DVConvertMake InterpreterStackBigIntptr.LP InterpreterStack64BitIntptr.LP InfToFinAddrConvert.
 
 Module DVConvertSafe
   (LP1 : LLVMParams) (LP2 : LLVMParams)
   (AC1 : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) (AC2 : AddrConvert LP2.ADDR LP2.PTOI LP1.ADDR LP1.PTOI)
   (ACSafe : AddrConvertSafe LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI AC1 AC2)
   (IPSafe : IPConvertSafe LP1.IP LP2.IP)
-  (Events1 : LLVM_INTERACTIONS LP1.ADDR LP1.IP LP1.SIZEOF) (Events2 : LLVM_INTERACTIONS LP2.ADDR LP2.IP LP2.SIZEOF)
-  (DVC1 : DVConvert LP1 LP2 AC1 Events1 Events2) (DVC2 : DVConvert LP2 LP1 AC2 Events2 Events1).
+  (DVC1 : DVConvert LP1 LP2 AC1) (DVC2 : DVConvert LP2 LP1 AC2).
   Import ACSafe.
   Import IPSafe.
 

--- a/src/rocq/Semantics/InfiniteToFinite/Conversions/EventConversions.v
+++ b/src/rocq/Semantics/InfiniteToFinite/Conversions/EventConversions.v
@@ -58,9 +58,60 @@ Import InterpFacts.
 Import MonadNotation.
 Import ListNotations.
 
-Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) (AC2 : AddrConvert LP2.ADDR LP2.PTOI LP1.ADDR LP1.PTOI) (E1 : LLVM_INTERACTIONS LP1.ADDR LP1.IP LP1.SIZEOF) (E2 : LLVM_INTERACTIONS LP2.ADDR LP2.IP LP2.SIZEOF) (DVC : DVConvert LP1 LP2 AC E1 E2) (DVCrev : DVConvert LP2 LP1 AC2 E2 E1).
+Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) (AC2 : AddrConvert LP2.ADDR LP2.PTOI LP1.ADDR LP1.PTOI) (DVC : DVConvert LP1 LP2 AC) (DVCrev : DVConvert LP2 LP1 AC2).
   Import DVC.
 
+  Module DV1 := LP1.DV.
+  Module DV2 := LP2.DV.
+
+  #[global]
+    Notation ExternalCallE1 := (ExternalCallE DV1.dvalue DV1.uvalue).
+  #[global]  
+    Notation ExternalCallE2 := (ExternalCallE DV2.dvalue DV2.uvalue).
+
+  #[global]  
+    Notation IntrinsicE1 := (IntrinsicE DV1.dvalue DV1.uvalue).  
+  #[global]
+    Notation IntrinsicE2 := (IntrinsicE DV2.dvalue DV2.uvalue).
+  #[global]
+    Notation MemoryE1 := (MemoryE DV1.dvalue DV1.uvalue).  
+  #[global]
+    Notation MemoryE2 := (MemoryE DV2.dvalue DV2.uvalue).
+  #[global]
+    Notation PickUvalueE1 := (PickUvalueE DV1.dvalue DV1.uvalue).  
+  #[global]
+    Notation PickUvalueE2 := (PickUvalueE DV2.dvalue DV2.uvalue).
+
+  #[global]
+    Notation L01 := (L0 DV1.dvalue DV1.uvalue).
+  #[global]  
+    Notation L02 := (L0 DV2.dvalue DV2.uvalue).
+  #[global]
+    Notation L11 := (L1 DV1.dvalue DV1.uvalue).
+  #[global]  
+    Notation L12 := (L1 DV2.dvalue DV2.uvalue).
+  #[global]
+    Notation L21 := (L2 DV1.dvalue DV1.uvalue).
+  #[global]  
+    Notation L22 := (L2 DV2.dvalue DV2.uvalue).
+  #[global]  
+    Notation L31 := (L3 DV1.dvalue DV1.uvalue).
+  #[global]  
+    Notation L32 := (L3 DV2.dvalue DV2.uvalue).
+  #[global]  
+    Notation L41 := (L4 DV1.dvalue DV1.uvalue).
+  #[global]
+    Notation L42 := (L4 DV2.dvalue DV2.uvalue).
+  #[global]
+    Notation L51 := (L5 DV1.dvalue DV1.uvalue).
+  #[global]
+    Notation L52 := (L5 DV2.dvalue DV2.uvalue).
+  #[global]
+    Notation L61 := (L6 DV1.dvalue DV1.uvalue).
+  #[global]
+    Notation L62 := (L6 DV2.dvalue DV2.uvalue).
+
+  
   Section CONVERSIONS.
     Context
       (dvalue_convert : DV1.dvalue -> OOM DV2.dvalue)
@@ -71,26 +122,26 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
     Section HANDLER_CONVERSIONS.
       Context {E} `{OOM_E : OOME -< E}.
 
-      Definition external_call_handler_convert `{E2.ExternalCallE -< E} : E1.ExternalCallE ~> itree E.
+      Definition external_call_handler_convert `{ExternalCallE2 -< E} : ExternalCallE1 ~> itree E.
         intros T e0.
         destruct e0.
         - (* ExternalCall *)
           refine (f' <- lift_OOM (uvalue_convert f);;
                   args' <- lift_OOM (map_monad_In args (fun elt Hin => dvalue_convert elt));;
-                  dv <- trigger (E2.ExternalCall t f' args');;
+                  dv <- trigger (ExternalCall t f' args');;
                   _).
           apply (lift_OOM (rev_dvalue_convert dv)).
         - (* Stdout *)
-          apply (trigger (E2.IO_stdout str)).
+          apply (trigger (IO_stdout str)).
         - (* Stderr *)
-          apply (trigger (E2.IO_stderr str)).
+          apply (trigger (IO_stderr str)).
       Defined.
 
-      Definition intrinsic_handler_convert `{E2.IntrinsicE -< E} : E1.IntrinsicE ~> itree E.
+      Definition intrinsic_handler_convert `{IntrinsicE2 -< E} : IntrinsicE1 ~> itree E.
         intros T i.
         inversion i; subst.
         refine (args' <- lift_OOM (map_monad_In args (fun elt Hin => dvalue_convert elt));;
-                rv <- trigger (E2.Intrinsic t f args');;
+                rv <- trigger (Intrinsic t f args');;
                 match rv with
                 | inl exc =>
                     exc' <- lift_OOM (rev_uvalue_convert exc);;
@@ -101,7 +152,7 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
                 end).
       Defined.
 
-      Definition global_handler_convert `{GlobalE LLVMAst.raw_id E2.DV.dvalue -< E} : GlobalE LLVMAst.raw_id E1.DV.dvalue ~> itree E.
+      Definition global_handler_convert `{GlobalE LLVMAst.raw_id DV2.dvalue -< E} : GlobalE LLVMAst.raw_id DV1.dvalue ~> itree E.
         (* Globals *)
         intros T e0.
         inversion e0.
@@ -113,7 +164,7 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
                  lift_OOM (rev_dvalue_convert dv)).
       Defined.
 
-      Definition local_handler_convert `{LocalE LLVMAst.raw_id E2.DV.uvalue -< E} : LocalE LLVMAst.raw_id E1.DV.uvalue ~> itree E.
+      Definition local_handler_convert `{LocalE LLVMAst.raw_id DV2.uvalue -< E} : LocalE LLVMAst.raw_id DV1.uvalue ~> itree E.
         (* Locals *)
         intros T e0.
         inversion e0.
@@ -126,8 +177,8 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
       Defined.
 
       Definition stack_handler_convert
-        `{StackE LLVMAst.raw_id E2.DV.uvalue E2.DV.uvalue -< E} :
-        StackE LLVMAst.raw_id E1.DV.uvalue E1.DV.uvalue ~> itree E.
+        `{StackE LLVMAst.raw_id DV2.uvalue DV2.uvalue -< E} :
+        StackE LLVMAst.raw_id DV1.uvalue DV1.uvalue ~> itree E.
         (* Stack *)
         intros T e0.
         inversion e0.
@@ -158,31 +209,31 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
       Defined.
 
       Definition memory_handler_convert
-        `{E2.MemoryE -< E} :
-        E1.MemoryE ~> itree E.
+        `{MemoryE2 -< E} :
+        MemoryE1 ~> itree E.
         (* MemoryE *)
         intros T e0.
         inversion e0.
         - (* MemPush *)
-          apply (trigger E2.MemPush).
+          apply (trigger MemPush).
         - (* MemPop *)
-          apply (trigger E2.MemPop).
+          apply (trigger MemPop).
         - (* Alloca *)
-          apply (ptr <- trigger (E2.Alloca t num_elements align);;
+          apply (ptr <- trigger (Alloca t num_elements align);;
                  lift_OOM (rev_dvalue_convert ptr)).
         - (* Load *)
           apply (a' <- lift_OOM (dvalue_convert a);;
-                 uv <- trigger (E2.Load t a');;
+                 uv <- trigger (Load t a');;
                  lift_OOM (rev_uvalue_convert uv)).
         - (* Store *)
           apply (a' <- lift_OOM (dvalue_convert a);;
                  v' <- lift_OOM (uvalue_convert v);;
-                 trigger (E2.Store t a' v')).
+                 trigger (Store t a' v')).
       Defined.
 
       Definition pick_handler_convert
-        `{E2.PickUvalueE -< E} :
-        E1.PickUvalueE ~> itree E.
+        `{PickUvalueE2 -< E} :
+        PickUvalueE1 ~> itree E.
         intros T e0.
         (* PickE *)
         (* TODO: confirm whether this is sane... *)
@@ -190,7 +241,7 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
         - (* pickUnique *)
           subst.
           refine (x' <- lift_OOM (uvalue_convert x);;
-                  dv <- trigger (E2.pickUnique x');;
+                  dv <- trigger (pickUnique x');;
                   _).
           destruct dv as [res _].
           apply (res' <- lift_OOM (rev_dvalue_convert res);;
@@ -198,7 +249,7 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
         - (* pickNonPoison *)
           subst.
           refine (x' <- lift_OOM (uvalue_convert x);;
-                  dv <- trigger (E2.pickNonPoison x');;
+                  dv <- trigger (pickNonPoison x');;
                   _).
           destruct dv as [res _].
           apply (res' <- lift_OOM (rev_dvalue_convert res);;
@@ -206,7 +257,7 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
         - (* pick *)
           subst.
           refine (x' <- lift_OOM (uvalue_convert x);;
-                  dv <- trigger (E2.pick x');;
+                  dv <- trigger (pick x');;
                   _).
           destruct dv as [res _].
           apply (res' <- lift_OOM (rev_dvalue_convert res);;
@@ -223,8 +274,8 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
       Defined.
 
       Definition llvm_exc_handler_convert
-        `{LLVMExcE E2.DV.uvalue -< E} :
-        LLVMExcE E1.DV.uvalue ~> itree E.
+        `{LLVMExcE DV2.uvalue -< E} :
+        LLVMExcE DV1.uvalue ~> itree E.
         (* LLVMExcE *)
         intros T e0.
         inversion e0.
@@ -259,8 +310,10 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
       Defined.
     End HANDLER_CONVERSIONS.
 
+
+    
     Definition L0_convert_helper
-      : Handler E1.L0 E2.L0.
+      : Handler L01 L02.
       refine (fun A e => _).
 
       refine (match e with
@@ -291,8 +344,10 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
               end).
     Defined.
 
+
+
     Definition L1_convert_helper
-      : Handler E1.L1 E2.L1.
+      : Handler L11 L12.
       refine (fun A e => _).
 
       refine (match e with
@@ -321,8 +376,9 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
               end).
     Defined.
 
+    
     Definition L2_convert_helper
-      : Handler E1.L2 E2.L2.
+      : Handler L21 L22.
       refine (fun A e => _).
 
       refine (match e with
@@ -347,8 +403,9 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
               end).
     Defined.
 
+    
     Definition L3_convert_helper
-      : Handler E1.L3 E2.L3.
+      : Handler L31 L32.
       refine (fun A e => _).
 
       refine (match e with
@@ -369,8 +426,9 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
               end).
     Defined.
 
+    
     Definition L4_convert_helper
-      : Handler E1.L4 E2.L4.
+      : Handler L41 L42.
       refine (fun A e => _).
 
       refine (match e with
@@ -389,11 +447,13 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
               end).
     Defined.
 
+    
     Definition L5_convert_helper
-      : Handler E1.L5 E2.L5 := L4_convert_helper.
+      : Handler L51 L52 := L4_convert_helper.
+
 
     Definition L6_convert_helper
-      : Handler E1.L6 E2.L6 := L5_convert_helper.
+      : Handler L61 L62 := L4_convert_helper.
   End CONVERSIONS.
 
     (*
@@ -406,30 +466,29 @@ Module Type EventConvert (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert
   Definition L6_convert_lazy : Handler E1.L6 E2.L6 := L6_convert_helper (ret ∘ dvalue_convert_lazy) (ret ∘ uvalue_convert_lazy) (ret ∘ DVCrev.dvalue_convert_lazy) (ret ∘ DVCrev.uvalue_convert_lazy).
      *)
 
-    Definition L0_convert_strict : Handler E1.L0 E2.L0 := L0_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict DVCrev.uvalue_convert_strict.
-    Definition L1_convert_strict : Handler E1.L1 E2.L1 := L1_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict DVCrev.uvalue_convert_strict.
-    Definition L2_convert_strict : Handler E1.L2 E2.L2 := L2_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict DVCrev.uvalue_convert_strict.
-    Definition L3_convert_strict : Handler E1.L3 E2.L3 := L3_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict.
-    Definition L4_convert_strict : Handler E1.L4 E2.L4 := L4_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict.
-    Definition L5_convert_strict : Handler E1.L5 E2.L5 := L5_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict.
-    Definition L6_convert_strict : Handler E1.L6 E2.L6 := L6_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict.
+    Definition L0_convert_strict : Handler L01 L02 := L0_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict DVCrev.uvalue_convert_strict.
+    Definition L1_convert_strict : Handler L11 L12 := L1_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict DVCrev.uvalue_convert_strict.
+    Definition L2_convert_strict : Handler L21 L22 := L2_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict DVCrev.uvalue_convert_strict.
+    Definition L3_convert_strict : Handler L31 L32 := L3_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict.
+    Definition L4_convert_strict : Handler L41 L42 := L4_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict.
+    Definition L5_convert_strict : Handler L51 L52 := L5_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict.
+    Definition L6_convert_strict : Handler L61 L62 := L6_convert_helper dvalue_convert_strict uvalue_convert_strict DVCrev.dvalue_convert_strict.
 End EventConvert.
 
-Module EventConvertMake (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) (AC2 : AddrConvert LP2.ADDR LP2.PTOI LP1.ADDR LP1.PTOI) (E1 : LLVM_INTERACTIONS LP1.ADDR LP1.IP LP1.SIZEOF) (E2 : LLVM_INTERACTIONS LP2.ADDR LP2.IP LP2.SIZEOF) (DVC : DVConvert LP1 LP2 AC E1 E2) (DVCrev : DVConvert LP2 LP1 AC2 E2 E1) : EventConvert LP1 LP2 AC AC2 E1 E2 DVC DVCrev.
-  Include EventConvert LP1 LP2 AC AC2 E1 E2 DVC DVCrev.
+Module EventConvertMake (LP1 : LLVMParams) (LP2 : LLVMParams) (AC : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) (AC2 : AddrConvert LP2.ADDR LP2.PTOI LP1.ADDR LP1.PTOI) (DVC : DVConvert LP1 LP2 AC) (DVCrev : DVConvert LP2 LP1 AC2) : EventConvert LP1 LP2 AC AC2 DVC DVCrev.
+  Include EventConvert LP1 LP2 AC AC2 DVC DVCrev.
 End EventConvertMake.
 
-Module ECFinInf := EventConvertMake InterpreterStack64BitIntptr.LP InterpreterStackBigIntptr.LP FinToInfAddrConvert InfToFinAddrConvert InterpreterStack64BitIntptr.LP.Events InterpreterStackBigIntptr.LP.Events DVCFinInf DVCInfFin.
-Module ECInfFin := EventConvertMake InterpreterStackBigIntptr.LP InterpreterStack64BitIntptr.LP InfToFinAddrConvert FinToInfAddrConvert InterpreterStackBigIntptr.LP.Events InterpreterStack64BitIntptr.LP.Events DVCInfFin DVCFinInf.
+Module ECFinInf := EventConvertMake InterpreterStack64BitIntptr.LP InterpreterStackBigIntptr.LP FinToInfAddrConvert InfToFinAddrConvert DVCFinInf DVCInfFin.
+Module ECInfFin := EventConvertMake InterpreterStackBigIntptr.LP InterpreterStack64BitIntptr.LP InfToFinAddrConvert FinToInfAddrConvert DVCInfFin DVCFinInf.
 
 Module EventConvertSafe
   (LP1 : LLVMParams) (LP2 : LLVMParams)
   (AC1 : AddrConvert LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI) (AC2 : AddrConvert LP2.ADDR LP2.PTOI LP1.ADDR LP1.PTOI)
   (ACSafe : AddrConvertSafe LP1.ADDR LP1.PTOI LP2.ADDR LP2.PTOI AC1 AC2)
   (IPSafe : IPConvertSafe LP1.IP LP2.IP)
-  (Events1 : LLVM_INTERACTIONS LP1.ADDR LP1.IP LP1.SIZEOF) (Events2 : LLVM_INTERACTIONS LP2.ADDR LP2.IP LP2.SIZEOF)
-  (DVC : DVConvert LP1 LP2 AC1 Events1 Events2) (DVCrev : DVConvert LP2 LP1 AC2 Events2 Events1) (EC : EventConvert LP1 LP2 AC1 AC2 Events1 Events2 DVC DVCrev).
-  Module DVCSafe := DVConvertSafe LP1 LP2 AC1 AC2 ACSafe IPSafe Events1 Events2 DVC DVCrev.
+  (DVC : DVConvert LP1 LP2 AC1) (DVCrev : DVConvert LP2 LP1 AC2) (EC : EventConvert LP1 LP2 AC1 AC2 DVC DVCrev).
+  Module DVCSafe := DVConvertSafe LP1 LP2 AC1 AC2 ACSafe IPSafe DVC DVCrev.
 
   (* Converting finite events to infinite events... *)
   Module DV1 := DVC.DV1. (* Finite *)
@@ -469,6 +528,4 @@ Module EventConvertSafe
   Definition rev_uvalue_convert (uv : DV2.uvalue) : OOM DV1.uvalue
     := DVCrev.uvalue_convert_strict uv.
 
-  Module E1 := Events1.
-  Module E2 := Events2.
 End EventConvertSafe.

--- a/src/rocq/Semantics/InfiniteToFinite/Conversions/TreeConversions.v
+++ b/src/rocq/Semantics/InfiniteToFinite/Conversions/TreeConversions.v
@@ -59,33 +59,39 @@ Import InterpFacts.
 Import MonadNotation.
 Import ListNotations.
 
-Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : AddrConvert IS1.LP.ADDR IS1.LP.PTOI IS2.LP.ADDR IS2.LP.PTOI) (AC2 : AddrConvert IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI) (DVC : DVConvert IS1.LP IS2.LP AC1 IS1.LP.Events IS2.LP.Events) (DVCrev : DVConvert IS2.LP IS1.LP AC2 IS2.LP.Events IS1.LP.Events) (EC : EventConvert IS1.LP IS2.LP AC1 AC2 IS1.LP.Events IS2.LP.Events DVC DVCrev).
-  Module E1 := IS1.LP.Events.
-  Module E2 := IS2.LP.Events.
+Module Type TreeConvert
+  (IS1 : InterpreterStack)
+  (IS2 : InterpreterStack)
+  (AC1 : AddrConvert IS1.LP.ADDR IS1.LP.PTOI IS2.LP.ADDR IS2.LP.PTOI)
+  (AC2 : AddrConvert IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI)
+  (DVC : DVConvert IS1.LP IS2.LP AC1)
+  (DVCrev : DVConvert IS2.LP IS1.LP AC2)
+  (EC : EventConvert IS1.LP IS2.LP AC1 AC2 DVC DVCrev).
 
   Import EC.
   Import DVC.
+
 
   (** Converting trees with events in language 1 to trees with events in language 2 *)
 
   (* TODO: move this? *)
   (*
-  Definition L0_convert_tree_lazy {T} (t : itree E1.L0 T) : itree E2.L0 T := interp L0_convert_lazy t.
-  Definition L1_convert_tree_lazy {T} (t : itree E1.L1 T) : itree E2.L1 T := interp L1_convert_lazy t.
-  Definition L2_convert_tree_lazy {T} (t : itree E1.L2 T) : itree E2.L2 T := interp L2_convert_lazy t.
-  Definition L3_convert_tree_lazy {T} (t : itree E1.L3 T) : itree E2.L3 T := interp L3_convert_lazy t.
-  Definition L4_convert_tree_lazy {T} (t : itree E1.L4 T) : itree E2.L4 T := interp L4_convert_lazy t.
-  Definition L5_convert_tree_lazy {T} (t : itree E1.L5 T) : itree E2.L5 T := interp L5_convert_lazy t.
-  Definition L6_convert_tree_lazy {T} (t : itree E1.L6 T) : itree E2.L6 T := interp L6_convert_lazy t.
+  Definition L0_convert_tree_lazy {T} (t : itree L01 T) : itree L02 T := interp L0_convert_lazy t.
+  Definition L1_convert_tree_lazy {T} (t : itree L11 T) : itree L12 T := interp L1_convert_lazy t.
+  Definition L2_convert_tree_lazy {T} (t : itree L21 T) : itree L22 T := interp L2_convert_lazy t.
+  Definition L3_convert_tree_lazy {T} (t : itree L31 T) : itree L32 T := interp L3_convert_lazy t.
+  Definition L4_convert_tree_lazy {T} (t : itree L41 T) : itree L42 T := interp L4_convert_lazy t.
+  Definition L5_convert_tree_lazy {T} (t : itree L51 T) : itree L52 T := interp L5_convert_lazy t.
+  Definition L6_convert_tree_lazy {T} (t : itree L61 T) : itree L62 T := interp L6_convert_lazy t.
    *)
 
-  Definition L0_convert_tree_strict {T} (t : itree E1.L0 T) : itree E2.L0 T := interp L0_convert_strict t.
-  Definition L1_convert_tree_strict {T} (t : itree E1.L1 T) : itree E2.L1 T := interp L1_convert_strict t.
-  Definition L2_convert_tree_strict {T} (t : itree E1.L2 T) : itree E2.L2 T := interp L2_convert_strict t.
-  Definition L3_convert_tree_strict {T} (t : itree E1.L3 T) : itree E2.L3 T := interp L3_convert_strict t.
-  Definition L4_convert_tree_strict {T} (t : itree E1.L4 T) : itree E2.L4 T := interp L4_convert_strict t.
-  Definition L5_convert_tree_strict {T} (t : itree E1.L5 T) : itree E2.L5 T := interp L5_convert_strict t.
-  Definition L6_convert_tree_strict {T} (t : itree E1.L6 T) : itree E2.L6 T := interp L6_convert_strict t.
+  Definition L0_convert_tree_strict {T} (t : itree L01 T) : itree L02 T := interp L0_convert_strict t.
+  Definition L1_convert_tree_strict {T} (t : itree L11 T) : itree L12 T := interp L1_convert_strict t.
+  Definition L2_convert_tree_strict {T} (t : itree L21 T) : itree L22 T := interp L2_convert_strict t.
+  Definition L3_convert_tree_strict {T} (t : itree L31 T) : itree L32 T := interp L3_convert_strict t.
+  Definition L4_convert_tree_strict {T} (t : itree L41 T) : itree L42 T := interp L4_convert_strict t.
+  Definition L5_convert_tree_strict {T} (t : itree L51 T) : itree L52 T := interp L5_convert_strict t.
+  Definition L6_convert_tree_strict {T} (t : itree L61 T) : itree L62 T := interp L6_convert_strict t.
 
   (*
   #[global] Instance L0_convert_tree_lazy_eutt_proper {T} {RR : relation T} :
@@ -207,54 +213,54 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
 
   (* TODO: move this? *)
   (*
-  Definition L0_convert_tree_lazy' {A B} (f : A -> B) (t : itree E1.L0 A) : itree E2.L0 B
+  Definition L0_convert_tree_lazy' {A B} (f : A -> B) (t : itree L01 A) : itree L02 B
     := fmap f (L0_convert_tree_lazy t).
 
-  Definition L1_convert_tree_lazy' {A B} (f : A -> B) (t : itree E1.L1 A) : itree E2.L1 B
+  Definition L1_convert_tree_lazy' {A B} (f : A -> B) (t : itree L11 A) : itree L12 B
     := fmap f (L1_convert_tree_lazy t).
 
-  Definition L2_convert_tree_lazy' {A B} (f : A -> B) (t : itree E1.L2 A) : itree E2.L2 B
+  Definition L2_convert_tree_lazy' {A B} (f : A -> B) (t : itree L21 A) : itree L22 B
     := fmap f (L2_convert_tree_lazy t).
 
-  Definition L3_convert_tree_lazy' {A B} (f : A -> B) (t : itree E1.L3 A) : itree E2.L3 B
+  Definition L3_convert_tree_lazy' {A B} (f : A -> B) (t : itree L31 A) : itree L32 B
     := fmap f (L3_convert_tree_lazy t).
 
-  Definition L4_convert_tree_lazy' {A B} (f : A -> B) (t : itree E1.L4 A) : itree E2.L4 B
+  Definition L4_convert_tree_lazy' {A B} (f : A -> B) (t : itree L41 A) : itree L42 B
     := fmap f (L4_convert_tree_lazy t).
 
-  Definition L5_convert_tree_lazy' {A B} (f : A -> B) (t : itree E1.L5 A) : itree E2.L5 B
+  Definition L5_convert_tree_lazy' {A B} (f : A -> B) (t : itree L51 A) : itree L52 B
     := fmap f (L5_convert_tree_lazy t).
 
-  Definition L6_convert_tree_lazy' {A B} (f : A -> B) (t : itree E1.L6 A) : itree E2.L6 B
+  Definition L6_convert_tree_lazy' {A B} (f : A -> B) (t : itree L61 A) : itree L62 B
     := fmap f (L6_convert_tree_lazy t).
    *)
 
   (* TODO: move this? *)
-  Definition L0_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree E1.L0 A) : itree E2.L0 B
+  Definition L0_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree L01 A) : itree L02 B
     := x <- L0_convert_tree_strict t;;
        lift_OOM (f x).
 
-  Definition L1_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree E1.L1 A) : itree E2.L1 B
+  Definition L1_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree L11 A) : itree L12 B
     := x <- L1_convert_tree_strict t;;
        lift_OOM (f x).
 
-  Definition L2_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree E1.L2 A) : itree E2.L2 B
+  Definition L2_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree L21 A) : itree L22 B
     := x <- L2_convert_tree_strict t;;
        lift_OOM (f x).
 
-  Definition L3_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree E1.L3 A) : itree E2.L3 B
+  Definition L3_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree L31 A) : itree L32 B
     := x <- L3_convert_tree_strict t;;
        lift_OOM (f x).
 
-  Definition L4_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree E1.L4 A) : itree E2.L4 B
+  Definition L4_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree L41 A) : itree L42 B
     := x <- L4_convert_tree_strict t;;
        lift_OOM (f x).
 
-  Definition L5_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree E1.L5 A) : itree E2.L5 B
+  Definition L5_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree L51 A) : itree L52 B
     := x <- L5_convert_tree_strict t;;
        lift_OOM (f x).
 
-  Definition L6_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree E1.L6 A) : itree E2.L6 B
+  Definition L6_convert_tree_strict' {A B} (f : A -> OOM B) (t : itree L61 A) : itree L62 B
     := x <- L6_convert_tree_strict t;;
        lift_OOM (f x).
 
@@ -345,7 +351,7 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
    *)
   
   #[global] Instance L0_convert_tree_strict'_eutt_proper {A B} {RA : relation A} {RB : relation B} f :
-    (forall u1 u2, RA u1 u2 -> @eutt E2.L0 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
+    (forall u1 u2, RA u1 u2 -> @eutt L02 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
     Proper (eutt RA ==> eutt RB) (L0_convert_tree_strict' f).
   Proof.
     unfold Proper, respectful.
@@ -357,7 +363,7 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
   Defined.
 
   #[global] Instance L1_convert_tree_strict'_eutt_proper {A B} {RA : relation A} {RB : relation B} f :
-    (forall u1 u2, RA u1 u2 -> @eutt E2.L1 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
+    (forall u1 u2, RA u1 u2 -> @eutt L12 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
     Proper (eutt RA ==> eutt RB) (L1_convert_tree_strict' f).
   Proof.
     unfold Proper, respectful.
@@ -369,7 +375,7 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
   Defined.
 
   #[global] Instance L2_convert_tree_strict'_eutt_proper {A B} {RA : relation A} {RB : relation B} f :
-    (forall u1 u2, RA u1 u2 -> @eutt E2.L2 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
+    (forall u1 u2, RA u1 u2 -> @eutt L22 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
     Proper (eutt RA ==> eutt RB) (L2_convert_tree_strict' f).
   Proof.
     unfold Proper, respectful.
@@ -381,7 +387,7 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
   Defined.
 
   #[global] Instance L3_convert_tree_strict'_eutt_proper {A B} {RA : relation A} {RB : relation B} f :
-    (forall u1 u2, RA u1 u2 -> @eutt E2.L3 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
+    (forall u1 u2, RA u1 u2 -> @eutt L32 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
     Proper (eutt RA ==> eutt RB) (L3_convert_tree_strict' f).
   Proof.
     unfold Proper, respectful.
@@ -393,7 +399,7 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
   Defined.
 
   #[global] Instance L4_convert_tree_strict'_eutt_proper {A B} {RA : relation A} {RB : relation B} f :
-    (forall u1 u2, RA u1 u2 -> @eutt E2.L4 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
+    (forall u1 u2, RA u1 u2 -> @eutt L42 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
     Proper (eutt RA ==> eutt RB) (L4_convert_tree_strict' f).
   Proof.
     unfold Proper, respectful.
@@ -405,7 +411,7 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
   Defined.
 
   #[global] Instance L5_convert_tree_strict'_eutt_proper {A B} {RA : relation A} {RB : relation B} f :
-    (forall u1 u2, RA u1 u2 -> @eutt E2.L5 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
+    (forall u1 u2, RA u1 u2 -> @eutt L52 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
     Proper (eutt RA ==> eutt RB) (L5_convert_tree_strict' f).
   Proof.
     unfold Proper, respectful.
@@ -417,7 +423,7 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
   Defined.
 
   #[global] Instance L6_convert_tree_strict'_eutt_proper {A B} {RA : relation A} {RB : relation B} f :
-    (forall u1 u2, RA u1 u2 -> @eutt E2.L6 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
+    (forall u1 u2, RA u1 u2 -> @eutt L62 _ _ RB (lift_OOM (f u1)) (lift_OOM (f u2))) ->
     Proper (eutt RA ==> eutt RB) (L6_convert_tree_strict' f).
   Proof.
     unfold Proper, respectful.
@@ -436,23 +442,23 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
     := fmap dvalue_convert_lazy t.
    *)
   
-  Definition convert_uvalue_tree_strict {E} `{OOME -< E} (t : itree E E1.DV.uvalue) : itree E E2.DV.uvalue
+  Definition convert_uvalue_tree_strict {E} `{OOME -< E} (t : itree E DV1.uvalue) : itree E DV2.uvalue
     := x <- t;;
        lift_OOM (uvalue_convert_strict x).
 
-  Definition convert_dvalue_tree_strict {E} `{OOME -< E} (t : itree E E1.DV.dvalue) : itree E E2.DV.dvalue
+  Definition convert_dvalue_tree_strict {E} `{OOME -< E} (t : itree E DV1.dvalue) : itree E DV2.dvalue
     := x <- t;;
        lift_OOM (dvalue_convert_strict x).
 
   (*
-  Definition L3_convert_PropT_lazy {A B} (RB : relation B) (f : A -> B) (ts : PropT E1.L3 A) : PropT E2.L3 B
+  Definition L3_convert_PropT_lazy {A B} (RB : relation B) (f : A -> B) (ts : PropT L31 A) : PropT L32 B
     := fun t_e2 => exists t_e1,
            ts t_e1 /\
              refine_OOM_h RB
                (L3_convert_tree_lazy' f t_e1)
                t_e2.
 
-  Definition L4_convert_PropT_lazy {A B} (RB : relation B) (f : A -> B) (ts : PropT IS1.LP.Events.L4 A) : PropT E2.L4 B
+  Definition L4_convert_PropT_lazy {A B} (RB : relation B) (f : A -> B) (ts : PropT IS1.LP.Events.L4 A) : PropT L42 B
     := fun t_e2 => exists t_e1,
            ts t_e1 /\
              refine_OOM_h RB
@@ -470,14 +476,14 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
     := L4_convert_PropT_lazy RB f ts.
    *)
   
-  Definition L3_convert_PropT_strict {A B} (RB : relation B) (f : A -> OOM B) (ts : PropT E1.L3 A) : PropT E2.L3 B
+  Definition L3_convert_PropT_strict {A B} (RB : relation B) (f : A -> OOM B) (ts : PropT L31 A) : PropT L32 B
     := fun t_e2 => exists t_e1,
            ts t_e1 /\
              refine_OOM_h RB
                (L3_convert_tree_strict' f t_e1)
                t_e2.
 
-  Definition L4_convert_PropT_strict {A B} (RB : relation B) (f : A -> OOM B) (ts : PropT IS1.LP.Events.L4 A) : PropT E2.L4 B
+  Definition L4_convert_PropT_strict {A B} (RB : relation B) (f : A -> OOM B) (ts : PropT (L4 DV1.dvalue DV1.uvalue) A) : PropT L42 B
     := fun t_e2 => exists t_e1,
            ts t_e1 /\
              refine_OOM_h RB
@@ -485,18 +491,26 @@ Module Type TreeConvert (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 :
                t_e2.
 
   Definition L5_convert_PropT_strict {A B}
-    (RB : relation B) (f : A -> OOM B) (ts : PropT IS1.LP.Events.L5 A)
-    : PropT E2.L5 B
+    (RB : relation B) (f : A -> OOM B) (ts : PropT (L5 DV1.dvalue DV1.uvalue) A)
+    : PropT L52 B
     := L4_convert_PropT_strict RB f ts.
 
   Definition L6_convert_PropT_strict {A B}
-    (RB : relation B) (f : A -> OOM B) (ts : PropT IS1.LP.Events.L6 A)
-    : PropT E2.L6 B
+    (RB : relation B) (f : A -> OOM B) (ts : PropT (L6 DV1.dvalue DV1.uvalue) A)
+    : PropT L62 B
     := L4_convert_PropT_strict RB f ts.
 
 End TreeConvert.
 
-Module TreeConvertMake (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : AddrConvert IS1.LP.ADDR IS1.LP.PTOI IS2.LP.ADDR IS2.LP.PTOI) (AC2 : AddrConvert IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI) (DVC : DVConvert IS1.LP IS2.LP AC1 IS1.LP.Events IS2.LP.Events) (DVCrev : DVConvert IS2.LP IS1.LP AC2 IS2.LP.Events IS1.LP.Events) (EC : EventConvert IS1.LP IS2.LP AC1 AC2 IS1.LP.Events IS2.LP.Events DVC DVCrev) : TreeConvert IS1 IS2 AC1 AC2 DVC DVCrev EC.
+Module TreeConvertMake
+  (IS1 : InterpreterStack)
+  (IS2 : InterpreterStack)
+  (AC1 : AddrConvert IS1.LP.ADDR IS1.LP.PTOI IS2.LP.ADDR IS2.LP.PTOI)
+  (AC2 : AddrConvert IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI)
+  (DVC : DVConvert IS1.LP IS2.LP AC1)
+  (DVCrev : DVConvert IS2.LP IS1.LP AC2)
+  (EC : EventConvert IS1.LP IS2.LP AC1 AC2 DVC DVCrev)
+  : TreeConvert IS1 IS2 AC1 AC2 DVC DVCrev EC.
   Include TreeConvert IS1 IS2 AC1 AC2 DVC DVCrev EC.
 End TreeConvertMake.
 

--- a/src/rocq/Semantics/InfiniteToFinite/LangRefine.v
+++ b/src/rocq/Semantics/InfiniteToFinite/LangRefine.v
@@ -1076,7 +1076,7 @@ Module VMemInt_Refine_InfFin : VMemInt_Refine InterpreterStackBigIntptr.LP.IP In
   Qed.
 End VMemInt_Refine_InfFin.
 
-Module Type Sizeof_Refine (SZ_INF : Sizeof) (SZ_FIN : Sizeof).
+Module Type Sizeof_Refine (SZ_INF : SIZEOF) (SZ_FIN : SIZEOF).
   Parameter bit_sizeof_dtyp_fin_inf :
     forall t,
       SZ_INF.bit_sizeof_dtyp t = SZ_FIN.bit_sizeof_dtyp t.
@@ -1094,33 +1094,33 @@ Module Type Sizeof_Refine (SZ_INF : Sizeof) (SZ_FIN : Sizeof).
       SZ_INF.max_preferred_dtyp_alignment dts = SZ_FIN.max_preferred_dtyp_alignment dts.
 End Sizeof_Refine.
 
-Module Sizeof_Refine_InfFin : Sizeof_Refine InterpreterStackBigIntptr.LP.SIZEOF InterpreterStack64BitIntptr.LP.SIZEOF.
+Module Sizeof_Refine_InfFin : Sizeof_Refine InterpreterStackBigIntptr.LP.SZ InterpreterStack64BitIntptr.LP.SZ.
   Lemma bit_sizeof_dtyp_fin_inf :
     forall t,
-      InterpreterStackBigIntptr.LP.SIZEOF.bit_sizeof_dtyp t = InterpreterStack64BitIntptr.LP.SIZEOF.bit_sizeof_dtyp t.
+      InterpreterStackBigIntptr.LP.SZ.bit_sizeof_dtyp t = InterpreterStack64BitIntptr.LP.SZ.bit_sizeof_dtyp t.
   Proof.
     intros t.
-    unfold InterpreterStackBigIntptr.LP.SIZEOF.bit_sizeof_dtyp.
+    unfold InterpreterStackBigIntptr.LP.SZ.bit_sizeof_dtyp.
     reflexivity.
   Qed.
 
   Lemma sizeof_dtyp_fin_inf :
     forall t,
-      InterpreterStackBigIntptr.LP.SIZEOF.sizeof_dtyp t = InterpreterStack64BitIntptr.LP.SIZEOF.sizeof_dtyp t.
+      InterpreterStackBigIntptr.LP.SZ.sizeof_dtyp t = InterpreterStack64BitIntptr.LP.SZ.sizeof_dtyp t.
   Proof.
     reflexivity.
   Qed.
 
   Lemma dtyp_alignment_fin_inf :
     forall t,
-      InterpreterStackBigIntptr.LP.SIZEOF.dtyp_alignment t = InterpreterStack64BitIntptr.LP.SIZEOF.dtyp_alignment t.
+      InterpreterStackBigIntptr.LP.SZ.dtyp_alignment t = InterpreterStack64BitIntptr.LP.SZ.dtyp_alignment t.
   Proof.
     reflexivity.
   Qed.
 
   Lemma max_preferred_dtyp_alignment_fin_inf :
     forall dts,
-      InterpreterStackBigIntptr.LP.SIZEOF.max_preferred_dtyp_alignment dts = InterpreterStack64BitIntptr.LP.SIZEOF.max_preferred_dtyp_alignment dts.
+      InterpreterStackBigIntptr.LP.SZ.max_preferred_dtyp_alignment dts = InterpreterStack64BitIntptr.LP.SZ.max_preferred_dtyp_alignment dts.
   Proof.
     reflexivity.
   Qed.
@@ -1215,7 +1215,25 @@ Module ItoP_Refine_InfFin : ItoP_Refine InterpreterStackBigIntptr InterpreterSta
   Qed.
 End ItoP_Refine_InfFin.
 
-Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : AddrConvert IS1.LP.ADDR IS1.LP.PTOI IS2.LP.ADDR IS2.LP.PTOI) (AC2 : AddrConvert IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI) (LLVM1 : LLVMTopLevel IS1) (LLVM2 : LLVMTopLevel IS2) (TLR1 : TopLevelRefinements IS1 LLVM1) (TLR2 : TopLevelRefinements IS2 LLVM2) (IPS : IPConvertSafe IS2.LP.IP IS1.LP.IP) (ACS : AddrConvertSafe IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI AC2 AC1) (DVC : DVConvert IS1.LP IS2.LP AC1 IS1.LP.Events IS2.LP.Events) (DVCrev : DVConvert IS2.LP IS1.LP AC2 IS2.LP.Events IS1.LP.Events) (EC : EventConvert IS1.LP IS2.LP AC1 AC2 IS1.LP.Events IS2.LP.Events DVC DVCrev) (TC : TreeConvert IS1 IS2 AC1 AC2 DVC DVCrev EC) (VMEM_IP_PROP1 : VMemInt_Intptr_Properties IS1.LP.IP) (VMEM_IP_PROP2 : VMemInt_Intptr_Properties IS2.LP.IP) (VMEM_REF : VMemInt_Refine IS1.LP.IP IS2.LP.IP) (SIZEOF_REF : Sizeof_Refine IS1.LP.SIZEOF IS2.LP.SIZEOF) (ITOP_REF : ItoP_Refine IS1 IS2 AC1 AC2).
+Module Type LangRefine
+  (IS1 : InterpreterStack)
+  (IS2 : InterpreterStack)
+  (AC1 : AddrConvert IS1.LP.ADDR IS1.LP.PTOI IS2.LP.ADDR IS2.LP.PTOI)
+  (AC2 : AddrConvert IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI)
+  (LLVM1 : LLVMTopLevel IS1)
+  (LLVM2 : LLVMTopLevel IS2)
+  (TLR1 : TopLevelRefinements IS1 LLVM1)
+  (TLR2 : TopLevelRefinements IS2 LLVM2)
+  (IPS : IPConvertSafe IS2.LP.IP IS1.LP.IP)
+  (ACS : AddrConvertSafe IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI AC2 AC1)
+  (DVC : DVConvert IS1.LP IS2.LP AC1)
+  (DVCrev : DVConvert IS2.LP IS1.LP AC2)
+  (EC : EventConvert IS1.LP IS2.LP AC1 AC2 DVC DVCrev)
+  (TC : TreeConvert IS1 IS2 AC1 AC2 DVC DVCrev EC)
+  (VMEM_IP_PROP1 : VMemInt_Intptr_Properties IS1.LP.IP)
+  (VMEM_IP_PROP2 : VMemInt_Intptr_Properties IS2.LP.IP)
+  (VMEM_REF : VMemInt_Refine IS1.LP.IP IS2.LP.IP)
+  (SIZEOF_REF : Sizeof_Refine IS1.LP.SZ IS2.LP.SZ) (ITOP_REF : ItoP_Refine IS1 IS2 AC1 AC2).
   Import TLR2.
 
   Import TC.
@@ -1226,7 +1244,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Import SIZEOF_REF.
   Import ITOP_REF.
 
-  Module DVCSafe := DVConvertSafe IS2.LP IS1.LP AC2 AC1 ACS IPS IS2.LP.Events IS1.LP.Events DVCrev DVC.
+  Module DVCSafe := DVConvertSafe IS2.LP IS1.LP AC2 AC1 ACS IPS DVCrev DVC.
   Import DVCSafe.
 
   Module MBT := MemBytesTheory IS2.LP IS2.LLVM.MEM.MP ByteM IS2.LLVM.MEM.CP.
@@ -1426,7 +1444,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   (** OOM Refinements *)
   Lemma Returns_ExternalCall_L0 :
     forall d f t args,
-      @Returns E1.L0 E1.DV.dvalue d (trigger (E1.ExternalCall t f args)).
+      @Returns L01 DV1.dvalue d (trigger (ExternalCall t f args)).
   Proof.
     intros d f t args.
 
@@ -1460,34 +1478,35 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   (** Model *)
   Import DynamicTypes TypToDtyp CFG.
 
-  Definition external_call_refine_strict {A B} (e1 : E1.ExternalCallE A) (e2 : E2.ExternalCallE B) : Prop.
+  
+  Definition external_call_refine_strict {A B} (e1 : ExternalCallE DV1.dvalue DV1.uvalue A) (e2 : ExternalCallE DV2.dvalue DV2.uvalue B) : Prop.
     (* External Calls *)
     refine (match e1, e2 with
-            | E1.ExternalCall dt1 f1 args1, E2.ExternalCall dt2 f2 args2 =>
+            | ExternalCall dt1 f1 args1, ExternalCall dt2 f2 args2 =>
                 (* Doesn't say anything about return value... *)
                 dt1 = dt2 /\
                   uvalue_refine_strict f1 f2 /\
                   Forall2 dvalue_refine_strict args1 args2
-            | E1.IO_stdout msg1, E2.IO_stdout msg2 =>
+            | IO_stdout msg1, IO_stdout msg2 =>
                 msg1 = msg2
-            | E1.IO_stderr msg1, E2.IO_stderr msg2 =>
+            | IO_stderr msg1, IO_stderr msg2 =>
                 msg1 = msg2
             | _, _ =>
                 False
             end).
   Defined.
 
-  Definition intrinsic_refine_strict {A B} (e1 : E1.IntrinsicE A) (e2 : E2.IntrinsicE B) : Prop.
+  Definition intrinsic_refine_strict {A B} (e1 : IntrinsicE DV1.dvalue DV1.uvalue A) (e2 : IntrinsicE DV2.dvalue DV2.uvalue B) : Prop.
     refine
       (match e1, e2 with
-       | E1.Intrinsic dt1 name1 args1, E2.Intrinsic dt2 name2 args2 =>
+       | Intrinsic dt1 name1 args1, Intrinsic dt2 name2 args2 =>
            dt1 = dt2 /\
              name1 = name2 /\
              Forall2 dvalue_refine_strict args1 args2
        end).
   Defined.
 
-  Definition globalE_refine_strict {A B} (e1 : GlobalE LLVMAst.raw_id E1.DV.dvalue A) (e2 : GlobalE LLVMAst.raw_id E2.DV.dvalue B) : Prop.
+  Definition globalE_refine_strict {A B} (e1 : GlobalE LLVMAst.raw_id DV1.dvalue A) (e2 : GlobalE LLVMAst.raw_id DV2.dvalue B) : Prop.
     (* Globals *)
     { inversion e1.
       - (* Global write *)
@@ -1502,7 +1521,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition localE_refine_strict {A B} (e1 : LocalE LLVMAst.raw_id E1.DV.uvalue A) (e2 : LocalE LLVMAst.raw_id E2.DV.uvalue B) : Prop.
+  Definition localE_refine_strict {A B} (e1 : LocalE LLVMAst.raw_id DV1.uvalue A) (e2 : LocalE LLVMAst.raw_id DV2.uvalue B) : Prop.
     (* Locals *)
     { inversion e1.
       - (* Local write *)
@@ -1517,7 +1536,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition stackE_refine_strict {A B} (e1 : StackE LLVMAst.raw_id E1.DV.uvalue E1.DV.uvalue A) (e2 : StackE LLVMAst.raw_id E2.DV.uvalue E2.DV.uvalue B) : Prop.
+  Definition stackE_refine_strict {A B} (e1 : StackE LLVMAst.raw_id DV1.uvalue DV1.uvalue A) (e2 : StackE LLVMAst.raw_id DV2.uvalue DV2.uvalue B) : Prop.
     (* Stack *)
     { inversion e1.
       - (* Stack Push *)
@@ -1547,7 +1566,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition memoryE_refine_strict {A B} (e1 : E1.MemoryE A) (e2 : E2.MemoryE B) : Prop.
+  Definition memoryE_refine_strict {A B} (e1 : MemoryE DV1.dvalue DV1.uvalue A) (e2 : MemoryE DV2.dvalue DV2.uvalue B) : Prop.
     (* MemoryE *)
     { inversion e1.
       - (* MemPush *)
@@ -1581,7 +1600,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition pickE_refine_strict {A B} (e1 : E1.PickUvalueE A) (e2 : E2.PickUvalueE B) : Prop.
+  Definition pickE_refine_strict {A B} (e1 : PickUvalueE DV1.dvalue DV1.uvalue A) (e2 : PickUvalueE DV2.dvalue DV2.uvalue B) : Prop.
     (* PickE *)
     { (* TODO: confirm whether this is sane... *)
       inversion e1.
@@ -1612,7 +1631,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition llvmExcE_refine_strict {A B} (e1 : LLVMExcE E1.DV.uvalue A) (e2 : LLVMExcE E2.DV.uvalue B) : Prop.
+  Definition llvmExcE_refine_strict {A B} (e1 : LLVMExcE DV1.uvalue A) (e2 : LLVMExcE DV2.uvalue B) : Prop.
     (* LLVMExcE *)
     { destruct e1 as [exc1].
       destruct e2 as [exc2].
@@ -1644,7 +1663,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition event_refine_strict A B (e1 : IS1.LP.Events.L0 A) (e2 : IS2.LP.Events.L0 B) : Prop.
+  Definition event_refine_strict A B (e1 : L0 DV1.dvalue DV1.uvalue A) (e2 : L0 DV2.dvalue DV2.uvalue B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -1677,7 +1696,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition L1_refine_strict A B (e1 : IS1.LP.Events.L1 A) (e2 : IS2.LP.Events.L1 B) : Prop.
+  Definition L1_refine_strict A B (e1 : L1 DV1.dvalue DV1.uvalue A) (e2 : L1 DV2.dvalue DV2.uvalue B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -1708,7 +1727,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition L2_refine_strict A B (e1 : IS1.LP.Events.L2 A) (e2 : IS2.LP.Events.L2 B) : Prop.
+  Definition L2_refine_strict A B (e1 : L2 DV1.dvalue DV1.uvalue A) (e2 : L2 DV2.dvalue DV2.uvalue B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -1735,7 +1754,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition L3_refine_strict A B (e1 : IS1.LP.Events.L3 A) (e2 : IS2.LP.Events.L3 B) : Prop.
+  Definition L3_refine_strict A B (e1 : L3 DV1.dvalue DV1.uvalue A) (e2 : L3 DV2.dvalue DV2.uvalue B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -1758,7 +1777,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition L4_refine_strict A B (e1 : IS1.LP.Events.L4 A) (e2 : IS2.LP.Events.L4 B) : Prop.
+  Definition L4_refine_strict A B (e1 : L4 DV1.dvalue DV1.uvalue A) (e2 : L4 DV2.dvalue DV2.uvalue B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -1780,7 +1799,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Defined.
 
 
-  Definition external_call_res_refine_strict {A B} (e1 : E1.ExternalCallE A) (res1 : A) (e2 : E2.ExternalCallE B) (res2 : B) : Prop.
+  Definition external_call_res_refine_strict {A B} (e1 : ExternalCallE DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : ExternalCallE DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
     (* External Calls *)
     inv e1.
     - (* ExternalCall *)
@@ -1806,7 +1825,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       all: exact False. (* Mismatch of event types *)
   Defined.
 
-  Definition intrinsic_res_refine_strict {A B} (e1 : E1.IntrinsicE A) (res1 : A) (e2 : E2.IntrinsicE B) (res2 : B) : Prop.
+  Definition intrinsic_res_refine_strict {A B} (e1 : IntrinsicE DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : IntrinsicE DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
     (* Intrinsics *)
     inv e1.
     inv e2.
@@ -1817,7 +1836,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
           ).
   Defined.
 
-  Definition globalE_res_refine_strict {A B} (e1 : GlobalE LLVMAst.raw_id E1.DV.dvalue A) (res1 : A) (e2 : GlobalE LLVMAst.raw_id E2.DV.dvalue B) (res2 : B) : Prop.
+  Definition globalE_res_refine_strict {A B} (e1 : GlobalE LLVMAst.raw_id DV1.dvalue A) (res1 : A) (e2 : GlobalE LLVMAst.raw_id DV2.dvalue B) (res2 : B) : Prop.
     (* Globals *)
     { inversion e1; subst.
       - (* Global write *)
@@ -1834,7 +1853,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition localE_res_refine_strict {A B} (e1 : LocalE LLVMAst.raw_id E1.DV.uvalue A) (res1 : A) (e2 : LocalE LLVMAst.raw_id E2.DV.uvalue B) (res2 : B) : Prop.
+  Definition localE_res_refine_strict {A B} (e1 : LocalE LLVMAst.raw_id DV1.uvalue A) (res1 : A) (e2 : LocalE LLVMAst.raw_id DV2.uvalue B) (res2 : B) : Prop.
     (* Locals *)
     { inversion e1; subst.
       - (* Local write *)
@@ -1850,7 +1869,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition stackE_res_refine_strict {A B} (e1 : StackE LLVMAst.raw_id E1.DV.uvalue E1.DV.uvalue A) (res1 : A) (e2 : StackE LLVMAst.raw_id E2.DV.uvalue E2.DV.uvalue B) (res2 : B) : Prop.
+  Definition stackE_res_refine_strict {A B} (e1 : StackE LLVMAst.raw_id DV1.uvalue DV1.uvalue A) (res1 : A) (e2 : StackE LLVMAst.raw_id DV2.uvalue DV2.uvalue B) (res2 : B) : Prop.
     (* Stack *)
     { inversion e1.
       - (* Stack Push *)
@@ -1880,7 +1899,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition memoryE_res_refine_strict {A B} (e1 : E1.MemoryE A) (res1 : A) (e2 : E2.MemoryE B) (res2 : B) : Prop.
+  Definition memoryE_res_refine_strict {A B} (e1 : MemoryE DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : MemoryE DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
     (* MemoryE *)
     { inversion e1; subst.
       - (* MemPush *)
@@ -1916,7 +1935,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition pickE_res_refine_strict {A B} (e1 : E1.PickUvalueE A) (res1 : A) (e2 : E2.PickUvalueE B) (res2 : B) : Prop.
+  Definition pickE_res_refine_strict {A B} (e1 : PickUvalueE DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : PickUvalueE DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
     (* PickE *)
     { (* TODO: confirm whether this is sane... *)
       inversion e1.
@@ -1950,7 +1969,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition llvmExcE_res_refine_strict {A B} (e1 : LLVMExcE E1.DV.uvalue A) (res1 : A) (e2 : LLVMExcE E2.DV.uvalue B) (res2 : B) : Prop.
+  Definition llvmExcE_res_refine_strict {A B} (e1 : LLVMExcE DV1.uvalue A) (res1 : A) (e2 : LLVMExcE DV2.uvalue B) (res2 : B) : Prop.
     (* LLVMExcE *)
     { inversion e1; inversion e2; subst.
       apply (uvalue_refine_strict H H1).
@@ -1980,7 +1999,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Lemma external_call_res_refine_strict_external_call_refine_strict {A B} (e1 : E1.ExternalCallE A) (res1 : A) (e2 : E2.ExternalCallE B) (res2 : B) :
+  Lemma external_call_res_refine_strict_external_call_refine_strict {A B} (e1 : ExternalCallE DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : ExternalCallE DV2.dvalue DV2.uvalue B) (res2 : B) :
     external_call_res_refine_strict e1 res1 e2 res2 -> external_call_refine_strict e1 e2.
   Proof.
     intros RES; red; red in RES.
@@ -1988,7 +2007,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       tauto.
   Qed.
   
-  Lemma intrinsic_res_refine_strict_intrinsic_refine_strict {A B} (e1 : E1.IntrinsicE A) (res1 : A) (e2 : E2.IntrinsicE B) (res2 : B) :
+  Lemma intrinsic_res_refine_strict_intrinsic_refine_strict {A B} (e1 : IntrinsicE DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : IntrinsicE DV2.dvalue DV2.uvalue B) (res2 : B) :
     intrinsic_res_refine_strict e1 res1 e2 res2 -> intrinsic_refine_strict e1 e2.
   Proof.
     intros RES; red; red in RES.
@@ -1996,7 +2015,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       tauto.
   Qed.
 
-  Lemma globalE_res_refine_strict_globalE_refine_strict {A B} (e1 : GlobalE LLVMAst.raw_id E1.DV.dvalue A) (res1 : A) (e2 : GlobalE LLVMAst.raw_id E2.DV.dvalue B) (res2 : B) :
+  Lemma globalE_res_refine_strict_globalE_refine_strict {A B} (e1 : GlobalE LLVMAst.raw_id DV1.dvalue A) (res1 : A) (e2 : GlobalE LLVMAst.raw_id DV2.dvalue B) (res2 : B) :
     globalE_res_refine_strict e1 res1 e2 res2 -> globalE_refine_strict e1 e2.
   Proof.
     intros RES; red; red in RES.
@@ -2004,7 +2023,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       tauto.
   Qed.
 
-  Lemma localE_res_refine_strict_localE_refine_strict {A B} (e1 : LocalE LLVMAst.raw_id E1.DV.uvalue A) (res1 : A) (e2 : LocalE LLVMAst.raw_id E2.DV.uvalue B) (res2 : B) :
+  Lemma localE_res_refine_strict_localE_refine_strict {A B} (e1 : LocalE LLVMAst.raw_id DV1.uvalue A) (res1 : A) (e2 : LocalE LLVMAst.raw_id DV2.uvalue B) (res2 : B) :
     localE_res_refine_strict e1 res1 e2 res2 -> localE_refine_strict e1 e2.
   Proof.
     intros RES; red; red in RES.
@@ -2012,7 +2031,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       tauto.
   Qed.
 
-  Lemma stackE_res_refine_strict_stackE_refine_strict {A B} (e1 : StackE LLVMAst.raw_id E1.DV.uvalue E1.DV.uvalue A) (res1 : A) (e2 : StackE LLVMAst.raw_id E2.DV.uvalue E2.DV.uvalue B) (res2 : B) :
+  Lemma stackE_res_refine_strict_stackE_refine_strict {A B} (e1 : StackE LLVMAst.raw_id DV1.uvalue DV1.uvalue A) (res1 : A) (e2 : StackE LLVMAst.raw_id DV2.uvalue DV2.uvalue B) (res2 : B) :
     stackE_res_refine_strict e1 res1 e2 res2 -> stackE_refine_strict e1 e2.
   Proof.
     intros RES; red; red in RES.
@@ -2020,7 +2039,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       tauto.
   Qed.
 
-  Lemma memoryE_res_refine_strict_memoryE_refine_strict {A B} (e1 : E1.MemoryE A) (res1 : A) (e2 : E2.MemoryE B) (res2 : B) :
+  Lemma memoryE_res_refine_strict_memoryE_refine_strict {A B} (e1 : MemoryE DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : MemoryE DV2.dvalue DV2.uvalue B) (res2 : B) :
     memoryE_res_refine_strict e1 res1 e2 res2 -> memoryE_refine_strict e1 e2.
   Proof.
     intros RES; red; red in RES.
@@ -2028,7 +2047,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       tauto.
   Qed.
 
-  Lemma pickE_res_refine_strict_pickE_refine_strict {A B} (e1 : E1.PickUvalueE A) (res1 : A) (e2 : E2.PickUvalueE B) (res2 : B) :
+  Lemma pickE_res_refine_strict_pickE_refine_strict {A B} (e1 : PickUvalueE DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : PickUvalueE DV2.dvalue DV2.uvalue B) (res2 : B) :
     pickE_res_refine_strict e1 res1 e2 res2 -> pickE_refine_strict e1 e2.
   Proof.
     destruct e1, e2; destruct res1, res2; cbn in *;
@@ -2045,7 +2064,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       tauto.
   Qed.
 
-  Lemma llvmExcE_res_refine_strict_llvmExcE_refine_strict {A B} (e1 : LLVMExcE E1.DV.uvalue A) (res1 : A) (e2 : LLVMExcE E2.DV.uvalue B) (res2 : B) :
+  Lemma llvmExcE_res_refine_strict_llvmExcE_refine_strict {A B} (e1 : LLVMExcE DV1.uvalue A) (res1 : A) (e2 : LLVMExcE DV2.uvalue B) (res2 : B) :
     llvmExcE_res_refine_strict e1 res1 e2 res2 -> llvmExcE_refine_strict e1 e2.
   Proof.
     intros RES; red; red in RES.
@@ -2091,7 +2110,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     debugE_res_refine_strict_debugE_refine_strict
     failureE_res_refine_strict_failureE_refine_strict : REFINE_DB.   
 
-  Definition event_res_refine_strict A B (e1 : IS1.LP.Events.L0 A) (res1 : A) (e2 : IS2.LP.Events.L0 B) (res2 : B) : Prop.
+  Definition event_res_refine_strict A B (e1 : L0 DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : L0 DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2124,7 +2143,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition L1_res_refine_strict A B (e1 : IS1.LP.Events.L1 A) (res1 : A) (e2 : IS2.LP.Events.L1 B) (res2 : B) : Prop.
+  Definition L1_res_refine_strict A B (e1 : L1 DV1.dvalue DV1.uvalue A) (res1 : A) (e2 :L1 DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2155,7 +2174,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition L2_res_refine_strict A B (e1 : IS1.LP.Events.L2 A) (res1 : A) (e2 : IS2.LP.Events.L2 B) (res2 : B) : Prop.
+  Definition L2_res_refine_strict A B (e1 : L2 DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : L2 DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2182,7 +2201,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition L3_res_refine_strict A B (e1 : IS1.LP.Events.L3 A) (res1 : A) (e2 : IS2.LP.Events.L3 B) (res2 : B) : Prop.
+  Definition L3_res_refine_strict A B (e1 : L3 DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : L3 DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2205,7 +2224,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition L4_res_refine_strict A B (e1 : IS1.LP.Events.L4 A) (res1 : A) (e2 : IS2.LP.Events.L4 B) (res2 : B) : Prop.
+  Definition L4_res_refine_strict A B (e1 : L4 DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : L4 DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2226,7 +2245,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition call_refine_strict (A B : Type) (c1 : IS1.LP.Events.CallE A) (c2 : CallE B) : Prop.
+  Definition call_refine_strict (A B : Type) (c1 : CallE DV1.uvalue A) (c2 : CallE DV2.uvalue B) : Prop.
   Proof.
     (* Calls *)
     { (* Doesn't say anything about return value... *)
@@ -2238,7 +2257,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Definition call_res_refine_strict (A B : Type) (c1 : IS1.LP.Events.CallE A) (res1 : A) (c2 : CallE B) (res2 : B) : Prop.
+  Definition call_res_refine_strict (A B : Type) (c1 : CallE DV1.uvalue A) (res1 : A) (c2 : CallE DV2.uvalue B) (res2 : B) : Prop.
   Proof.
     (* Calls *)
     { inv c1.
@@ -2250,7 +2269,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     }
   Defined.
 
-  Lemma call_res_refine_strict_call_refine_strict {A B : Type} (c1 : IS1.LP.Events.CallE A) (res1 : A) (c2 : CallE B) (res2 : B) :
+  Lemma call_res_refine_strict_call_refine_strict {A B : Type} (c1 : CallE DV1.uvalue A) (res1 : A) (c2 : CallE DV2.uvalue B) (res2 : B) :
     call_res_refine_strict _ _ c1 res1 c2 res2 -> call_refine_strict _ _ c1 c2.
   Proof.
     intros H; red in H; red.
@@ -2259,13 +2278,13 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
   #[global] Hint Resolve call_res_refine_strict_call_refine_strict : REFINE_DB.
 
-  Definition L0'_refine_strict A B (e1 : IS1.LP.Events.L0' A) (e2 : IS2.LP.Events.L0' B) : Prop
+  Definition L0'_refine_strict A B (e1 : L0' DV1.dvalue DV1.uvalue A) (e2 : L0' _ _ B) : Prop
     := (sum_prerel call_refine_strict event_refine_strict) _ _ e1 e2.
 
-  Definition L0'_res_refine_strict A B (e1 : IS1.LP.Events.L0' A) (res1 : A) (e2 : IS2.LP.Events.L0' B) (res2 : B) : Prop
+  Definition L0'_res_refine_strict A B (e1 : L0' _ _ A) (res1 : A) (e2 : L0' _ _ B) (res2 : B) : Prop
     := (sum_postrel call_res_refine_strict event_res_refine_strict) _ _ e1 res1 e2 res2.
 
-  Definition exp_E_refine_strict A B (e1 : IS1.LP.Events.exp_E A) (e2 : IS2.LP.Events.exp_E B) : Prop.
+  Definition exp_E_refine_strict A B (e1 : exp_E DV1.dvalue DV1.uvalue A) (e2 : exp_E DV2.dvalue DV2.uvalue B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2292,7 +2311,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition exp_E_res_refine_strict A B (e1 : IS1.LP.Events.exp_E A) (res1 : A) (e2 : IS2.LP.Events.exp_E B) (res2 : B) : Prop.
+  Definition exp_E_res_refine_strict A B (e1 : exp_E DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : exp_E DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2319,7 +2338,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition instr_E_refine_strict A B (e1 : IS1.LP.Events.instr_E A) (e2 : IS2.LP.Events.instr_E B) : Prop.
+  Definition instr_E_refine_strict A B (e1 : instr_E DV1.dvalue DV1.uvalue A) (e2 : instr_E DV2.dvalue DV2.uvalue B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2334,7 +2353,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             end).
   Defined.
 
-  Definition instr_E_res_refine_strict A B (e1 : IS1.LP.Events.instr_E A) (res1 : A) (e2 : IS2.LP.Events.instr_E B) (res2 : B) : Prop.
+  Definition instr_E_res_refine_strict A B (e1 : instr_E DV1.dvalue DV1.uvalue A) (res1 : A) (e2 : instr_E DV2.dvalue DV2.uvalue B) (res2 : B) : Prop.
   Proof.
     refine (match e1, e2 with
             | inl1 e1, inl1 e2 =>
@@ -2393,7 +2412,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma trigger_alloca_E1E2_rutt_strict_sound :
     forall dt n osz,
       rutt event_refine_strict event_res_refine_strict dvalue_refine_strict
-        (trigger (IS1.LP.Events.Alloca dt n osz)) (trigger (Alloca dt n osz)).
+        (trigger (@Alloca _ _ dt n osz)) (trigger (@Alloca _ _ dt n osz)).
   Proof.
     intros dt n osz.
     apply rutt_trigger.
@@ -2505,9 +2524,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma exp_E_refine_strict_event_refine_strict :
-    forall A B (e1 : IS1.LP.Events.exp_E A) (e2 : exp_E B),
+    forall A B (e1 : exp_E DV1.dvalue DV1.uvalue A) (e2 : exp_E DV2.dvalue DV2.uvalue B),
       exp_E_refine_strict A B e1 e2 ->
-      event_refine_strict A B (IS1.LP.Events.exp_to_L0 e1) (exp_to_L0 e2).
+      event_refine_strict A B (exp_to_L0 e1) (exp_to_L0 e2).
   Proof.
     intros A B e1 e2 H.
     destruct e1, e2.
@@ -2572,9 +2591,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma exp_E_refine_strict_instr_E_refine_strict :
-    forall A B (e1 : IS1.LP.Events.exp_E A) (e2 : exp_E B),
+    forall A B (e1 : exp_E DV1.dvalue DV1.uvalue A) (e2 : exp_E _ _ B),
       exp_E_refine_strict A B e1 e2 ->
-      instr_E_refine_strict A B (IS1.LP.Events.exp_to_instr e1) (exp_to_instr e2).
+      instr_E_refine_strict A B (exp_to_instr e1) (exp_to_instr e2).
   Proof.
     intros A B e1 e2 H.
     destruct e1, e2.
@@ -2638,9 +2657,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma instr_E_refine_strict_L0'_refine_strict :
-    forall A B (e1 : IS1.LP.Events.instr_E A) (e2 : instr_E B),
+    forall A B (e1 : instr_E DV1.dvalue DV1.uvalue A) (e2 : instr_E _ _ B),
       instr_E_refine_strict A B e1 e2 ->
-      L0'_refine_strict A B (IS1.LP.Events.instr_to_L0' e1) (instr_to_L0' e2).
+      L0'_refine_strict A B (instr_to_L0' e1) (instr_to_L0' e2).
   Proof.
     intros A B e1 e2 H.
     unfold L0'_refine_strict.
@@ -2707,8 +2726,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma event_refine_strict_exp_E_refine_strict_inv :
-    forall A B (e1 : IS1.LP.Events.exp_E A) (e2 : exp_E B) a b,
-      event_res_refine_strict A B (IS1.LP.Events.exp_to_L0 e1) a (exp_to_L0 e2) b ->
+    forall A B (e1 : exp_E DV1.dvalue DV1.uvalue A) (e2 : exp_E _ _ B) a b,
+      event_res_refine_strict A B (exp_to_L0 e1) a (exp_to_L0 e2) b ->
       exp_E_refine_strict A B e1 e2.
   Proof.
     intros A B e1 e2 a b H.
@@ -2719,8 +2738,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma event_res_refine_strict_exp_E_res_refine_strict_inv :
-    forall A B (e1 : IS1.LP.Events.exp_E A) (e2 : exp_E B) a b,
-      event_res_refine_strict A B (IS1.LP.Events.exp_to_L0 e1) a (exp_to_L0 e2) b ->
+    forall A B (e1 : exp_E DV1.dvalue DV1.uvalue A) (e2 : exp_E _ _ B) a b,
+      event_res_refine_strict A B (exp_to_L0 e1) a (exp_to_L0 e2) b ->
       exp_E_res_refine_strict A B e1 a e2 b.
   Proof.
     intros A B e1 e2 a b H.
@@ -2731,8 +2750,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma L0'_res_refine_strict_instr_E_res_refine_strict_inv :
-    forall A B (e1 : IS1.LP.Events.instr_E A) (e2 : instr_E B) a b,
-      L0'_res_refine_strict A B (IS1.LP.Events.instr_to_L0' e1) a (instr_to_L0' e2) b ->
+    forall A B (e1 : instr_E DV1.dvalue DV1.uvalue A) (e2 : instr_E _ _ B) a b,
+      L0'_res_refine_strict A B (instr_to_L0' e1) a (instr_to_L0' e2) b ->
       instr_E_res_refine_strict A B e1 a e2 b.
   Proof.
     intros A B e1 e2 a b H.
@@ -2748,8 +2767,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         t1
         t2 ->
       rutt event_refine_strict event_res_refine_strict RR
-        (translate IS1.LP.Events.exp_to_L0 t1)
-        (translate exp_to_L0 t2).
+        (translate (@exp_to_L0 DV1.dvalue DV1.uvalue) t1)
+        (translate (@exp_to_L0 DV2.dvalue DV2.uvalue) t2).
   Proof.
     intros *.
     revert t1 t2.
@@ -2796,8 +2815,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         t2
         (OOM:=OOME) ->
       orutt event_refine_strict event_res_refine_strict RR
-        (translate IS1.LP.Events.exp_to_L0 t1)
-        (translate exp_to_L0 t2)
+        (translate (@exp_to_L0 DV1.dvalue DV1.uvalue) t1)
+        (translate (@exp_to_L0 _ _) t2)
         (OOM:=OOME).
   Proof.
     intros *.
@@ -2850,8 +2869,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma instr_E_res_refine_strict_exp_E_res_refine_strict_inv :
-    forall A B (e1 : IS1.LP.Events.exp_E A) (e2 : exp_E B) a b,
-      instr_E_res_refine_strict A B (IS1.LP.Events.exp_to_instr e1) a (exp_to_instr e2) b ->
+    forall A B (e1 : exp_E DV1.dvalue DV1.uvalue A) (e2 : exp_E _ _ B) a b,
+      instr_E_res_refine_strict A B (exp_to_instr e1) a (exp_to_instr e2) b ->
       exp_E_res_refine_strict A B e1 a e2 b.
   Proof.
     intros A B e1 e2 a b H.
@@ -2865,8 +2884,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall {R1 R2} {RR : R1 -> R2 -> Prop} t1 t2,
       rutt instr_E_refine_strict instr_E_res_refine_strict RR t1 t2 ->
       rutt L0'_refine_strict L0'_res_refine_strict RR
-        (translate IS1.LP.Events.instr_to_L0' t1)
-        (translate instr_to_L0' t2).
+        (translate (@instr_to_L0' DV1.dvalue DV1.uvalue) t1)
+        (translate (@instr_to_L0' _ _) t2).
   Proof.
     intros *.
     revert t1 t2.
@@ -2907,8 +2926,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall {R1 R2} {RR : R1 -> R2 -> Prop} t1 t2,
       orutt instr_E_refine_strict instr_E_res_refine_strict RR t1 t2 (OOM:=OOME) ->
       orutt L0'_refine_strict L0'_res_refine_strict RR
-        (translate IS1.LP.Events.instr_to_L0' t1)
-        (translate instr_to_L0' t2)
+        (translate (@instr_to_L0' DV1.dvalue DV1.uvalue) t1)
+        (translate (@instr_to_L0' _ _) t2)
         (OOM:=OOME).
   Proof.
     intros *.
@@ -2946,8 +2965,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       intros o CONTRA.
       eapply H1.
       unfold instr_to_L0' in CONTRA.
-      unfold_subevents.
-      repeat break_match_hyp_inv; auto.
+      unfold_subevents. unfold OOME_L0' in *. 
+      repeat break_match_hyp_inv; auto. reflexivity.
     - gstep; eauto.
       red.
       cbn.
@@ -2966,8 +2985,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall {R1 R2} {RR : R1 -> R2 -> Prop} t1 t2,
       rutt exp_E_refine_strict exp_E_res_refine_strict RR t1 t2 ->
       rutt instr_E_refine_strict instr_E_res_refine_strict RR
-        (translate IS1.LP.Events.exp_to_instr t1)
-        (translate exp_to_instr t2).
+        (translate (@exp_to_instr DV1.dvalue DV1.uvalue) t1)
+        (translate (@exp_to_instr _ _)t2).
   Proof.
     intros *.
     revert t1 t2.
@@ -3008,8 +3027,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall {R1 R2} {RR : R1 -> R2 -> Prop} t1 t2,
       orutt exp_E_refine_strict exp_E_res_refine_strict RR t1 t2 (OOM:=OOME) ->
       orutt instr_E_refine_strict instr_E_res_refine_strict RR
-        (translate IS1.LP.Events.exp_to_instr t1)
-        (translate exp_to_instr t2)
+        (translate (@exp_to_instr DV1.dvalue DV1.uvalue) t1)
+        (translate (@exp_to_instr _ _) t2)
         (OOM:=OOME).
   Proof.
     intros *.
@@ -3048,7 +3067,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       eapply H1.
       unfold exp_to_instr in *.
       unfold_subevents.
-      repeat break_match_hyp_inv; auto.
+      repeat break_match_hyp_inv; auto. reflexivity.
     - gstep; eauto.
       red.
       cbn.
@@ -3066,7 +3085,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma translate_LU_to_exp_lookup_id_orutt :
     forall id : LLVMAst.ident,
       orutt exp_E_refine_strict exp_E_res_refine_strict uvalue_refine_strict
-        (translate IS1.LP.Events.LU_to_exp (IS1.LLVM.D.lookup_id id)) (translate LU_to_exp (lookup_id id))
+        (translate (@LU_to_exp _ _) (IS1.LLVM.D.lookup_id id)) (translate (@LU_to_exp _ _) (lookup_id id))
         (OOM:=OOME).
   Proof.
     intros id.
@@ -3131,7 +3150,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma is_concrete_l:
     forall (l : list DV1.uvalue) (l' : list DV2.uvalue),
       Forall2 (fun (a : DV1.uvalue) (b : DV2.uvalue) => uvalue_convert_strict a = NoOom b) l l' ->
-      forallb IS1.LP.Events.DV.is_concrete l = true ->
+      forallb DV1.is_concrete l = true ->
       forallb is_concrete l' = true.
   Proof.
     intros l l' H.
@@ -3149,7 +3168,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma is_concrete_l_false:
     forall (fields : list DV1.uvalue) (l : list DV2.uvalue),
       Forall2 (fun (a : DV1.uvalue) (b : DV2.uvalue) => uvalue_convert_strict a = NoOom b) fields l ->
-      forallb IS1.LP.Events.DV.is_concrete fields = false ->
+      forallb DV1.is_concrete fields = false ->
       forallb is_concrete l = true
       -> False.
   Proof.
@@ -3170,10 +3189,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma map_dvalue_convert_strict_succeeds:
     forall (fields : list DV1.uvalue) (l : list DV2.uvalue),
       Forall2 (fun (a : DV1.uvalue) (b : DV2.uvalue) => uvalue_convert_strict a = NoOom b) fields l ->
-      forall l0 : list IS1.LP.Events.DV.dvalue,
+      forall l0 : list DV1.dvalue,
         Forall2
-          (fun (a : IS1.LP.Events.DV.uvalue) (b : IS1.LP.Events.DV.dvalue) =>
-             IS1.LP.Events.DV.uvalue_to_dvalue a = inr b) fields l0 ->
+          (fun (a : DV1.uvalue) (b : DV1.dvalue) =>
+             DV1.uvalue_to_dvalue a = inr b) fields l0 ->
         forall l1 : list dvalue,
           map_monad uvalue_to_dvalue l = inr l1 -> map_monad dvalue_convert_strict l0 = NoOom l1.
   Proof.
@@ -3641,7 +3660,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma contains_undef_or_poison_E1_E2 :
     forall u2 u1,
       uvalue_refine_strict u1 u2 ->
-      IS1.LP.Events.DV.contains_undef_or_poison u1 = contains_undef_or_poison u2.
+      DV1.contains_undef_or_poison u1 = contains_undef_or_poison u2.
   Proof.
     intros u2.
     induction u2; intros u1 REF;
@@ -4092,7 +4111,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma dvalue_has_dtyp_fin_to_inf_dvalue :
     forall dv_fin t,
       dvalue_has_dtyp dv_fin t ->
-      IS1.LP.Events.DV.dvalue_has_dtyp (fin_to_inf_dvalue dv_fin) t.
+      DV1.dvalue_has_dtyp (fin_to_inf_dvalue dv_fin) t.
   Proof.
     intros dv_fin t TYP.
     induction TYP;
@@ -4747,7 +4766,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma dvalue_convert_strict_struct_map :
     forall fields_fin res,
       DVCrev.dvalue_convert_strict (DVALUE_Struct fields_fin) = NoOom res ->
-      res = (IS1.LP.Events.DV.DVALUE_Struct (map fin_to_inf_dvalue fields_fin)).
+      res = (DV1.DVALUE_Struct (map fin_to_inf_dvalue fields_fin)).
   Proof.
     intros fields_fin res CONV.
     cbn in CONV.
@@ -4766,7 +4785,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma dvalue_convert_strict_packed_struct_map :
     forall fields_fin res,
       DVCrev.dvalue_convert_strict (DVALUE_Packed_struct fields_fin) = NoOom res ->
-      res = (IS1.LP.Events.DV.DVALUE_Packed_struct (map fin_to_inf_dvalue fields_fin)).
+      res = (DV1.DVALUE_Packed_struct (map fin_to_inf_dvalue fields_fin)).
   Proof.
     intros fields_fin res CONV.
     cbn in CONV.
@@ -4785,7 +4804,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma dvalue_convert_strict_array_map :
     forall fields_fin res t,
       DVCrev.dvalue_convert_strict (DVALUE_Array t fields_fin) = NoOom res ->
-      res = (IS1.LP.Events.DV.DVALUE_Array t (map fin_to_inf_dvalue fields_fin)).
+      res = (DV1.DVALUE_Array t (map fin_to_inf_dvalue fields_fin)).
   Proof.
     intros fields_fin res t CONV.
     cbn in CONV.
@@ -4804,7 +4823,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma dvalue_convert_strict_vector_map :
     forall fields_fin res t,
       DVCrev.dvalue_convert_strict (DVALUE_Vector t fields_fin) = NoOom res ->
-      res = (IS1.LP.Events.DV.DVALUE_Vector t (map fin_to_inf_dvalue fields_fin)).
+      res = (DV1.DVALUE_Vector t (map fin_to_inf_dvalue fields_fin)).
   Proof.
     intros fields_fin res t CONV.
     cbn in CONV.
@@ -4996,8 +5015,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dvalue_refine_strict r1 r2 ->
       uvalue_refine_strict r3 r4 ->
       rutt exp_E_refine_strict exp_E_res_refine_strict eq
-        (trigger (IS1.LP.Events.Store dt r1 r3))
-        (trigger (IS2.LP.Events.Store dt r2 r4)).
+        (trigger (@Store DV1.dvalue DV1.uvalue dt r1 r3))
+        (trigger (@Store _ _ dt r2 r4)).
   Proof.
     intros dt r1 r2 r3 r4 R1R2 R3R4.
     apply rutt_trigger.
@@ -5010,7 +5029,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   (* TODO: move this! Probably somewhere that I get a version for each language? *)
   Ltac solve_dec_oom :=
     let s := fresh "s" in
-    first [intros ? s | intros s];
+    first [intros ? ? ? s | intros s];
     repeat destruct s;
     try solve
       [
@@ -5022,21 +5041,21 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     eexists; reflexivity.
 
   Lemma exp_E_dec_oom :
-    forall A (e : exp_E A), {forall o : OOME A, e <> subevent _ o} + {exists o : OOME A, e = subevent _ o}.
+    forall A d u (e : @exp_E d u A), {forall o : OOME A, e <> subevent _ o} + {exists o : OOME A, e = subevent _ o}.
   Proof.
     solve_dec_oom.
   Qed.
 
   (* TODO: move this! *)
   Lemma L0'_dec_oom :
-    forall A (e : L0' A), {forall o : OOME A, e <> subevent _ o} + {exists o : OOME A, e = subevent _ o}.
+    forall A d u (e : @L0' d u A), {forall o : OOME A, e <> subevent _ o} + {exists o : OOME A, e = subevent _ o}.
   Proof.
     solve_dec_oom.
   Qed.
 
   (* TODO: move this! *)
   Lemma L0_dec_oom :
-    forall A (e : L0 A), {forall o : OOME A, e <> subevent _ o} + {exists o : OOME A, e = subevent _ o}.
+    forall A d u (e : @L0 d u A), {forall o : OOME A, e <> subevent _ o} + {exists o : OOME A, e = subevent _ o}.
   Proof.
     solve_dec_oom.
   Qed.
@@ -5066,12 +5085,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@ToDvalue_Int sz)
         iop v1 v2 = success_unERR_UB_OOM res_fin ->
       DVCrev.dvalue_convert_strict res_fin = NoOom res_inf ->
-      @IS1.LP.Events.DV.eval_int_op err_ub_oom (@Integers.bit_int sz)
+      @DV1.eval_int_op err_ub_oom (@Integers.bit_int sz)
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@IS1.LP.Events.DV.ToDvalue_Int sz)
+        (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@DV1.ToDvalue_Int sz)
         iop v1 v2 = success_unERR_UB_OOM res_inf.
   Proof.
     intros sz v1 v2 iop res_fin res_inf EVAL CONV.
@@ -5129,12 +5148,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       IS1.LP.IP.from_Z (IP.to_Z v1_fin) = NoOom v1_inf ->
       IS1.LP.IP.from_Z (IP.to_Z v2_fin) = NoOom v2_inf ->
       DVCrev.dvalue_convert_strict res_fin = NoOom res_inf ->
-      @IS1.LP.Events.DV.eval_int_op err_ub_oom IS1.LP.IP.intptr
+      @DV1.eval_int_op err_ub_oom IS1.LP.IP.intptr
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        IS1.LP.Events.DV.VMemInt_intptr' IS1.LP.Events.DV.ToDvalue_intptr
+        DV1.VMemInt_intptr' DV1.ToDvalue_intptr
         iop v1_inf v2_inf = success_unERR_UB_OOM res_inf.
   Proof.
     intros v1_fin v2_fin v1_inf v2_inf iop res_fin res_inf
@@ -5486,7 +5505,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         iop dv1_fin dv2_fin = ret res_fin ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_iop_integer_h err_ub_oom
+      @DV1.eval_iop_integer_h err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -5572,7 +5591,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
           fin_to_inf_dvalue dv2_fin = dv2_inf ->
           f_inf dv1_inf dv2_inf = ret (fin_to_inf_dvalue res_fin)) ->
       @vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_fin (combine xs ys) = ret res ->
-      @IS1.LP.Events.DV.vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_inf (combine (map fin_to_inf_dvalue xs) (map fin_to_inf_dvalue ys)) = ret (map fin_to_inf_dvalue res).
+      @DV1.vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_inf (combine (map fin_to_inf_dvalue xs) (map fin_to_inf_dvalue ys)) = ret (map fin_to_inf_dvalue res).
   Proof.
     intros f_fin f_inf xs ys res F RES.
 
@@ -5627,7 +5646,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         iop dv1_fin dv2_fin = ret res_fin ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_iop err_ub_oom
+      @DV1.eval_iop err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -5714,12 +5733,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       @eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) Int VMInt ss icmp a b = ret res_fin  ->
-      @IS1.LP.Events.DV.eval_int_icmp err_ub_oom
+      @DV1.eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) Int VMInt ss icmp a b = ret (fin_to_inf_dvalue res_fin).
   Proof.
     intros Int VMInt ss icmp a b res_fin FIN.
-    unfold eval_int_icmp, IS1.LP.Events.DV.eval_int_icmp.
+    unfold eval_int_icmp, DV1.eval_int_icmp.
     unfold eval_int_icmp in FIN.
     destruct ss.
     - destruct (true && negb (msamesign a b))%bool.
@@ -5766,11 +5785,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       IS1.LP.IP.from_Z (IP.to_Z v1_fin) = NoOom v1_inf ->
       IS1.LP.IP.from_Z (IP.to_Z v2_fin) = NoOom v2_inf ->
       DVCrev.dvalue_convert_strict res_fin = NoOom res_inf ->
-      @IS1.LP.Events.DV.eval_int_icmp err_ub_oom
+      @DV1.eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         IS1.LP.IP.intptr
-        IS1.LP.Events.DV.VMemInt_intptr'
+        DV1.VMemInt_intptr'
         ss icmp v1_inf v2_inf = success_unERR_UB_OOM res_inf.
   Proof.
     intros v1_fin v2_fin v1_inf v2_inf ss icmp res_fin res_inf EVAL LIFT1 LIFT2 CONV.
@@ -5840,7 +5859,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         samesign icmp dv1_inf dv2_inf = ret (fin_to_inf_dvalue res_fin).
   Proof.
     intros dv1_fin dv2_fin res_fin samesign icmp dv1_inf dv2_inf EVAL LIFT1 LIFT2.
-    Opaque IS1.LP.Events.DV.eval_int_icmp
+    Opaque DV1.eval_int_icmp
       eval_int_icmp.
     unfold eval_icmp in EVAL.
     (* Nasty case analysis... *)
@@ -5895,7 +5914,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall fop a b res_fin res_inf,
       double_op fop a b = success_unERR_UB_OOM res_fin ->
       DVCrev.dvalue_convert_strict res_fin = NoOom res_inf ->
-      IS1.LP.Events.DV.double_op fop a b = success_unERR_UB_OOM res_inf.
+      DV1.double_op fop a b = success_unERR_UB_OOM res_inf.
   Proof.
     intros fop a b res_fin res_inf EVAL REF.
     destruct fop; cbn in *; inv EVAL;
@@ -5908,7 +5927,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   x1 : DVCrev.DV2.dvalue
   e1 : dvalue_convert_strict x1 = NoOom (DVALUE_Double (Floats.Float.neg x))
   ============================
-  IS1.LP.Events.DV.eval_fneg (DVCrev.DV2.DVALUE_Double x) = success_unERR_UB_OOM x1
+  DV1.eval_fneg (DVCrev.DV2.DVALUE_Double x) = success_unERR_UB_OOM x1
 
 *)
 
@@ -5916,7 +5935,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma double_neg_fin_inf :
     forall f res_fin,
       dvalue_convert_strict res_fin = NoOom (DVALUE_Double (Floats.Float.neg f)) ->
-      IS1.LP.Events.DV.eval_fneg (IS1.LP.Events.DV.DVALUE_Double f) = success_unERR_UB_OOM res_fin.
+      DV1.eval_fneg (DV1.DVALUE_Double f) = success_unERR_UB_OOM res_fin.
   Proof.
     intros f res_fin  EVAL.
     cbn in *; inv EVAL.
@@ -5928,7 +5947,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma float_neg_fin_inf :
     forall f res_fin,
       dvalue_convert_strict res_fin = NoOom (DVALUE_Float (Floats.Float32.neg f)) ->
-      IS1.LP.Events.DV.eval_fneg (IS1.LP.Events.DV.DVALUE_Float f) = success_unERR_UB_OOM res_fin.
+      DV1.eval_fneg (DV1.DVALUE_Float f) = success_unERR_UB_OOM res_fin.
   Proof.
     intros f res_fin  EVAL.
     cbn in *; inv EVAL.
@@ -5940,7 +5959,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall t res_fin res_inf,
       eval_fneg (DVALUE_Poison t) = success_unERR_UB_OOM res_fin -> 
       DVCrev.dvalue_convert_strict res_fin = NoOom res_inf ->
-      IS1.LP.Events.DV.eval_fneg (IS1.LP.Events.DV.DVALUE_Poison t) = success_unERR_UB_OOM res_inf.
+      DV1.eval_fneg (DV1.DVALUE_Poison t) = success_unERR_UB_OOM res_inf.
   Proof.
     intros t res_fin res_inf EVAL REF.
     cbn in *; inv EVAL;
@@ -5953,7 +5972,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall fop a b res_fin res_inf,
       float_op fop a b = success_unERR_UB_OOM res_fin ->
       DVCrev.dvalue_convert_strict res_fin = NoOom res_inf ->
-      IS1.LP.Events.DV.float_op fop a b = success_unERR_UB_OOM res_inf.
+      DV1.float_op fop a b = success_unERR_UB_OOM res_inf.
   Proof.
     intros fop a b res_fin res_inf EVAL REF.
     destruct fop; cbn in *; inv EVAL;
@@ -5970,7 +5989,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         fop dv1_fin dv2_fin = ret res_fin ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_fop err_ub_oom
+      @DV1.eval_fop err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -5991,8 +6010,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         cbn.
 
         (* These should be the same... *)
-        unfold IS1.LP.Events.DV.fop_is_div.
-        unfold fop_is_div in Heqb.
+        unfold AstLib.fop_is_div in *.
         rewrite Heqb.
         reflexivity.
       }
@@ -6017,8 +6035,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         cbn.
 
         (* These should be the same... *)
-        unfold IS1.LP.Events.DV.fop_is_div.
-        unfold fop_is_div in Heqb.
+        unfold AstLib.fop_is_div in *.
         rewrite Heqb.
         reflexivity.
       }
@@ -6048,7 +6065,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         dv1_fin  = ret res_fin ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
-      @IS1.LP.Events.DV.eval_fneg err_ub_oom
+      @DV1.eval_fneg err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -6089,14 +6106,14 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall fcmp a b res_fin res_inf,
       double_cmp fcmp a b = res_fin ->
       DVCrev.dvalue_convert_strict res_fin = NoOom res_inf ->
-      IS1.LP.Events.DV.double_cmp fcmp a b = res_inf.
+      DV1.double_cmp fcmp a b = res_inf.
   Proof.
     intros fcmp a b res_fin res_inf EVAL REF.
     destruct fcmp; cbn in *; subst;
       cbn in REF;
       inv REF; auto;
       solve
-        [ unfold double_cmp, IS1.LP.Events.DV.double_cmp in *;
+        [ unfold double_cmp, DV1.double_cmp in *;
           repeat break_match_hyp_inv; auto;
           setoid_rewrite Heqb0; reflexivity
         ].
@@ -6106,14 +6123,14 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall fcmp a b res_fin res_inf,
       float_cmp fcmp a b = res_fin ->
       DVCrev.dvalue_convert_strict res_fin = NoOom res_inf ->
-      IS1.LP.Events.DV.float_cmp fcmp a b = res_inf.
+      DV1.float_cmp fcmp a b = res_inf.
   Proof.
     intros fcmp a b res_fin res_inf EVAL REF.
     destruct fcmp; cbn in *; subst;
       cbn in REF;
       inv REF; auto;
       solve
-        [ unfold float_cmp, IS1.LP.Events.DV.float_cmp in *;
+        [ unfold float_cmp, DV1.float_cmp in *;
           repeat break_match_hyp_inv; auto;
           setoid_rewrite Heqb0; reflexivity
         ].
@@ -6127,7 +6144,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         fcmp dv1_fin dv2_fin = ret res_fin ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_fcmp err_ub_oom
+      @DV1.eval_fcmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         fcmp dv1_inf dv2_inf = ret (fin_to_inf_dvalue res_fin).
@@ -6543,7 +6560,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         dvalue_refine_strict_inv REF; auto.
         rename fields0 into dts.
         rewrite max_preferred_dtyp_alignment_fin_inf.
-        generalize (SIZEOF.max_preferred_dtyp_alignment dts) as struct_padding.
+        generalize (SZ.max_preferred_dtyp_alignment dts) as struct_padding.
         revert dts idx.
         eapply map_monad_oom_Forall2 in H1.
         revert x H1.
@@ -6560,7 +6577,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
           + forward IHfields; intros; auto.
             apply H; cbn; auto.
             cbn in IHfields.
-            specialize (IHfields (offset + pad_amount (preferred_alignment (SIZEOF.dtyp_alignment d)) offset + SIZEOF.sizeof_dtyp d) l H5 dts (idx - Z.of_N (pad_amount (preferred_alignment (SIZEOF.dtyp_alignment d)) offset) - Z.of_N (SIZEOF.sizeof_dtyp d))%Z struct_padding).
+            specialize (IHfields (offset + pad_amount (preferred_alignment (SZ.dtyp_alignment d)) offset + SZ.sizeof_dtyp d) l H5 dts (idx - Z.of_N (pad_amount (preferred_alignment (SZ.dtyp_alignment d)) offset) - Z.of_N (SZ.sizeof_dtyp d))%Z struct_padding).
             cbn in *.
             erewrite IHfields; intros; eauto.
       } 
@@ -6596,7 +6613,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         - reflexivity.
         - cbn.
           rewrite sizeof_dtyp_fin_inf.
-          destruct (idx <? Z.of_N (SIZEOF.sizeof_dtyp dt))%Z.
+          destruct (idx <? Z.of_N (SZ.sizeof_dtyp dt))%Z.
           + apply H. repeat constructor. apply H4.
           + erewrite IHelts; intros; eauto.
             apply H; cbn; auto.
@@ -6612,7 +6629,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         - reflexivity.
         - cbn.
           rewrite sizeof_dtyp_fin_inf.
-          destruct (idx <? Z.of_N (SIZEOF.sizeof_dtyp dt))%Z.
+          destruct (idx <? Z.of_N (SZ.sizeof_dtyp dt))%Z.
           + apply H. repeat constructor. apply H4.
           + apply IHelts; intros; auto.
             apply H; auto.
@@ -6828,11 +6845,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
          | (dt::dts) =>
              let padding :=
                if pad
-               then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset
+               then pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset
                else 0%N
              in
              let zpadding := Z.of_N padding in
-             let sz := SIZEOF.sizeof_dtyp dt in
+             let sz := SZ.sizeof_dtyp dt in
              (* Skip any padding bytes *)
              let dbs' := drop padding dbs in
              let init_bytes := take sz dbs' in
@@ -6851,11 +6868,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
          | (dt::dts) =>
              let padding :=
                if pad
-               then pad_amount (preferred_alignment (IS1.LP.SIZEOF.dtyp_alignment dt)) offset
+               then pad_amount (preferred_alignment (IS1.LP.SZ.dtyp_alignment dt)) offset
                else 0%N
              in
              let zpadding := Z.of_N padding in
-             let sz := IS1.LP.SIZEOF.sizeof_dtyp dt in
+             let sz := IS1.LP.SZ.sizeof_dtyp dt in
              (* Skip any padding bytes *)
              let dbs' := drop padding dbs in
              let init_bytes := take sz dbs' in
@@ -6888,8 +6905,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       }
 
       remember (dvalue_bytes_to_dvalue
-                  (take (SIZEOF.sizeof_dtyp a)
-                     (drop (if pad then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment a)) offset else 0)
+                  (take (SZ.sizeof_dtyp a)
+                     (drop (if pad then pad_amount (preferred_alignment (SZ.dtyp_alignment a)) offset else 0)
                         dvbs_fin)) a) as init.
       destruct_err_oom_poison init;
         try solve [subst; cbn; eauto].
@@ -6902,29 +6919,29 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             | dt :: dts0 =>
                 f0 <-
                   dvalue_bytes_to_dvalue
-                    (take (SIZEOF.sizeof_dtyp dt)
+                    (take (SZ.sizeof_dtyp dt)
                        (drop
                           (if pad
-                           then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset
+                           then pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset
                            else 0) dbs)) dt;;
                 rest <-
                   go
                     (offset +
-                       (if pad then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset else 0) +
-                       SIZEOF.sizeof_dtyp dt) dts0
-                    (drop (SIZEOF.sizeof_dtyp dt)
+                       (if pad then pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset else 0) +
+                       SZ.sizeof_dtyp dt) dts0
+                    (drop (SZ.sizeof_dtyp dt)
                        (drop
                           (if pad
-                           then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset
+                           then pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset
                            else 0) dbs));;
                 {|
                   EitherMonad.unEitherT := {| unMkOomableT := Unpoisoned (Unoomed (inr (f0 :: rest))) |}
                 |}
             end)
-           (offset + (if pad then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment a)) offset else 0) +
-              SIZEOF.sizeof_dtyp a) dts
-           (drop (SIZEOF.sizeof_dtyp a)
-              (drop (if pad then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment a)) offset else 0)
+           (offset + (if pad then pad_amount (preferred_alignment (SZ.dtyp_alignment a)) offset else 0) +
+              SZ.sizeof_dtyp a) dts
+           (drop (SZ.sizeof_dtyp a)
+              (drop (if pad then pad_amount (preferred_alignment (SZ.dtyp_alignment a)) offset else 0)
                  dvbs_fin))) as rest.
 
       erewrite IHdts with (res:=rest).
@@ -7090,7 +7107,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       Opaque IS1.LLVM.MEM.DVALUE_BYTE.dvalue_bytes_to_dvalue
         dvalue_bytes_to_dvalue.
       cbn in *.
-      destruct ((SIZEOF.sizeof_dtyp dt =? 0)%N) eqn:HSIZE.
+      destruct ((SZ.sizeof_dtyp dt =? 0)%N) eqn:HSIZE.
       { clear - IHdt NOOM.
         induction sz using N.peano_ind.
         - cbn.
@@ -7144,8 +7161,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             reflexivity.
       }
 
-      remember (split_every_nil (SIZEOF.sizeof_dtyp dt) dvbs_fin) as split_fin.
-      remember (split_every_nil (SIZEOF.sizeof_dtyp dt) dvbs_inf) as split_inf.
+      remember (split_every_nil (SZ.sizeof_dtyp dt) dvbs_fin) as split_fin.
+      remember (split_every_nil (SZ.sizeof_dtyp dt) dvbs_inf) as split_inf.
       symmetry in Heqsplit_fin, Heqsplit_inf.
 
       pose proof split_every_nil_Forall2 _ _ _ _ _ _ REF Heqsplit_inf Heqsplit_fin as ALL.
@@ -7221,16 +7238,16 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       remember
         (fun pad : option N => fix go
            (offset : N) (dts : list dtyp) (dbs : list IS1.LLVM.MEM.DVALUE_BYTE.dvalue_byte) {struct dts} :
-          ErrOOMPoison (list IS1.LP.Events.DV.dvalue) :=
+          ErrOOMPoison (list DV1.dvalue) :=
            match dts with
            | [] => ret []
            | dt :: dts0 =>
                let padding :=
                  if pad
-                 then pad_amount (preferred_alignment (IS1.LP.SIZEOF.dtyp_alignment dt)) offset
+                 then pad_amount (preferred_alignment (IS1.LP.SZ.dtyp_alignment dt)) offset
                  else 0 in
                let zpadding := Z.of_N padding in
-               let sz := IS1.LP.SIZEOF.sizeof_dtyp dt in
+               let sz := IS1.LP.SZ.sizeof_dtyp dt in
                let dbs' := drop padding dbs in
                let init_bytes := take sz dbs' in
                let rest_bytes := drop sz dbs' in
@@ -7247,10 +7264,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
            | [] => ret []
            | dt :: dts0 =>
                let padding :=
-                 if pad then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset else 0
+                 if pad then pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset else 0
                in
                let zpadding := Z.of_N padding in
-               let sz := SIZEOF.sizeof_dtyp dt in
+               let sz := SZ.sizeof_dtyp dt in
                let dbs' := drop padding dbs in
                let init_bytes := take sz dbs' in
                let rest_bytes := drop sz dbs' in
@@ -7269,9 +7286,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
            match dts with
            | [] => ret []
            | dt :: dts0 =>
-               let padding := pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset in
+               let padding := pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset in
                let zpadding := Z.of_N padding in
-               let sz := SIZEOF.sizeof_dtyp dt in
+               let sz := SZ.sizeof_dtyp dt in
                let dbs' := drop padding dbs in
                let init_bytes := take sz dbs' in
                let rest_bytes := drop sz dbs' in
@@ -7296,16 +7313,16 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
            | [] => ret []
            | dt :: dts0 =>
                let padding :=
-                 if pad then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset else 0 in
+                 if pad then pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset else 0 in
                let zpadding := Z.of_N padding in
-               let sz := SIZEOF.sizeof_dtyp dt in
+               let sz := SZ.sizeof_dtyp dt in
                let dbs' := drop padding dbs in
                let init_bytes := take sz dbs' in
                let rest_bytes := drop sz dbs' in
                let offset' := offset + padding in
                f <- dvalue_bytes_to_dvalue init_bytes dt;;
                rest <- go (offset' + sz) dts0 rest_bytes;; ret (f :: rest)
-           end) (Some (SIZEOF.max_preferred_dtyp_alignment fields)) 0 fields dvbs_fin) as res.
+           end) (Some (SZ.max_preferred_dtyp_alignment fields)) 0 fields dvbs_fin) as res.
       destruct_err_oom_poison res; inv CONTRA; cbn in *; auto;
       setoid_rewrite H1;
       cbn;
@@ -7323,16 +7340,16 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       remember
         (fun pad : option N => fix go
            (offset : N) (dts : list dtyp) (dbs : list IS1.LLVM.MEM.DVALUE_BYTE.dvalue_byte) {struct dts} :
-          ErrOOMPoison (list IS1.LP.Events.DV.dvalue) :=
+          ErrOOMPoison (list DV1.dvalue) :=
            match dts with
            | [] => ret []
            | dt :: dts0 =>
                let padding :=
                  if pad
-                 then pad_amount (preferred_alignment (IS1.LP.SIZEOF.dtyp_alignment dt)) offset
+                 then pad_amount (preferred_alignment (IS1.LP.SZ.dtyp_alignment dt)) offset
                  else 0 in
                let zpadding := Z.of_N padding in
-               let sz := IS1.LP.SIZEOF.sizeof_dtyp dt in
+               let sz := IS1.LP.SZ.sizeof_dtyp dt in
                let dbs' := drop padding dbs in
                let init_bytes := take sz dbs' in
                let rest_bytes := drop sz dbs' in
@@ -7349,10 +7366,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
            | [] => ret []
            | dt :: dts0 =>
                let padding :=
-                 if pad then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset else 0
+                 if pad then pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset else 0
                in
                let zpadding := Z.of_N padding in
-               let sz := SIZEOF.sizeof_dtyp dt in
+               let sz := SZ.sizeof_dtyp dt in
                let dbs' := drop padding dbs in
                let init_bytes := take sz dbs' in
                let rest_bytes := drop sz dbs' in
@@ -7373,7 +7390,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
            | dt :: dts0 =>
                let padding := 0 in
                let zpadding := Z.of_N padding in
-               let sz := SIZEOF.sizeof_dtyp dt in
+               let sz := SZ.sizeof_dtyp dt in
                let dbs' := drop padding dbs in
                let init_bytes := take sz dbs' in
                let rest_bytes := drop sz dbs' in
@@ -7398,9 +7415,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
            | [] => ret []
            | dt :: dts0 =>
                let padding :=
-                 if pad then pad_amount (preferred_alignment (SIZEOF.dtyp_alignment dt)) offset else 0 in
+                 if pad then pad_amount (preferred_alignment (SZ.dtyp_alignment dt)) offset else 0 in
                let zpadding := Z.of_N padding in
-               let sz := SIZEOF.sizeof_dtyp dt in
+               let sz := SZ.sizeof_dtyp dt in
                let dbs' := drop padding dbs in
                let init_bytes := take sz dbs' in
                let rest_bytes := drop sz dbs' in
@@ -7422,7 +7439,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       Opaque IS1.LLVM.MEM.DVALUE_BYTE.dvalue_bytes_to_dvalue
         dvalue_bytes_to_dvalue.
       cbn in *.
-      destruct ((SIZEOF.sizeof_dtyp dt =? 0)%N) eqn:HSIZE.
+      destruct ((SZ.sizeof_dtyp dt =? 0)%N) eqn:HSIZE.
       { clear - IHdt NOOM.
         induction sz using N.peano_ind.
         - cbn.
@@ -7476,8 +7493,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
             reflexivity.
       }
 
-      remember (split_every_nil (SIZEOF.sizeof_dtyp dt) dvbs_fin) as split_fin.
-      remember (split_every_nil (SIZEOF.sizeof_dtyp dt) dvbs_inf) as split_inf.
+      remember (split_every_nil (SZ.sizeof_dtyp dt) dvbs_fin) as split_fin.
+      remember (split_every_nil (SZ.sizeof_dtyp dt) dvbs_inf) as split_inf.
       symmetry in Heqsplit_fin, Heqsplit_inf.
 
       pose proof split_every_nil_Forall2 _ _ _ _ _ _ REF Heqsplit_inf Heqsplit_fin as ALL.
@@ -7555,7 +7572,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        IS1.LP.Events.DV.dvalue IS1.LP.Events.DV.DVALUE_Poison (IS1.LLVM.MEM.MP.DVALUE_BYTES.dvalue_bytes_to_dvalue dvbs_inf τ) = success_unERR_UB_OOM (fin_to_inf_dvalue res).
+        DV1.dvalue DV1.DVALUE_Poison (IS1.LLVM.MEM.MP.DVALUE_BYTES.dvalue_bytes_to_dvalue dvbs_inf τ) = success_unERR_UB_OOM (fin_to_inf_dvalue res).
   Proof.
     intros τ dvbs_inf dvbs_fin res H H0.
     remember (@DVALUE_BYTES.dvalue_bytes_to_dvalue ErrOOMPoison
@@ -7671,7 +7688,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma get_conv_case_pure_fin_inf:
     forall conv t_from dv t_to res,
       get_conv_case conv t_from dv t_to = Conv_Pure res ->
-      IS1.LLVM.MEM.CP.CONC.get_conv_case conv t_from (fin_to_inf_dvalue dv) t_to = IS1.LP.Events.DV.Conv_Pure (fin_to_inf_dvalue res).
+      IS1.LLVM.MEM.CP.CONC.get_conv_case conv t_from (fin_to_inf_dvalue dv) t_to = DV1.Conv_Pure (fin_to_inf_dvalue res).
   Proof.
     intros conv t_from dv t_to res CONV.
     destruct conv.
@@ -7806,7 +7823,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma get_conv_case_itop_fin_inf:
     forall conv t_from dv t_to res,
       get_conv_case conv t_from dv t_to = Conv_ItoP res ->
-      IS1.LLVM.MEM.CP.CONC.get_conv_case conv t_from (fin_to_inf_dvalue dv) t_to = IS1.LP.Events.DV.Conv_ItoP (fin_to_inf_dvalue res).
+      IS1.LLVM.MEM.CP.CONC.get_conv_case conv t_from (fin_to_inf_dvalue dv) t_to = DV1.Conv_ItoP (fin_to_inf_dvalue res).
   Proof.
     intros conv t_from dv t_to res CONV.
     destruct conv.
@@ -7916,7 +7933,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma get_conv_case_ptoi_fin_inf:
     forall conv t_from dv t_to res,
       get_conv_case conv t_from dv t_to = Conv_PtoI res ->
-      IS1.LLVM.MEM.CP.CONC.get_conv_case conv t_from (fin_to_inf_dvalue dv) t_to = IS1.LP.Events.DV.Conv_PtoI (fin_to_inf_dvalue res).
+      IS1.LLVM.MEM.CP.CONC.get_conv_case conv t_from (fin_to_inf_dvalue dv) t_to = DV1.Conv_PtoI (fin_to_inf_dvalue res).
   Proof.
     intros conv t_from dv t_to res CONV.
     destruct conv.
@@ -8058,8 +8075,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
         - cbn.
           replace
-            (fun (acc : N) (t : dtyp) => pad_to_align (IS1.LP.SIZEOF.dtyp_alignment t) acc + IS1.LP.SIZEOF.sizeof_dtyp t)%N with
-              (fun (acc : N) (t : dtyp) => pad_to_align (SIZEOF.dtyp_alignment t) acc + SIZEOF.sizeof_dtyp t)%N; eauto.
+            (fun (acc : N) (t : dtyp) => pad_to_align (IS1.LP.SZ.dtyp_alignment t) acc + IS1.LP.SZ.sizeof_dtyp t)%N with
+              (fun (acc : N) (t : dtyp) => pad_to_align (SZ.dtyp_alignment t) acc + SZ.sizeof_dtyp t)%N; eauto.
 
           apply FunctionalExtensionality.functional_extensionality.
           intros.
@@ -8069,8 +8086,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
           rewrite dtyp_alignment_fin_inf.
           auto.
         - replace
-            (fun (acc : N) (t : dtyp) => acc + IS1.LP.SIZEOF.sizeof_dtyp t) with
-            (fun (acc : N) (t : dtyp) => acc + SIZEOF.sizeof_dtyp t); eauto.
+            (fun (acc : N) (t : dtyp) => acc + IS1.LP.SZ.sizeof_dtyp t) with
+            (fun (acc : N) (t : dtyp) => acc + SZ.sizeof_dtyp t); eauto.
 
           apply FunctionalExtensionality.functional_extensionality.
           intros.
@@ -8136,7 +8153,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall t vec idx res,
       @index_into_vec_dv err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) t vec idx = ret res ->
-      @IS1.LP.Events.DV.index_into_vec_dv err_ub_oom
+      @DV1.index_into_vec_dv err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) t
         (fin_to_inf_dvalue vec) (fin_to_inf_dvalue idx) =
@@ -8144,7 +8161,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Proof.
     intros t vec idx res INDEX.
     unfold index_into_vec_dv in INDEX.
-    unfold IS1.LP.Events.DV.index_into_vec_dv.
+    unfold DV1.index_into_vec_dv.
 
     break_match_hyp_inv.
     { (* Arrays *)
@@ -8468,7 +8485,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
       fin_to_inf_dvalue dv3_fin = dv3_inf ->
-      @IS1.LP.Events.DV.insert_into_vec_dv err_ub_oom
+      @DV1.insert_into_vec_dv err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         t dv1_inf dv2_inf dv3_inf = ret (fin_to_inf_dvalue res_fin).
@@ -8476,7 +8493,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     intros dv1_fin dv2_fin dv3_fin res_fin dv1_inf dv2_inf dv3_inf t INSERT LIFT1 LIFT2 LIFT3.
     subst.
     unfold insert_into_vec_dv in INSERT.
-    unfold IS1.LP.Events.DV.insert_into_vec_dv.
+    unfold DV1.insert_into_vec_dv.
 
     break_match_hyp_inv.
     { (* Arrays *)
@@ -8581,10 +8598,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma index_into_str_dv_fin_inf :
     forall {v idx} {res : err_ub_oom dvalue},
       index_into_str_dv v idx = res ->
-      E1.DV.index_into_str_dv (fin_to_inf_dvalue v) idx = fmap fin_to_inf_dvalue res.
+      DV1.index_into_str_dv (fin_to_inf_dvalue v) idx = fmap fin_to_inf_dvalue res.
   Proof.
     intros v idx res H.
-    unfold E1.DV.index_into_str_dv, index_into_str_dv in *.
+    unfold DV1.index_into_str_dv, index_into_str_dv in *.
     break_match_hyp;
       try solve
         [ unfold fin_to_inf_dvalue; break_match_goal; break_match_hyp_inv; clear Heqs; destruct p; clear e0;
@@ -8629,7 +8646,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
          match idxs with
          | [] => ret str
          | i :: tl =>
-             v <- E1.DV.index_into_str_dv str i ;;
+             v <- DV1.index_into_str_dv str i ;;
              loop v tl
          end) (fin_to_inf_dvalue str) idxs = ret (fin_to_inf_dvalue res).
   Proof.
@@ -8706,7 +8723,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma insert_into_str_fin_inf :
     forall {str v i} {res : err_ub_oom dvalue},
       insert_into_str str v i = res ->
-      E1.DV.insert_into_str (fin_to_inf_dvalue str) (fin_to_inf_dvalue v) i = fmap fin_to_inf_dvalue res.
+      DV1.insert_into_str (fin_to_inf_dvalue str) (fin_to_inf_dvalue v) i = fmap fin_to_inf_dvalue res.
   Proof.
     intros str v i res INSERT.
     destruct str;
@@ -8721,7 +8738,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
     - (* Structs *)
       rewrite fin_to_inf_dvalue_struct;
-        unfold E1.DV.insert_into_str, insert_into_str in *.
+        unfold DV1.insert_into_str, insert_into_str in *.
       cbn in INSERT.
       break_match_hyp.
       rewrite <- fmap_map.
@@ -8739,7 +8756,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       reflexivity.
     - (* Packed Structs *)
       rewrite fin_to_inf_dvalue_packed_struct;
-        unfold E1.DV.insert_into_str, insert_into_str in *.
+        unfold DV1.insert_into_str, insert_into_str in *.
       cbn in INSERT.
       break_match_hyp.
       rewrite <- fmap_map.
@@ -8757,7 +8774,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       reflexivity.
     - (* Array *)
       rewrite fin_to_inf_dvalue_array;
-        unfold E1.DV.insert_into_str, insert_into_str in *.
+        unfold DV1.insert_into_str, insert_into_str in *.
       cbn in INSERT.
       break_match_hyp.
       rewrite <- fmap_map.
@@ -8804,12 +8821,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
          match idxs with
          | [] => raise_error "Index was not provided"
          | i :: nil =>
-             v <- E1.DV.insert_into_str str (fin_to_inf_dvalue elt) i;;
+             v <- DV1.insert_into_str str (fin_to_inf_dvalue elt) i;;
              ret v
          | i :: tl =>
-             subfield <- E1.DV.index_into_str_dv str i;;
+             subfield <- DV1.index_into_str_dv str i;;
              modified_subfield <- loop subfield tl;;
-             E1.DV.insert_into_str str modified_subfield i
+             DV1.insert_into_str str modified_subfield i
          end) (fin_to_inf_dvalue str) idxs = fmap fin_to_inf_dvalue res.
   Proof.
     induction idxs;
@@ -8868,11 +8885,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
               "concretize_uvalueM: ill-typed select, condition in vector was not poison or i1." = ue
       end x ->
       match fin_to_inf_dvalue a with
-      | @E1.DV.DVALUE_I 1 i =>
+      | @DV1.DVALUE_I 1 i =>
           if (@Integers.unsigned 1 i =? 1)%Z
           then fun y : err_ub_oom DVCrev.DV2.dvalue => success_unERR_UB_OOM (fin_to_inf_dvalue d) = y
           else fun y : err_ub_oom DVCrev.DV2.dvalue => success_unERR_UB_OOM (fin_to_inf_dvalue d0) = y
-      | E1.DV.DVALUE_Poison t => fun y : err_ub_oom DVCrev.DV2.dvalue => success_unERR_UB_OOM (E1.DV.DVALUE_Poison t) = y
+      | DV1.DVALUE_Poison t => fun y : err_ub_oom DVCrev.DV2.dvalue => success_unERR_UB_OOM (DV1.DVALUE_Poison t) = y
       | _ =>
           fun ue : err_ub_oom DVCrev.DV2.dvalue =>
             ERR_unERR_UB_OOM
@@ -8939,10 +8956,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
          | (c::conds), (x::xs), (y::ys) =>
              @bind ErrUbOomProp Monad_ErrUbOomProp _ _
                (match c with
-                | IS1.LP.Events.DV.DVALUE_Poison t =>
+                | DV1.DVALUE_Poison t =>
                     (* TODO: Should be the type of the result of the select... *)
-                    @ret ErrUbOomProp Monad_ErrUbOomProp _ (IS1.LP.Events.DV.DVALUE_Poison t)
-                | @IS1.LP.Events.DV.DVALUE_I 1 i =>
+                    @ret ErrUbOomProp Monad_ErrUbOomProp _ (DV1.DVALUE_Poison t)
+                | @DV1.DVALUE_I 1 i =>
                     if (@Integers.unsigned 1 i =? 1)%Z
                     then @ret ErrUbOomProp Monad_ErrUbOomProp _ x
                     else @ret ErrUbOomProp Monad_ErrUbOomProp _ y
@@ -9088,7 +9105,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
                    EitherMonad.unEitherT :=
                      {| EitherMonad.unEitherT := {| IdentityMonad.unIdent := inr (inr (inr dv)) |} |}
                  |}
-             |} => E1.DV.dvalue_has_dtyp dv dt /\ dv <> E1.DV.DVALUE_Poison dt
+             |} => DV1.dvalue_has_dtyp dv dt /\ dv <> DV1.DVALUE_Poison dt
            | _ => True
            end) err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -9268,7 +9285,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       do 2 rewrite fin_to_inf_dvalue_vector.
       repeat red.
       exists (fmap (map fin_to_inf_dvalue) x).
-      exists (fun elts => ret (IS1.LP.Events.DV.DVALUE_Vector t0 elts)).
+      exists (fun elts => ret (DV1.DVALUE_Vector t0 elts)).
       split; eauto.
       split; eauto.
 
@@ -9287,7 +9304,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma fin_to_inf_dvalue_not_poison :
     forall dv_fin t,
       dv_fin <> DVALUE_Poison t ->
-      fin_to_inf_dvalue dv_fin <> IS1.LP.Events.DV.DVALUE_Poison t.
+      fin_to_inf_dvalue dv_fin <> DV1.DVALUE_Poison t.
   Proof.
     intros dv_fin t NPOISON CONTRA.
     eapply NPOISON.
@@ -9300,18 +9317,18 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     auto.
   Qed.
 
-  Definition concretization_list_refine : (list (IS1.LP.Events.DV.uvalue * IS1.LP.Events.DV.dvalue)) -> (list (uvalue * dvalue)) -> Prop
+  Definition concretization_list_refine : (list (DV1.uvalue * DV1.dvalue)) -> (list (uvalue * dvalue)) -> Prop
     :=
     Forall2 (uvalue_refine_strict × dvalue_refine_strict).
 
   Definition concretization_map_refine
-    (inf_map : NMap (list (IS1.LP.Events.DV.uvalue * IS1.LP.Events.DV.dvalue)))
+    (inf_map : NMap (list (DV1.uvalue * DV1.dvalue)))
     (fin_map : NMap (list (uvalue * dvalue))) : Prop
     :=
     NM_Refine concretization_list_refine inf_map fin_map.
 
   Lemma concretization_map_refine_empty :
-    concretization_map_refine (NM.empty (list (IS1.LP.Events.DV.uvalue * IS1.LP.Events.DV.dvalue))) (NM.empty (list (uvalue * dvalue))).
+    concretization_map_refine (NM.empty (list (DV1.uvalue * DV1.dvalue))) (NM.empty (list (uvalue * dvalue))).
   Proof.
     repeat red.
     split.
@@ -9326,7 +9343,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma concretize_map_refine_find_none_inf_fin :
     forall acc_inf acc_fin sid,
       concretization_map_refine acc_inf acc_fin ->
-      NM.find (elt:=list (IS1.LP.Events.DV.uvalue * IS1.LP.Events.DV.dvalue)) sid acc_inf = None ->
+      NM.find (elt:=list (DV1.uvalue * DV1.dvalue)) sid acc_inf = None ->
       NM.find (elt:=list (uvalue * dvalue)) sid acc_fin = None.
   Proof.
     intros acc_inf acc_fin sid ACC_REF FIND.
@@ -9343,7 +9360,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma concretize_map_refine_find_some_inf_fin :
     forall acc_inf acc_fin sid conc_list_inf,
       concretization_map_refine acc_inf acc_fin ->
-      NM.find (elt:=list (IS1.LP.Events.DV.uvalue * IS1.LP.Events.DV.dvalue)) sid acc_inf = Some conc_list_inf ->
+      NM.find (elt:=list (DV1.uvalue * DV1.dvalue)) sid acc_inf = Some conc_list_inf ->
       exists conc_list_fin,
         NM.find (elt:=list (uvalue * dvalue)) sid acc_fin = Some conc_list_fin /\
           concretization_list_refine conc_list_inf conc_list_fin.
@@ -9473,7 +9490,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         new_concretized_byte in *.
       red.
       pose proof ACC_REF as [_ ACC_MAPS].
-      destruct (NM.find (elt:=list (IS1.LP.Events.DV.uvalue * IS1.LP.Events.DV.dvalue)) sid acc_inf) eqn:FIND_INF.
+      destruct (NM.find (elt:=list (DV1.uvalue * DV1.dvalue)) sid acc_inf) eqn:FIND_INF.
       - eapply concretize_map_refine_find_some_inf_fin in FIND_INF; eauto.
         destruct FIND_INF as (?&?&?).
         rewrite H in MAPS2.
@@ -9588,15 +9605,15 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (fun (A : Type) (x ue : err_ub_oom A) => x = ue) acc_fin uvs_fin (ret res) ->
       @IS1.LLVM.MEM.CP.CONCBASE.concretize_uvalue_bytes_helper ErrUbOomProp Monad_ErrUbOomProp
-        (fun (dt0 : dtyp) (edv : err_ub_oom IS1.LP.Events.DV.dvalue) =>
-           match @unERR_UB_OOM IdentityMonad.ident IS1.LP.Events.DV.dvalue edv with
+        (fun (dt0 : dtyp) (edv : err_ub_oom DV1.dvalue) =>
+           match @unERR_UB_OOM IdentityMonad.ident DV1.dvalue edv with
            | {|
                EitherMonad.unEitherT :=
                  {|
                    EitherMonad.unEitherT :=
                      {| EitherMonad.unEitherT := {| IdentityMonad.unIdent := inr (inr (inr dv)) |} |}
                  |}
-             |} => IS1.LP.Events.DV.dvalue_has_dtyp dv dt0 /\ dv <> IS1.LP.Events.DV.DVALUE_Poison dt0
+             |} => DV1.dvalue_has_dtyp dv dt0 /\ dv <> DV1.DVALUE_Poison dt0
            | _ => True
            end) err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -9698,7 +9715,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma dvalue_int_unsigned_E1E2 :
     forall x y,
       dvalue_refine_strict x y ->
-      IS1.LP.Events.DV.dvalue_int_unsigned x = dvalue_int_unsigned y.
+      DV1.dvalue_int_unsigned x = dvalue_int_unsigned y.
   Proof.
     induction x; intros y REF;
       try
@@ -10055,7 +10072,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
           repeat red.
           exists (ret (map fin_to_inf_dvalue x1)).
-          exists (fun fields => ret (IS1.LP.Events.DV.DVALUE_Struct fields)).
+          exists (fun fields => ret (DV1.DVALUE_Struct fields)).
           split.
           { eapply map_monad_ErrUbOomProp_forall2.
             apply Util.Forall2_forall.
@@ -10129,7 +10146,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
           repeat red.
           exists (ret (map fin_to_inf_dvalue x1)).
-          exists (fun fields => ret (IS1.LP.Events.DV.DVALUE_Packed_struct fields)).
+          exists (fun fields => ret (DV1.DVALUE_Packed_struct fields)).
           split.
           { eapply map_monad_ErrUbOomProp_forall2.
             apply Util.Forall2_forall.
@@ -10203,7 +10220,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
       repeat red.
       exists (ret (map fin_to_inf_dvalue x1)).
-      exists (fun fields => ret (IS1.LP.Events.DV.DVALUE_Array t fields)).
+      exists (fun fields => ret (DV1.DVALUE_Array t fields)).
       split.
       { eapply map_monad_ErrUbOomProp_forall2.
         apply Util.Forall2_forall.
@@ -10277,7 +10294,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
       repeat red.
       exists (ret (map fin_to_inf_dvalue x1)).
-      exists (fun fields => ret (IS1.LP.Events.DV.DVALUE_Vector t fields)).
+      exists (fun fields => ret (DV1.DVALUE_Vector t fields)).
       split.
       { eapply map_monad_ErrUbOomProp_forall2.
         apply Util.Forall2_forall.
@@ -11452,7 +11469,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma concretize_fails_inf_fin :
     forall uv_inf uv_fin
       (REF : uvalue_refine_strict uv_inf uv_fin)
-      (FAILS : forall dv : IS1.LP.Events.DV.dvalue, ~ IS1.LLVM.MEM.CP.CONC.concretize uv_inf dv),
+      (FAILS : forall dv : DV1.dvalue, ~ IS1.LLVM.MEM.CP.CONC.concretize uv_inf dv),
     forall dv : dvalue, ~ concretize uv_fin dv.
   Proof.
     intros uv_inf uv_fin REF FAILS dv CONC.
@@ -11526,12 +11543,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@ToDvalue_Int sz)
         iop v1 v2 = UB_unERR_UB_OOM ub_msg ->
-      @IS1.LP.Events.DV.eval_int_op err_ub_oom (@Integers.bit_int sz)
+      @DV1.eval_int_op err_ub_oom (@Integers.bit_int sz)
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@IS1.LP.Events.DV.ToDvalue_Int sz)
+        (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@DV1.ToDvalue_Int sz)
         iop v1 v2 = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros sz v1 v2 iop ub_msg EVAL.
@@ -11561,12 +11578,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         iop v1_fin v2_fin = UB_unERR_UB_OOM ub_msg ->
       IS1.LP.IP.from_Z (IP.to_Z v1_fin) = NoOom v1_inf ->
       IS1.LP.IP.from_Z (IP.to_Z v2_fin) = NoOom v2_inf ->
-      @IS1.LP.Events.DV.eval_int_op err_ub_oom IS1.LP.IP.intptr
+      @DV1.eval_int_op err_ub_oom IS1.LP.IP.intptr
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        IS1.LP.Events.DV.VMemInt_intptr' IS1.LP.Events.DV.ToDvalue_intptr
+        DV1.VMemInt_intptr' DV1.ToDvalue_intptr
         iop v1_inf v2_inf = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros v1_fin v2_fin v1_inf v2_inf iop ub_msg
@@ -11753,12 +11770,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@ToDvalue_Int sz)
         iop v1 v2 = ERR_unERR_UB_OOM err_msg ->
-      @IS1.LP.Events.DV.eval_int_op err_ub_oom (@Integers.bit_int sz)
+      @DV1.eval_int_op err_ub_oom (@Integers.bit_int sz)
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@IS1.LP.Events.DV.ToDvalue_Int sz)
+        (@VIntVMemInt (@Integers.bit_int sz) (@VInt_Bounded sz)) (@DV1.ToDvalue_Int sz)
         iop v1 v2 = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros sz v1 v2 iop ub_msg EVAL.
@@ -11788,12 +11805,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         iop v1_fin v2_fin = ERR_unERR_UB_OOM err_msg ->
       IS1.LP.IP.from_Z (IP.to_Z v1_fin) = NoOom v1_inf ->
       IS1.LP.IP.from_Z (IP.to_Z v2_fin) = NoOom v2_inf ->
-      @IS1.LP.Events.DV.eval_int_op err_ub_oom IS1.LP.IP.intptr
+      @DV1.eval_int_op err_ub_oom IS1.LP.IP.intptr
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        IS1.LP.Events.DV.VMemInt_intptr' IS1.LP.Events.DV.ToDvalue_intptr
+        DV1.VMemInt_intptr' DV1.ToDvalue_intptr
         iop v1_inf v2_inf = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros v1_fin v2_fin v1_inf v2_inf iop err_msg
@@ -11991,7 +12008,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
           fin_to_inf_dvalue dv2_fin = dv2_inf ->
           f_inf dv1_inf dv2_inf = UB_unERR_UB_OOM ub_msg) ->
       @vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_fin (combine xs ys) = UB_unERR_UB_OOM ub_msg ->
-      @IS1.LP.Events.DV.vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_inf (combine (map fin_to_inf_dvalue xs) (map fin_to_inf_dvalue ys)) = UB_unERR_UB_OOM ub_msg.
+      @DV1.vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_inf (combine (map fin_to_inf_dvalue xs) (map fin_to_inf_dvalue ys)) = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros f_fin f_inf xs ys res SUCCESS UB RES.
 
@@ -12020,7 +12037,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         cbn in RES; inv RES;
         symmetry in Heqres'.
       { specialize (IHZIP res eq_refl).
-        unfold IS1.LP.Events.DV.vec_loop in *.
+        unfold DV1.vec_loop in *.
         unfold vec_loop.
         rewrite IHZIP; reflexivity.
       }
@@ -12049,7 +12066,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
           fin_to_inf_dvalue dv2_fin = dv2_inf ->
           f_inf dv1_inf dv2_inf = ERR_unERR_UB_OOM ub_msg) ->
       @vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_fin (combine xs ys) = ERR_unERR_UB_OOM err_msg ->
-      @IS1.LP.Events.DV.vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_inf (combine (map fin_to_inf_dvalue xs) (map fin_to_inf_dvalue ys)) = ERR_unERR_UB_OOM err_msg.
+      @DV1.vec_loop _ err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) f_inf (combine (map fin_to_inf_dvalue xs) (map fin_to_inf_dvalue ys)) = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros f_fin f_inf xs ys res SUCCESS UB RES.
 
@@ -12078,7 +12095,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         cbn in RES; inv RES;
         symmetry in Heqres'.
       { specialize (IHZIP res eq_refl).
-        unfold IS1.LP.Events.DV.vec_loop in *.
+        unfold DV1.vec_loop in *.
         unfold vec_loop.
         rewrite IHZIP; reflexivity.
       }
@@ -12104,7 +12121,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         iop dv1_fin dv2_fin = UB_unERR_UB_OOM ub_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_iop_integer_h err_ub_oom
+      @DV1.eval_iop_integer_h err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -12163,7 +12180,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         iop dv1_fin dv2_fin = ERR_unERR_UB_OOM ub_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_iop_integer_h err_ub_oom
+      @DV1.eval_iop_integer_h err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -12215,7 +12232,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         iop dv1_fin dv2_fin = UB_unERR_UB_OOM ub_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_iop err_ub_oom
+      @DV1.eval_iop err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -12285,7 +12302,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         iop dv1_fin dv2_fin = ERR_unERR_UB_OOM err_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_iop err_ub_oom
+      @DV1.eval_iop err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -12344,13 +12361,13 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       @eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) Int VMInt samesign icmp a b = UB_unERR_UB_OOM ub_msg  ->
-      @IS1.LP.Events.DV.eval_int_icmp err_ub_oom
+      @DV1.eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) Int VMInt samesign icmp a b = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros Int VMInt samesign icmp a b ub_msg FIN.
-    Transparent eval_int_icmp IS1.LP.Events.DV.eval_int_icmp.
-    unfold eval_int_icmp, IS1.LP.Events.DV.eval_int_icmp.
+    Transparent eval_int_icmp DV1.eval_int_icmp.
+    unfold eval_int_icmp, DV1.eval_int_icmp.
     destruct icmp;
       try solve
         [ cbn in *;
@@ -12375,11 +12392,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         samesign icmp v1_fin v2_fin = UB_unERR_UB_OOM ub_msg ->
       IS1.LP.IP.from_Z (IP.to_Z v1_fin) = NoOom v1_inf ->
       IS1.LP.IP.from_Z (IP.to_Z v2_fin) = NoOom v2_inf ->
-      @IS1.LP.Events.DV.eval_int_icmp err_ub_oom
+      @DV1.eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         IS1.LP.IP.intptr
-        IS1.LP.Events.DV.VMemInt_intptr'
+        DV1.VMemInt_intptr'
         samesign icmp v1_inf v2_inf = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros v1_fin v2_fin v1_inf v2_inf samesign icmp ub_msg EVAL LIFT1 LIFT2.
@@ -12415,11 +12432,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         samesign icmp v1_fin v2_fin = ERR_unERR_UB_OOM err_msg ->
       IS1.LP.IP.from_Z (IP.to_Z v1_fin) = NoOom v1_inf ->
       IS1.LP.IP.from_Z (IP.to_Z v2_fin) = NoOom v2_inf ->
-      @IS1.LP.Events.DV.eval_int_icmp err_ub_oom
+      @DV1.eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         IS1.LP.IP.intptr
-        IS1.LP.Events.DV.VMemInt_intptr'
+        DV1.VMemInt_intptr'
         samesign icmp v1_inf v2_inf = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros v1_fin v2_fin v1_inf v2_inf samesign icmp err_msg EVAL LIFT1 LIFT2.
@@ -12462,7 +12479,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         samesign icmp dv1_inf dv2_inf = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros dv1_fin dv2_fin ub_msg samesign icmp dv1_inf dv2_inf EVAL LIFT1 LIFT2.
-    Opaque IS1.LP.Events.DV.eval_int_icmp
+    Opaque DV1.eval_int_icmp
       eval_int_icmp.
     unfold eval_icmp in EVAL.
     (* Nasty case analysis... *)
@@ -12512,13 +12529,13 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       @eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) Int VMInt samesign icmp a b = ERR_unERR_UB_OOM err_msg  ->
-      @IS1.LP.Events.DV.eval_int_icmp err_ub_oom
+      @DV1.eval_int_icmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) Int VMInt samesign icmp a b = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros Int VMInt samesign icmp a b err_msg FIN.
-    Transparent eval_int_icmp IS1.LP.Events.DV.eval_int_icmp.
-    unfold eval_int_icmp, IS1.LP.Events.DV.eval_int_icmp.
+    Transparent eval_int_icmp DV1.eval_int_icmp.
+    unfold eval_int_icmp, DV1.eval_int_icmp.
     destruct icmp;
       try solve
         [ cbn in *;
@@ -12539,8 +12556,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall fields,
       (forall dv,
           In dv fields ->
-          show_dvalue dv = IS1.LP.Events.DV.show_dvalue (fin_to_inf_dvalue dv)) ->
-      map show_dvalue fields = map IS1.LP.Events.DV.show_dvalue (map fin_to_inf_dvalue fields).
+          show_dvalue dv = DV1.show_dvalue (fin_to_inf_dvalue dv)) ->
+      map show_dvalue fields = map DV1.show_dvalue (map fin_to_inf_dvalue fields).
   Proof.
     induction fields; intros SHOW.
     - reflexivity.
@@ -12569,7 +12586,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
   Lemma show_dvalue_fin_inf :
     forall dv,
-      show_dvalue dv = IS1.LP.Events.DV.show_dvalue (fin_to_inf_dvalue dv).
+      show_dvalue dv = DV1.show_dvalue (fin_to_inf_dvalue dv).
   Proof.
     intros dv.
     induction dv; cbn; rewrite_fin_to_inf_dvalue; cbn; auto;
@@ -12593,9 +12610,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         samesign icmp dv1_inf dv2_inf = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros dv1_fin dv2_fin err_msg samesign icmp dv1_inf dv2_inf EVAL LIFT1 LIFT2.
-    Opaque IS1.LP.Events.DV.eval_int_icmp
+    Opaque DV1.eval_int_icmp
       eval_int_icmp
-      IS1.LP.Events.DV.show_dvalue
+      DV1.show_dvalue
       show_dvalue.
 
     unfold eval_icmp in EVAL.
@@ -12664,7 +12681,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma double_op_ub_fin_inf :
     forall fop a b ub_msg,
       double_op fop a b = UB_unERR_UB_OOM ub_msg ->
-      IS1.LP.Events.DV.double_op fop a b = UB_unERR_UB_OOM ub_msg.
+      DV1.double_op fop a b = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros fop a b ub_msg EVAL.
     destruct fop; cbn in *; inv EVAL.
@@ -12673,7 +12690,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma float_op_ub_fin_inf :
     forall fop a b ub_msg,
       float_op fop a b = UB_unERR_UB_OOM ub_msg ->
-      IS1.LP.Events.DV.float_op fop a b = UB_unERR_UB_OOM ub_msg.
+      DV1.float_op fop a b = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros fop a b ub_msg EVAL.
     destruct fop; cbn in *; inv EVAL.
@@ -12682,7 +12699,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma double_op_err_fin_inf :
     forall fop a b err_msg,
       double_op fop a b = ERR_unERR_UB_OOM err_msg ->
-      IS1.LP.Events.DV.double_op fop a b = ERR_unERR_UB_OOM err_msg.
+      DV1.double_op fop a b = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros fop a b err_msg EVAL.
     destruct fop; cbn in *; inv EVAL; auto.
@@ -12691,7 +12708,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma float_op_err_fin_inf :
     forall fop a b err_msg,
       float_op fop a b = ERR_unERR_UB_OOM err_msg ->
-      IS1.LP.Events.DV.float_op fop a b = ERR_unERR_UB_OOM err_msg.
+      DV1.float_op fop a b = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros fop a b err_msg EVAL.
     destruct fop; cbn in *; inv EVAL; auto.
@@ -12706,7 +12723,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         fop dv1_fin dv2_fin = UB_unERR_UB_OOM ub_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_fop err_ub_oom
+      @DV1.eval_fop err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -12727,8 +12744,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         cbn.
 
         (* These should be the same... *)
-        unfold IS1.LP.Events.DV.fop_is_div.
-        unfold fop_is_div in Heqb.
+        unfold AstLib.fop_is_div in *.
         rewrite Heqb.
         reflexivity.
       }
@@ -12752,8 +12768,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         cbn.
 
         (* These should be the same... *)
-        unfold IS1.LP.Events.DV.fop_is_div.
-        unfold fop_is_div in Heqb.
+        unfold AstLib.fop_is_div in *.
         rewrite Heqb.
         reflexivity.
       }
@@ -12775,7 +12790,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         dv1_fin  = UB_unERR_UB_OOM ub_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
-      @IS1.LP.Events.DV.eval_fneg err_ub_oom
+      @DV1.eval_fneg err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -12805,10 +12820,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     - (* Structs *)
       cbn.
       assert ((map
-         (fun x0 : E2.DV.dvalue =>
+         (fun x0 : DV2.dvalue =>
             CeresS.List [CeresSerialize.to_sexp x0; CeresS.Atom_ (CeresS.Raw ",")]) fields) =
                 (map
-         (fun x0 : E1.DV.dvalue =>
+         (fun x0 : DV1.dvalue =>
             CeresS.List [CeresSerialize.to_sexp x0; CeresS.Atom_ (CeresS.Raw ",")]) x)).
       { generalize dependent fields.
         induction x; intros fields H H1;
@@ -12840,10 +12855,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     - (* Packed structs *)
       cbn.
       assert ((map
-         (fun x0 : E2.DV.dvalue =>
+         (fun x0 : DV2.dvalue =>
             CeresS.List [CeresSerialize.to_sexp x0; CeresS.Atom_ (CeresS.Raw ",")]) fields) =
                 (map
-         (fun x0 : E1.DV.dvalue =>
+         (fun x0 : DV1.dvalue =>
             CeresS.List [CeresSerialize.to_sexp x0; CeresS.Atom_ (CeresS.Raw ",")]) x)).
       { generalize dependent fields.
         induction x; intros fields H H1;
@@ -12875,10 +12890,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     - (* Arrays *)
       cbn.
       assert ((map
-         (fun x0 : E2.DV.dvalue =>
+         (fun x0 : DV2.dvalue =>
             CeresS.List [CeresSerialize.to_sexp x0; CeresS.Atom_ (CeresS.Raw ",")]) elts) =
                 (map
-         (fun x0 : E1.DV.dvalue =>
+         (fun x0 : DV1.dvalue =>
             CeresS.List [CeresSerialize.to_sexp x0; CeresS.Atom_ (CeresS.Raw ",")]) x)).
       { generalize dependent elts.
         induction x; intros elts H H1;
@@ -12910,10 +12925,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     - (* Vectors *)
       cbn.
       assert ((map
-         (fun x0 : E2.DV.dvalue =>
+         (fun x0 : DV2.dvalue =>
             CeresS.List [CeresSerialize.to_sexp x0; CeresS.Atom_ (CeresS.Raw ",")]) elts) =
                 (map
-         (fun x0 : E1.DV.dvalue =>
+         (fun x0 : DV1.dvalue =>
             CeresS.List [CeresSerialize.to_sexp x0; CeresS.Atom_ (CeresS.Raw ",")]) x)).
       { generalize dependent elts.
         induction x; intros elts H H1;
@@ -12963,7 +12978,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         fop dv1_fin dv2_fin = ERR_unERR_UB_OOM err_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_fop err_ub_oom
+      @DV1.eval_fop err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -13012,7 +13027,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         fcmp dv1_fin dv2_fin = UB_unERR_UB_OOM ub_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_fcmp err_ub_oom
+      @DV1.eval_fcmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         fcmp dv1_inf dv2_inf = UB_unERR_UB_OOM ub_msg.
@@ -13030,7 +13045,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         fcmp dv1_fin dv2_fin = ERR_unERR_UB_OOM err_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
-      @IS1.LP.Events.DV.eval_fcmp err_ub_oom
+      @DV1.eval_fcmp err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         fcmp dv1_inf dv2_inf = ERR_unERR_UB_OOM err_msg.
@@ -13087,7 +13102,6 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   (* TODO: Move this / generalize monad? *)
-  (* TODO: Prove this *)
   Lemma insert_into_vec_dv_no_ub_fin_inf :
     forall dv1_fin dv2_fin dv3_fin ub_msg t,
       @insert_into_vec_dv err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -13135,7 +13149,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
                    EitherMonad.unEitherT :=
                      {| EitherMonad.unEitherT := {| IdentityMonad.unIdent := inr (inr (inr dv)) |} |}
                  |}
-             |} => E1.DV.dvalue_has_dtyp dv dt /\ dv <> E1.DV.DVALUE_Poison dt
+             |} => DV1.dvalue_has_dtyp dv dt /\ dv <> DV1.DVALUE_Poison dt
            | _ => True
            end) err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -13285,15 +13299,15 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (fun (A : Type) (x ue : err_ub_oom A) => x = ue) acc_fin uvs_fin (UB_unERR_UB_OOM ub_msg) ->
       @IS1.LLVM.MEM.CP.CONCBASE.concretize_uvalue_bytes_helper ErrUbOomProp Monad_ErrUbOomProp
-        (fun (dt0 : dtyp) (edv : err_ub_oom IS1.LP.Events.DV.dvalue) =>
-           match @unERR_UB_OOM IdentityMonad.ident IS1.LP.Events.DV.dvalue edv with
+        (fun (dt0 : dtyp) (edv : err_ub_oom DV1.dvalue) =>
+           match @unERR_UB_OOM IdentityMonad.ident DV1.dvalue edv with
            | {|
                EitherMonad.unEitherT :=
                  {|
                    EitherMonad.unEitherT :=
                      {| EitherMonad.unEitherT := {| IdentityMonad.unIdent := inr (inr (inr dv)) |} |}
                  |}
-             |} => IS1.LP.Events.DV.dvalue_has_dtyp dv dt0 /\ dv <> IS1.LP.Events.DV.DVALUE_Poison dt0
+             |} => DV1.dvalue_has_dtyp dv dt0 /\ dv <> DV1.DVALUE_Poison dt0
            | _ => True
            end) err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -13403,15 +13417,15 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   (*       (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident) *)
   (*       (fun (A : Type) (x ue : err_ub_oom A) => x = ue) uvs_fin (UB_unERR_UB_OOM ub_msg) -> *)
   (*     @IS1.LLVM.MEM.CP.CONCBASE.concretize_uvalue_bytes ErrUbOomProp Monad_ErrUbOomProp *)
-  (*       (fun (dt0 : dtyp) (edv : err_ub_oom IS1.LP.Events.DV.dvalue) => *)
-  (*          match @unERR_UB_OOM IdentityMonad.ident IS1.LP.Events.DV.dvalue edv with *)
+  (*       (fun (dt0 : dtyp) (edv : err_ub_oom DV1.dvalue) => *)
+  (*          match @unERR_UB_OOM IdentityMonad.ident DV1.dvalue edv with *)
   (*          | {| *)
   (*              EitherMonad.unEitherT := *)
   (*                {| *)
   (*                  EitherMonad.unEitherT := *)
   (*                    {| EitherMonad.unEitherT := {| IdentityMonad.unIdent := inr (inr (inr dv)) |} |} *)
   (*                |} *)
-  (*            |} => IS1.LP.Events.DV.dvalue_has_dtyp dv dt0 /\ dv <> IS1.LP.Events.DV.DVALUE_Poison dt0 *)
+  (*            |} => DV1.dvalue_has_dtyp dv dt0 /\ dv <> DV1.DVALUE_Poison dt0 *)
   (*          | _ => True *)
   (*          end) err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) *)
   (*       (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) *)
@@ -13438,7 +13452,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        IS1.LP.Events.DV.dvalue IS1.LP.Events.DV.DVALUE_Poison (IS1.LLVM.MEM.MP.DVALUE_BYTES.dvalue_bytes_to_dvalue dvbs_inf τ) = UB_unERR_UB_OOM ub_msg.
+        DV1.dvalue DV1.DVALUE_Poison (IS1.LLVM.MEM.MP.DVALUE_BYTES.dvalue_bytes_to_dvalue dvbs_inf τ) = UB_unERR_UB_OOM ub_msg.
   Proof.
     intros τ dvbs_inf dvbs_fin ub_msg H H0.
     remember (@DVALUE_BYTES.dvalue_bytes_to_dvalue ErrOOMPoison
@@ -13491,15 +13505,15 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   (*       (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident) *)
   (*       (fun (A : Type) (x ue : err_ub_oom A) => x = ue) l dt (UB_unERR_UB_OOM ub_msg) -> *)
   (*     @IS1.LLVM.MEM.CP.CONCBASE.extractbytes_to_dvalue ErrUbOomProp Monad_ErrUbOomProp *)
-  (*       (fun (dt0 : dtyp) (edv : err_ub_oom IS1.LP.Events.DV.dvalue) => *)
-  (*          match @unERR_UB_OOM IdentityMonad.ident IS1.LP.Events.DV.dvalue edv with *)
+  (*       (fun (dt0 : dtyp) (edv : err_ub_oom DV1.dvalue) => *)
+  (*          match @unERR_UB_OOM IdentityMonad.ident DV1.dvalue edv with *)
   (*          | {| *)
   (*              EitherMonad.unEitherT := *)
   (*                {| *)
   (*                  EitherMonad.unEitherT := *)
   (*                    {| EitherMonad.unEitherT := {| IdentityMonad.unIdent := inr (inr (inr dv)) |} |} *)
   (*                |} *)
-  (*            |} => IS1.LP.Events.DV.dvalue_has_dtyp dv dt0 /\ dv <> IS1.LP.Events.DV.DVALUE_Poison dt0 *)
+  (*            |} => DV1.dvalue_has_dtyp dv dt0 /\ dv <> DV1.DVALUE_Poison dt0 *)
   (*          | _ => True *)
   (*          end) err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) *)
   (*       (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident) *)
@@ -14954,7 +14968,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
           intros u H0 uv_fin H2 ub_msg0 H3.
           eapply IH; eauto.
-          eapply IS1.LP.Events.DV.uvalue_concat_bytes_strict_subterm; eauto.
+          eapply DV1.uvalue_concat_bytes_strict_subterm; eauto.
         }
 
         destruct H1 as [[] | H1].
@@ -15001,7 +15015,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
         uvalue_convert_strict_inv Heqo1.
         eapply IH; eauto.
-        eapply IS1.LP.Events.DV.uvalue_concat_bytes_strict_subterm; eauto.
+        eapply DV1.uvalue_concat_bytes_strict_subterm; eauto.
         repeat constructor.
       }
 
@@ -15067,7 +15081,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         dv1_fin = ERR_unERR_UB_OOM err_msg ->
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
-      @IS1.LP.Events.DV.eval_fneg err_ub_oom
+      @DV1.eval_fneg err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_UB_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -15097,7 +15111,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
-        IS1.LP.Events.DV.dvalue IS1.LP.Events.DV.DVALUE_Poison (IS1.LLVM.MEM.MP.DVALUE_BYTES.dvalue_bytes_to_dvalue dvbs_inf τ) = ERR_unERR_UB_OOM err_msg.
+        DV1.dvalue DV1.DVALUE_Poison (IS1.LLVM.MEM.MP.DVALUE_BYTES.dvalue_bytes_to_dvalue dvbs_inf τ) = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros τ dvbs_inf dvbs_fin err_msg H H0.
     remember (@DVALUE_BYTES.dvalue_bytes_to_dvalue ErrOOMPoison
@@ -15134,7 +15148,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       (msg : string)
       (CONV : get_conv_case LLVMAst.Bitcast t_from dv t_to = Conv_Illegal msg),
       IS1.LLVM.MEM.CP.CONC.get_conv_case LLVMAst.Bitcast t_from (fin_to_inf_dvalue dv) t_to =
-        IS1.LP.Events.DV.Conv_Illegal msg.
+        DV1.Conv_Illegal msg.
   Proof.
     intros t_from dv t_to msg CONV.
     cbn in *; inv CONV; auto.
@@ -15164,7 +15178,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma get_conv_case_illegal_fin_inf:
     forall conv t_from dv t_to msg,
       get_conv_case conv t_from dv t_to = Conv_Illegal msg ->
-      IS1.LLVM.MEM.CP.CONC.get_conv_case conv t_from (fin_to_inf_dvalue dv) t_to = IS1.LP.Events.DV.Conv_Illegal msg.
+      IS1.LLVM.MEM.CP.CONC.get_conv_case conv t_from (fin_to_inf_dvalue dv) t_to = DV1.Conv_Illegal msg.
   Proof.
     intros conv t_from dv t_to msg CONV.
     destruct conv;
@@ -15214,8 +15228,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
                    repeat setoid_rewrite padding_fin_inf; eauto
                   | break_match_hyp_inv; auto;
                     erewrite IHidxs_fin; eauto;
-                    replace (fun (acc : Z) (t : dtyp) => (pad_to_align (IS1.LP.SIZEOF.dtyp_alignment t) acc + IS1.LP.SIZEOF.sizeof_dtyp t))%Z with
-                      (fun (acc : Z) (t : dtyp) => (pad_to_align (SIZEOF.dtyp_alignment t) acc + SIZEOF.sizeof_dtyp t)%Z); eauto;
+                    replace (fun (acc : Z) (t : dtyp) => (pad_to_align (IS1.LP.SZ.dtyp_alignment t) acc + IS1.LP.SZ.sizeof_dtyp t))%Z with
+                      (fun (acc : Z) (t : dtyp) => (pad_to_align (SZ.dtyp_alignment t) acc + SZ.sizeof_dtyp t)%Z); eauto;
                     apply FunctionalExtensionality.functional_extensionality;
                     intros;
                     apply FunctionalExtensionality.functional_extensionality;
@@ -15236,9 +15250,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
         replace
           (fun (acc : N) (t : dtyp) =>
-             pad_to_align (IS1.LP.SIZEOF.dtyp_alignment t) acc + IS1.LP.SIZEOF.sizeof_dtyp t) with
+             pad_to_align (IS1.LP.SZ.dtyp_alignment t) acc + IS1.LP.SZ.sizeof_dtyp t) with
           (fun (acc : N) (t : dtyp) =>
-             pad_to_align (SIZEOF.dtyp_alignment t) acc + SIZEOF.sizeof_dtyp t); eauto;
+             pad_to_align (SZ.dtyp_alignment t) acc + SZ.sizeof_dtyp t); eauto;
           apply FunctionalExtensionality.functional_extensionality;
           intros;
           apply FunctionalExtensionality.functional_extensionality;
@@ -15250,9 +15264,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
         replace
           (fun (acc : N) (t : dtyp) =>
-             acc + IS1.LP.SIZEOF.sizeof_dtyp t) with
+             acc + IS1.LP.SZ.sizeof_dtyp t) with
           (fun (acc : N) (t : dtyp) =>
-             acc + SIZEOF.sizeof_dtyp t); eauto;
+             acc + SZ.sizeof_dtyp t); eauto;
           apply FunctionalExtensionality.functional_extensionality;
           intros;
           apply FunctionalExtensionality.functional_extensionality;
@@ -15320,11 +15334,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma index_into_vec_dv_err_fin_inf:
     forall (t : dtyp) (vec idx : dvalue) err_msg,
       index_into_vec_dv t vec idx = ERR_unERR_UB_OOM err_msg ->
-      IS1.LP.Events.DV.index_into_vec_dv t (fin_to_inf_dvalue vec) (fin_to_inf_dvalue idx) = ERR_unERR_UB_OOM err_msg.
+      DV1.index_into_vec_dv t (fin_to_inf_dvalue vec) (fin_to_inf_dvalue idx) = ERR_unERR_UB_OOM err_msg.
   Proof.
     intros t vec idx err_msg INDEX.
     unfold index_into_vec_dv in INDEX.
-    unfold IS1.LP.Events.DV.index_into_vec_dv.
+    unfold DV1.index_into_vec_dv.
 
     break_match_hyp_inv; rewrite_fin_to_inf_dvalue; auto.
     { (* Arrays *)
@@ -15380,7 +15394,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       fin_to_inf_dvalue dv1_fin = dv1_inf ->
       fin_to_inf_dvalue dv2_fin = dv2_inf ->
       fin_to_inf_dvalue dv3_fin = dv3_inf ->
-      @IS1.LP.Events.DV.insert_into_vec_dv err_ub_oom
+      @DV1.insert_into_vec_dv err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         t dv1_inf dv2_inf dv3_inf = ERR_unERR_UB_OOM msg.
@@ -15388,7 +15402,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     intros dv1_fin dv2_fin dv3_fin msg dv1_inf dv2_inf dv3_inf t INSERT LIFT1 LIFT2 LIFT3.
     subst.
     unfold insert_into_vec_dv in INSERT.
-    unfold IS1.LP.Events.DV.insert_into_vec_dv.
+    unfold DV1.insert_into_vec_dv.
 
     break_match_hyp_inv; rewrite_fin_to_inf_dvalue; auto.
     { (* Arrays *)
@@ -15447,7 +15461,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
          match idxs with
          | [] => ret str
          | i :: tl =>
-             v <- E1.DV.index_into_str_dv str i ;;
+             v <- DV1.index_into_str_dv str i ;;
              loop v tl
          end) (fin_to_inf_dvalue str) idxs = ERR_unERR_UB_OOM msg.
   Proof.
@@ -15520,7 +15534,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
                    EitherMonad.unEitherT :=
                      {| EitherMonad.unEitherT := {| IdentityMonad.unIdent := inr (inr (inr dv)) |} |}
                  |}
-             |} => E1.DV.dvalue_has_dtyp dv dt /\ dv <> E1.DV.DVALUE_Poison dt
+             |} => DV1.dvalue_has_dtyp dv dt /\ dv <> DV1.DVALUE_Poison dt
            | _ => True
            end) err_ub_oom
         (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -15671,15 +15685,15 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (@RAISE_OOM_err_ub_oom_T IdentityMonad.ident IdentityMonad.Monad_ident)
         (fun (A : Type) (x ue : err_ub_oom A) => x = ue) acc_fin uvs_fin (ERR_unERR_UB_OOM msg) ->
       @IS1.LLVM.MEM.CP.CONCBASE.concretize_uvalue_bytes_helper ErrUbOomProp Monad_ErrUbOomProp
-        (fun (dt0 : dtyp) (edv : err_ub_oom IS1.LP.Events.DV.dvalue) =>
-           match @unERR_UB_OOM IdentityMonad.ident IS1.LP.Events.DV.dvalue edv with
+        (fun (dt0 : dtyp) (edv : err_ub_oom DV1.dvalue) =>
+           match @unERR_UB_OOM IdentityMonad.ident DV1.dvalue edv with
            | {|
                EitherMonad.unEitherT :=
                  {|
                    EitherMonad.unEitherT :=
                      {| EitherMonad.unEitherT := {| IdentityMonad.unIdent := inr (inr (inr dv)) |} |}
                  |}
-             |} => IS1.LP.Events.DV.dvalue_has_dtyp dv dt0 /\ dv <> IS1.LP.Events.DV.DVALUE_Poison dt0
+             |} => DV1.dvalue_has_dtyp dv dt0 /\ dv <> DV1.DVALUE_Poison dt0
            | _ => True
            end) err_ub_oom (@Monad_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
         (@RAISE_ERROR_err_ub_oom IdentityMonad.ident IdentityMonad.Monad_ident)
@@ -17277,7 +17291,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
           intros u H0 uv_fin H2 ub_msg0 H3.
           eapply IH; eauto.
-          eapply IS1.LP.Events.DV.uvalue_concat_bytes_strict_subterm; eauto.
+          eapply DV1.uvalue_concat_bytes_strict_subterm; eauto.
         }
 
         destruct H1 as [[] | H1].
@@ -17324,7 +17338,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
         uvalue_convert_strict_inv Heqo1.
         eapply IH; eauto.
-        eapply IS1.LP.Events.DV.uvalue_concat_bytes_strict_subterm; eauto.
+        eapply DV1.uvalue_concat_bytes_strict_subterm; eauto.
         repeat constructor.
       }
 
@@ -17451,7 +17465,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     intros dt CONTRA.
     eapply (NON_POISON_INF dt).
 
-    replace (IS1.LP.Events.DV.DVALUE_Poison dt) with
+    replace (DV1.DVALUE_Poison dt) with
       (fin_to_inf_dvalue (DVALUE_Poison dt)).
     2: {
       unfold fin_to_inf_dvalue.
@@ -17473,7 +17487,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall uv1 uv2,
       uvalue_refine_strict uv1 uv2 ->
       rutt (sum_prerel call_refine_strict event_refine_strict) (sum_postrel call_res_refine_strict event_res_refine_strict) dvalue_refine_strict
-        (LLVMEvents.lift_err (fun x : IS1.LP.Events.DV.dvalue => Ret x) (IS1.LP.Events.DV.uvalue_to_dvalue uv1))
+        (LLVMEvents.lift_err (fun x : DV1.dvalue => Ret x) (DV1.uvalue_to_dvalue uv1))
         (LLVMEvents.lift_err (fun x : dvalue => Ret x) (uvalue_to_dvalue uv2)).
   Proof.
     intros uv1 uv2 H.
@@ -17767,13 +17781,13 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       uv1 uv2,
       uvalue_refine_strict uv1 uv2 ->
       orutt pre post dvalue_refine_strict
-        (LLVMEvents.lift_err (fun x : IS1.LP.Events.DV.dvalue => Ret x) (IS1.LP.Events.DV.uvalue_to_dvalue uv1))
+        (LLVMEvents.lift_err (fun x : DV1.dvalue => Ret x) (DV1.uvalue_to_dvalue uv1))
         (LLVMEvents.lift_err (fun x : dvalue => Ret x) (uvalue_to_dvalue uv2))
         (OOM:=OOME).
   Proof.
     intros E1 E2 OOM1 OOM2 ERR1 ERR2 pre post ERRDISC ERRPRE uv1 uv2 H.
     apply lift_err_orutt_strict; try typeclasses eauto; eauto; repeat constructor.
-    destruct (IS1.LP.Events.DV.uvalue_to_dvalue uv1) eqn:Huv1.
+    destruct (DV1.uvalue_to_dvalue uv1) eqn:Huv1.
     - pose proof Huv1 as Huv1'.
       eapply uvalue_to_dvalue_dvalue_refine_strict_error in Huv1; eauto.
       destruct Huv1 as (?&Huv1); rewrite Huv1.
@@ -17792,17 +17806,17 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall E1 E2
       `{OOM1 : OOME -< E1} `{OOM2 : OOME -< E2}
       `{ERR1: FailureE -< E1} `{ERR2: FailureE -< E2}
-      `{PICK1: IS1.LP.Events.PickE -< E1} `{PICK2: PickE -< E2}
+      `{PICK1: PickE -< E1} `{PICK2: PickE -< E2}
       (pre : prerel E1 E2) (post : postrel E1 E2)
       (ERRDISC : forall e1 e2, @subevent FailureE E2 ERR2 void e1 <> @subevent OOME E2 OOM2 void e2)
       (PICKDISC : forall e1 e2, @subevent PickE E2 PICK2 {_ : dvalue | True} e1 <> @subevent OOME E2 OOM2 {_ : dvalue | True} e2)
       (ERRPRE : pre void void (@subevent FailureE E1 ERR1 void (Throw tt)) (@subevent FailureE E2 ERR2 void (Throw tt)))
-      (PICKPRE : forall uv1 uv2, uvalue_refine_strict uv1 uv2 -> pre {_ : IS1.LP.Events.DV.dvalue | True} {_ : dvalue | True}     
-    (subevent {_ : IS1.LP.Events.DV.dvalue | True} (IS1.LLVM.MEM.CP.CONC.pick_unique_uvalue uv1))
+      (PICKPRE : forall uv1 uv2, uvalue_refine_strict uv1 uv2 -> pre {_ : DV1.dvalue | True} {_ : dvalue | True}     
+    (subevent {_ : DV1.dvalue | True} (IS1.LLVM.MEM.CP.CONC.pick_unique_uvalue uv1))
     (subevent {_ : dvalue | True} (pick_unique_uvalue uv2)))
-(POSTREF : forall uv1 uv2 dv1 dv2, post {_ : IS1.LP.Events.DV.dvalue | True} {_ : dvalue | True}
-      (subevent {_ : IS1.LP.Events.DV.dvalue | True} (IS1.LLVM.MEM.CP.CONC.pick_unique_uvalue uv1))
-      (exist (fun _ : IS1.LP.Events.DV.dvalue => True) dv1 I)
+(POSTREF : forall uv1 uv2 dv1 dv2, post {_ : DV1.dvalue | True} {_ : dvalue | True}
+      (subevent {_ : DV1.dvalue | True} (IS1.LLVM.MEM.CP.CONC.pick_unique_uvalue uv1))
+      (exist (fun _ : DV1.dvalue => True) dv1 I)
       (subevent {_ : dvalue | True} (pick_unique_uvalue uv2)) (exist (fun _ : dvalue => True) dv2 I) -> dvalue_refine_strict dv1 dv2)
       uv1 uv2,
       uvalue_refine_strict uv1 uv2 ->
@@ -17850,7 +17864,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       (pre void void (@subevent UBE E1 UB1 void (ThrowUB tt)) (@subevent UBE E2 UB2 void (ThrowUB tt))) ->
       (pre void void (@subevent FailureE E1 ERR1 void (Throw tt)) (@subevent FailureE E2 ERR2 void (Throw tt))) ->
       orutt pre post dvalue_refine_strict
-        (IS1.LP.Events.DV.eval_iop iop dv1_1 dv2_1) (eval_iop iop dv1_2 dv2_2)
+        (DV1.eval_iop iop dv1_1 dv2_1) (eval_iop iop dv1_2 dv2_2)
         (OOM:=OOME).
   Proof.
     intros E1 E2 ? ? ? ? ? ? pre post iop dv1_1 dv2_1 dv1_2 dv2_2 H H0 OOMDISC ERRDISC UBPRE ERRPRE.
@@ -17930,7 +17944,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dvalue_refine_strict dv1_1 dv1_2 ->
       dvalue_refine_strict dv2_1 dv2_2 ->
       orutt pre post dvalue_refine_strict
-        (IS1.LP.Events.DV.eval_fop fop dv1_1 dv2_1) (eval_fop fop dv1_2 dv2_2)
+        (DV1.eval_fop fop dv1_1 dv2_1) (eval_fop fop dv1_2 dv2_2)
         (OOM:=OOME).
   Proof.
     intros E1 E2 OOM1 OOM2 UB1 UB2 ERR1 ERR2 pre post UBDISC ERRDISC UBINJ ERRINJ fop dv1_1 dv2_1 dv1_2 dv2_2 H H0.
@@ -17969,7 +17983,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dv1_1 dv1_2,
       dvalue_refine_strict dv1_1 dv1_2 ->
       orutt pre post dvalue_refine_strict
-        (IS1.LP.Events.DV.eval_fneg dv1_1) (eval_fneg dv1_2)
+        (DV1.eval_fneg dv1_1) (eval_fneg dv1_2)
         (OOM:=OOME).
   Proof.
     intros E1 E2 OOM1 OOM2 UB1 UB2 ERR1 ERR2 pre post UBDISC ERRDISC UBINJ ERRINJ
@@ -18010,7 +18024,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dvalue_refine_strict dv1_1 dv1_2 ->
       dvalue_refine_strict dv2_1 dv2_2 ->
       orutt pre post dvalue_refine_strict
-        (IS1.LP.Events.DV.eval_fcmp cmp dv1_1 dv2_1) (eval_fcmp cmp dv1_2 dv2_2)
+        (DV1.eval_fcmp cmp dv1_1 dv2_1) (eval_fcmp cmp dv1_2 dv2_2)
         (OOM:=OOME).
   Proof.
     intros E1 E2 OOM1 OOM2 UB1 UB2 ERR1 ERR2 pre post UBDISC ERRDISC UBINJ ERRINJ cmp dv1_1 dv2_1 dv1_2 dv2_2 H
@@ -18039,7 +18053,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
   Lemma fin_to_inf_dvalue_dvalue_int_unsigned :
     forall dv,
-      IS1.LP.Events.DV.dvalue_int_unsigned (fin_to_inf_dvalue dv) = dvalue_int_unsigned dv.
+      DV1.dvalue_int_unsigned (fin_to_inf_dvalue dv) = dvalue_int_unsigned dv.
   Proof.
     intros dv.
     destruct dv; cbn;
@@ -18107,7 +18121,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dvalue_refine_strict dv1_1 dv1_2 ->
       dvalue_refine_strict dv2_1 dv2_2 ->
       orutt pre post dvalue_refine_strict
-        (IS1.LP.Events.DV.index_into_vec_dv τ dv1_1 dv2_1) (index_into_vec_dv τ dv1_2 dv2_2)
+        (DV1.index_into_vec_dv τ dv1_1 dv2_1) (index_into_vec_dv τ dv1_2 dv2_2)
         (OOM:=OOME).
   Proof.
     intros E1 E2 OOM1 OOM2 UB1 UB2 ERR1 ERR2 pre post UBDISC ERRDISC UBINJ ERRINJ τ dv1_1 dv2_1 dv1_2 dv2_2 REF1 REF2.
@@ -18149,7 +18163,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dvalue_refine_strict dv2_1 dv2_2 ->
       dvalue_refine_strict dv3_1 dv3_2 ->
       orutt pre post dvalue_refine_strict
-        (IS1.LP.Events.DV.insert_into_vec_dv τ dv1_1 dv2_1 dv3_1) (insert_into_vec_dv τ dv1_2 dv2_2 dv3_2)
+        (DV1.insert_into_vec_dv τ dv1_1 dv2_1 dv3_1) (insert_into_vec_dv τ dv1_2 dv2_2 dv3_2)
         (OOM:=OOME).
   Proof.
     intros E1 E2 OOM1 OOM2 UB1 UB2 ERR1 ERR2 pre post UBDISC ERRDISC UBINJ ERRINJ τ dv1_1 dv2_1 dv3_1 dv1_2 dv2_2 dv3_2 REF1 REF2 REF3.
@@ -18240,13 +18254,13 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dv1 dv2 idxs,
       dvalue_refine_strict dv1 dv2 ->
       orutt pre post dvalue_refine_strict
-        ((fix loop (str : IS1.LP.Events.DV.dvalue) (idxs0 : list LLVMAst.int_ast) {struct idxs0} :
-           itree _ IS1.LP.Events.DV.dvalue :=
+        ((fix loop (str : DV1.dvalue) (idxs0 : list LLVMAst.int_ast) {struct idxs0} :
+           itree _ DV1.dvalue :=
             match idxs0 with
             | [] => Ret str
             | i :: tl =>
-                ITree.bind (IS1.LP.Events.DV.index_into_str_dv str i)
-                  (fun v : IS1.LP.Events.DV.dvalue => loop v tl)
+                ITree.bind (DV1.index_into_str_dv str i)
+                  (fun v : DV1.dvalue => loop v tl)
             end) dv1 idxs)
         ((fix loop (str : dvalue) (idxs0 : list LLVMAst.int_ast) {struct idxs0} : itree _ dvalue :=
             match idxs0 with
@@ -18292,19 +18306,19 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dvalue_refine_strict dv1 dv2 ->
       dvalue_refine_strict dv1' dv2' ->
       orutt pre post dvalue_refine_strict
-        ((fix loop (str : IS1.LP.Events.DV.dvalue) (idxs0 : list LLVMAst.int_ast) {struct idxs0} :
-           itree _ IS1.LP.Events.DV.dvalue :=
+        ((fix loop (str : DV1.dvalue) (idxs0 : list LLVMAst.int_ast) {struct idxs0} :
+           itree _ DV1.dvalue :=
             match idxs0 with
             | [] => LLVMEvents.raise "Index was not provided"
             | [i] =>
-                ITree.bind (IS1.LP.Events.DV.insert_into_str str dv1' i)
-                  (fun v : IS1.LP.Events.DV.dvalue => Ret v)
+                ITree.bind (DV1.insert_into_str str dv1' i)
+                  (fun v : DV1.dvalue => Ret v)
             | i :: (_ :: _) as tl =>
-                ITree.bind (IS1.LP.Events.DV.index_into_str_dv str i)
-                  (fun subfield : IS1.LP.Events.DV.dvalue =>
+                ITree.bind (DV1.index_into_str_dv str i)
+                  (fun subfield : DV1.dvalue =>
                      ITree.bind (loop subfield tl)
-                       (fun modified_subfield : IS1.LP.Events.DV.dvalue =>
-                          IS1.LP.Events.DV.insert_into_str str modified_subfield i))
+                       (fun modified_subfield : DV1.dvalue =>
+                          DV1.insert_into_str str modified_subfield i))
             end) dv1 idxs)
         ((fix loop (str : dvalue) (idxs0 : list LLVMAst.int_ast) {struct idxs0} : itree _ dvalue :=
             match idxs0 with
@@ -18357,7 +18371,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dt (r1 : list IS1.MEM.DVALUE_BYTE.dvalue_byte) (r2 : list dvalue_byte),
       dvalue_bytes_refine r1 r2 ->
       orutt (OOM:=OOME) pre post dvalue_refine_strict
-        (ErrOOMPoison_handle_poison_and_oom IS1.LP.Events.DV.DVALUE_Poison
+        (ErrOOMPoison_handle_poison_and_oom DV1.DVALUE_Poison
            (IS1.LLVM.MEM.MP.DVALUE_BYTES.dvalue_bytes_to_dvalue r1 dt))
         (ErrOOMPoison_handle_poison_and_oom DVALUE_Poison (DVALUE_BYTES.dvalue_bytes_to_dvalue r2 dt)).
   Proof.
@@ -18396,20 +18410,20 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       map_monad dvalue_convert_strict xs1 = NoOom xs2 ->
       map_monad dvalue_convert_strict ys1 = NoOom ys2 ->
       orutt (OOM:=OOME) pre post (Forall2 dvalue_refine_strict)
-        ((fix loop (conds xs ys : list IS1.LP.Events.DV.dvalue) {struct conds} :
-           itree _ (list IS1.LP.Events.DV.dvalue) :=
+        ((fix loop (conds xs ys : list DV1.dvalue) {struct conds} :
+           itree _ (list DV1.dvalue) :=
             match conds with
             | [] =>
                 match xs with
                 | [] =>
-                    fun ys0 : list IS1.LP.Events.DV.dvalue =>
+                    fun ys0 : list DV1.dvalue =>
                       match ys0 with
                       | [] => Ret []
                       | _ :: _ =>
                           LLVMEvents.raise "concretize_uvalueM: ill-typed vector select, length mismatch."
                       end
                 | _ :: _ =>
-                    fun _ : list IS1.LP.Events.DV.dvalue =>
+                    fun _ : list DV1.dvalue =>
                       LLVMEvents.raise "concretize_uvalueM: ill-typed vector select, length mismatch."
                 end ys
             | c :: conds0 =>
@@ -18422,16 +18436,16 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
                     | y :: ys0 =>
                         ITree.bind
                           match c with
-                          | @IS1.LP.Events.DV.DVALUE_I 1 i =>
+                          | @DV1.DVALUE_I 1 i =>
                               if (@Integers.unsigned 1 i =? 1)%Z then Ret x5 else Ret y
-                          | IS1.LP.Events.DV.DVALUE_Poison t => Ret (IS1.LP.Events.DV.DVALUE_Poison t)
+                          | DV1.DVALUE_Poison t => Ret (DV1.DVALUE_Poison t)
                           | _ =>
                               LLVMEvents.raise
                                 "concretize_uvalueM: ill-typed select, condition in vector was not poison or i1."
                           end
-                          (fun selected : IS1.LP.Events.DV.dvalue =>
+                          (fun selected : DV1.dvalue =>
                              ITree.bind (loop conds0 xs0 ys0)
-                               (fun rest : list IS1.LP.Events.DV.dvalue => Ret (selected :: rest)))
+                               (fun rest : list DV1.dvalue => Ret (selected :: rest)))
                     end
                 end
             end) cnds1 xs1 ys1)
@@ -18525,15 +18539,15 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       concretization_map_refine acc1 acc2 ->
       orutt (OOM:=OOME) pre post dvalue_bytes_refine
         ((fix concretize_uvalue_bytes_helper
-            (acc : NMap (list (IS1.LP.Events.DV.uvalue * IS1.LP.Events.DV.dvalue)))
-            (uvs0 : list IS1.LP.Events.DV.uvalue) {struct uvs0} :
+            (acc : NMap (list (DV1.uvalue * DV1.dvalue)))
+            (uvs0 : list DV1.uvalue) {struct uvs0} :
            itree E1 (list IS1.LLVM.MEM.MP.DVALUE_BYTES.dvalue_byte) :=
             match uvs0 with
             | [] => Ret []
-            | IS1.LP.Events.DV.UVALUE_ExtractByte byte_uv dt0 idx sid :: uvs1 =>
+            | DV1.UVALUE_ExtractByte byte_uv dt0 idx sid :: uvs1 =>
                 match
                   match
-                    NM.find (elt:=list (IS1.LP.Events.DV.uvalue * IS1.LP.Events.DV.dvalue)) sid acc
+                    NM.find (elt:=list (DV1.uvalue * DV1.dvalue)) sid acc
                   with
                   | Some v => Util.assoc byte_uv v
                   | None => None
@@ -18547,10 +18561,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
                     ITree.bind
                       (IS1.LLVM.MEM.CP.CONC.concretize_uvalueM (itree E1)
                          (fun dt1 : dtyp =>
-                            lift_err_RAISE_ERROR (IS1.LP.Events.DV.default_dvalue_of_dtyp dt1))
+                            lift_err_RAISE_ERROR (DV1.default_dvalue_of_dtyp dt1))
                          (itree E1)
                          (fun (A : Type) (x0 : itree E1 A) => x0) byte_uv)
-                      (fun dv : IS1.LP.Events.DV.dvalue =>
+                      (fun dv : DV1.dvalue =>
                          ITree.bind
                            (concretize_uvalue_bytes_helper
                               (IS1.LLVM.MEM.CP.CONCBASE.new_concretized_byte acc byte_uv dv sid) uvs1)
@@ -19959,16 +19973,16 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma Store_E1E2_orutt :
     forall E1 E2
       `{OOM1 : OOME -< E1} `{OOM2 : OOME -< E2}
-      `{MEM1 : IS1.LP.Events.MemoryE -< E1} `{MEM2 : IS2.LP.Events.MemoryE -< E2}
+      `{MEM1 : MemoryE DV1.dvalue DV1.uvalue -< E1} `{MEM2 : MemoryE _ _ -< E2}
       (pre : prerel E1 E2) (post : postrel E1 E2)
-      (MEMPRE : forall dt r1 r2 r3 r4, dvalue_refine_strict r1 r3 -> uvalue_refine_strict r2 r4 -> pre unit unit (MEM1 unit (IS1.LP.Events.Store dt r1 r2)) (MEM2 unit (Store dt r3 r4)))
+      (MEMPRE : forall dt r1 r2 r3 r4, dvalue_refine_strict r1 r3 -> uvalue_refine_strict r2 r4 -> pre unit unit (MEM1 unit (Store dt r1 r2)) (MEM2 unit (Store dt r3 r4)))
       (MEMDISC : forall e (o : OOME unit), MEM2 unit e <> subevent unit o)
        dt r1 r2 r3 r4,
       dvalue_refine_strict r1 r2 ->
       uvalue_refine_strict r3 r4 ->
       orutt (OOM:=OOME) pre post eq
-        (trigger (IS1.LP.Events.Store dt r1 r3))
-        (trigger (IS2.LP.Events.Store dt r2 r4)).
+        (trigger (Store dt r1 r3))
+        (trigger (Store dt r2 r4)).
   Proof.
     intros E1 E2 OOM1 OOM2 MEM1 MEM2 pre post MEMPRE MEMDISC dt r1 r2 r3 r4 R1R2 R3R4.
     apply orutt_trigger; eauto.
@@ -19997,24 +20011,31 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     : ORUTT.
 
   #[global] Hint Extern 1 (uvalue_refine_strict _ _) => solve_uvalue_refine_strict : ORUTT.
-  Hint Extern 1 (forall _ _ _,   ReSum_inr _ _ _ _ _ _ _ <> subevent _ _) => solve [intros * CONTRA; inv CONTRA] : ORUTT.
-  Hint Extern 1 (forall _ _,   ReSum_inr _ _ _ _ _ _ _ <> subevent _ _) => solve [intros * CONTRA; inv CONTRA] : ORUTT.
+  Hint Extern 1 (forall _ _ _, _ <> subevent _ _) => solve [intros * CONTRA; inv CONTRA] : ORUTT.
+  Hint Extern 1 (forall _ _,  _ _ <> subevent _ _) => solve [intros * CONTRA; inv CONTRA] : ORUTT.
   Hint Extern 1 (forall _ _ _, _ -> (instr_E_refine_strict _ _ _ _)) => solve [repeat constructor; auto].
   Hint Extern 1 (_ -< _) => typeclasses eauto.
+  Hint Extern 1 (forall (dt : dtyp) (r4 : DV1.dvalue) (r5 : DV1.uvalue) (r6 : DV2.dvalue) (r7 : DV2.uvalue),
+        dvalue_refine_strict r4 r6 ->
+        uvalue_refine_strict r5 r7 ->
+        exp_E_refine_strict unit unit (_ (Store dt r4 r5)) (_ (Store dt r6 r7)))
+       => cbn;intros;tauto : ORUTT.
+   (*
   Hint Extern 1 (forall (dt : dtyp) (r4 : DV1.dvalue) (r5 : DV1.uvalue) (r6 : DV2.dvalue) (r7 : DV2.uvalue),
   dvalue_refine_strict r4 r6 ->
   uvalue_refine_strict r5 r7 ->
   exp_E_refine_strict unit unit
-    (ReSum_inr IFun sum1 IS1.LP.Events.MemoryE
-       (IS1.LP.Events.LLVMEnvE +'
-        IS1.LP.Events.MemoryE +'
-        IS1.LP.Events.PickUvalueE +'
-        OOME +' LLVMExcE IS1.LP.Events.DV.uvalue +' UBE +' DebugE +' FailureE)
-       IS1.LP.Events.LLVMGEnvE unit (IS1.LP.Events.Store dt r4 r5))
-    (ReSum_inr IFun sum1 MemoryE
-       (LLVMEnvE +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
-       LLVMGEnvE unit (Store dt r6 r7))) => cbn; intros; tauto.
-
+    (ReSum_inr IFun sum1 (MemoryE DV1.dvalue DV1.uvalue)
+       (LLVMEnvE DV1.uvalue +'
+        MemoryE DV1.dvalue DV1.uvalue +'
+        PickUvalueE DV1.dvalue DV1.uvalue +'
+        OOME +' LLVMExcE DV1.uvalue +' UBE +' DebugE +' FailureE)
+       LLVMGEnvE DV1.dvalue unit (Store dt r4 r5))
+    (ReSum_inr IFun sum1 (MemoryE DV2.dvalue DV2.uvalue)
+       (LLVMEnvE DV2.uvalue +' MemoryE DV2.dvalue DV2.uvalue +' PickUvalueE DV2.dvalue DV2.uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+       LLVMGEnvE DV2.dvalue unit (Store dt r6 r7))) => cbn; intros; tauto : ORUTT.
+ *)
+  
   Lemma initialize_global_E1E2_orutt :
     forall g,
       orutt exp_E_refine_strict exp_E_res_refine_strict eq
@@ -20023,7 +20044,6 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         (OOM:=OOME).
   Proof.
     intros g.
-    cbn.
     unfold LLVM1.initialize_global, initialize_global.
     repeat break_match_goal; cbn; eauto 6 with ORUTT.
   Qed.
@@ -20080,12 +20100,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     cbn.
     repeat run_orutt_bind; eauto with ORUTT.
     - (* In the future this allocate_one_E1E2_rutt_strict_sound lemma may be orutt *)
-      apply rutt_orutt; [| apply L0_dec_oom].
+      apply rutt_orutt; [| intros; apply L0_dec_oom].
       apply allocate_one_E1E2_rutt_strict_sound.
     - intros [] [] _.
       repeat run_orutt_bind; eauto with ORUTT.
 
-      apply rutt_orutt; [| apply L0_dec_oom].
+      apply rutt_orutt; [| intros; apply L0_dec_oom].
       apply allocate_globals_E1E2_rutt_strict_sound.
   Qed.
 
@@ -20115,10 +20135,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     forall phis bid_from,
       orutt instr_E_refine_strict instr_E_res_refine_strict (Forall2 (eq × uvalue_refine_strict))
         (map_monad
-           (fun x => translate IS1.LP.Events.exp_to_instr (IS1.LLVM.D.denote_phi bid_from x))
+           (fun x => translate (@exp_to_instr DV1.dvalue DV1.uvalue) (IS1.LLVM.D.denote_phi bid_from x))
            phis)
         (map_monad
-           (fun x => translate exp_to_instr (denote_phi bid_from x))
+           (fun x => translate (@exp_to_instr _ _) (denote_phi bid_from x))
            phis)
         (OOM:=OOME).
   Proof.
@@ -20146,6 +20166,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   #[global] Hint Resolve
    orutt_trigger_LocalWrite : ORUTT.
 
+
+  
   Lemma denote_phis_orutt_strict :
     forall phis bid_from,
       orutt instr_E_refine_strict instr_E_res_refine_strict eq
@@ -20165,9 +20187,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         run_orutt_bind; eauto 10 with ORUTT.
         solve_orutt_denote_concretize_if_no_undef_or_poison.
 
-        intros [] [] _.
-        run_orutt_bind; eauto with ORUTT.
         intros r1 r2 EQ; subst; eauto with ORUTT.
+        run_orutt_bind; eauto with ORUTT.
+        intros r1 r3 EQ; subst; eauto with ORUTT.
     }
   Qed.
 
@@ -20204,27 +20226,27 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   #[global] Hint Extern 1 (instr_E_refine_strict _ _ _ _) => solve [repeat constructor; auto] : ORUTT.
 
   #[global] Hint Extern 1 (forall _ _ _ _,
-        instr_E_res_refine_strict {_ : IS1.LP.Events.DV.dvalue | True} {_ : dvalue | True}
-          (subevent {_ : IS1.LP.Events.DV.dvalue | True} (IS1.LLVM.MEM.CP.CONC.pick_unique_uvalue _))
-          (exist (fun _ : IS1.LP.Events.DV.dvalue => True) _ I)
+        instr_E_res_refine_strict {_ : DV1.dvalue | True} {_ : dvalue | True}
+          (subevent {_ : DV1.dvalue | True} (IS1.LLVM.MEM.CP.CONC.pick_unique_uvalue _))
+          (exist (fun _ : DV1.dvalue => True) _ I)
           (subevent {_ : dvalue | True} (pick_unique_uvalue _)) (exist (fun _ : dvalue => True) _ I) ->
-        dvalue_refine_strict _ _) => intros *; cbn in *; tauto.
+        dvalue_refine_strict _ _) => intros *; cbn in *; tauto : ORUTT.
 
   Lemma orutt_trigger_Load :
     forall E1 E2
       `{OOM1 : OOME -< E1} `{OOM2 : OOME -< E2}
-      `{MEM1 : IS1.LP.Events.MemoryE -< E1} `{MEM2 : IS2.LP.Events.MemoryE -< E2}
+      `{MEM1 : MemoryE DV1.dvalue DV1.uvalue -< E1} `{MEM2 : MemoryE _ _ -< E2}
       (pre : prerel E1 E2) (post : postrel E1 E2)
-      (MEMPRE : forall dt dv1 dv2, dvalue_refine_strict dv1 dv2 -> pre DV1.uvalue DV2.uvalue (MEM1 DV1.uvalue (IS1.LP.Events.Load dt dv1)) (MEM2 DV2.uvalue (Load dt dv2)))
+      (MEMPRE : forall dt dv1 dv2, dvalue_refine_strict dv1 dv2 -> pre DV1.uvalue DV2.uvalue (MEM1 DV1.uvalue (@Load DV1.dvalue DV1.uvalue dt dv1)) (MEM2 DV2.uvalue (Load dt dv2)))
       (MEMPOST : forall dt dv1 dv2 (t1 : DV1.uvalue) (t2 : DV2.uvalue),
-          post DV1.uvalue DV2.uvalue (MEM1 DV1.uvalue (IS1.LP.Events.Load dt dv1)) t1
+          post DV1.uvalue DV2.uvalue (MEM1 DV1.uvalue (@Load DV1.dvalue DV1.uvalue dt dv1)) t1
             (MEM2 DV2.uvalue (Load dt dv2)) t2 ->
           uvalue_refine_strict t1 t2)
       (MEMDISC : forall dt dv2 (o : OOME DV2.uvalue), MEM2 DV2.uvalue (Load dt dv2) <> subevent DV2.uvalue o)
       dt
       (dv1 : DV1.dvalue) (dv2 : DV2.dvalue)
       (REF: dvalue_refine_strict dv1 dv2),
-      orutt (OOM:=OOME) pre post uvalue_refine_strict (trigger (IS1.LP.Events.Load dt dv1)) (trigger (Load dt dv2)).
+      orutt (OOM:=OOME) pre post uvalue_refine_strict (trigger (@Load _ _ dt dv1)) (trigger (Load dt dv2)).
   Proof.
     intros E1 E2 OOM1 OOM2 MEM1 MEM2 pre post MEMPRE MEMPOST MEMDISC dt dv1 dv2 REF.
     apply orutt_trigger; eauto.
@@ -20232,11 +20254,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
   #[global] Hint Resolve
    orutt_trigger_Load : ORUTT.
-  #[global] Hint Extern 1 (forall (dt : dtyp) (dv1 : IS1.LP.Events.DV.dvalue) (dv2 : dvalue) (t1 : DV1.uvalue)
+  #[global] Hint Extern 1 (forall (dt : dtyp) (dv1 : DV1.dvalue) (dv2 : dvalue) (t1 : DV1.uvalue)
     (t2 : DV2.uvalue),
   instr_E_res_refine_strict DV1.uvalue DV2.uvalue
-    (ReSum_inr IFun sum1 IS1.LP.Events.MemoryE (IS1.LP.Events.IntrinsicE +' IS1.LP.Events.exp_E)
-       IS1.LP.Events.CallE DV1.uvalue (IS1.LP.Events.Load dt dv1))
+    (ReSum_inr IFun sum1 (@MemoryE DV1.dvalue DV1.uvalue) (@IntrinsicE DV1.dvalue DV1.uvalue +' exp_E DV1.dvalue DV1.uvalue)
+       CallE DV1.uvalue (@Load DV1.dvalue DV1.uvalue dt dv1))
     t1 (ReSum_inr IFun sum1 MemoryE (IntrinsicE +' exp_E) CallE DV2.uvalue (Load dt dv2)) t2 ->
   uvalue_refine_strict t1 t2) => 
     intros ? ? ? ? ? ?; cbn in *; tauto : ORUTT.
@@ -20268,6 +20290,10 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     intros r6 r7 H2.
     run_orutt_bind; [eauto with ORUTT|].
 
+    apply orutt_trigger_Load; eauto with ORUTT.
+    intros; eauto. cbn in *. tauto.
+
+    
     intros r8 r9 H3.
     repeat rewrite bind_bind.
     setoid_rewrite bind_ret_l.
@@ -20311,23 +20337,11 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
                     ].
     break_match_goal.
     { apply orutt_bind with (RR:=eq); eauto with ORUTT.
-      intros [] [] ?.
-      apply orutt_bind with (RR:=uvalue_refine_strict).
-      eapply orutt_denote_concretize_if_no_undef_or_poison;
-        try solve [ intros * CONTRA; inv CONTRA | constructor | auto ].
+      intros; eauto with ORUTT.
+      run_orutt_bind; eauto with ORUTT.
+      eapply orutt_denote_concretize_if_no_undef_or_poison; eauto with ORUTT.
       rewrite uvalue_refine_strict_equation; cbn.
-      rewrite H3; auto.
-
-      intros r10 r11 R10R11.
-      { apply orutt_trigger; cbn; unfold uvalue_refine_strict;
-          repeat setoid_rewrite H3; cbn; auto.
-
-        intros [] [] ?; auto.
-
-        intros o CONTRA.
-        unfold_subevents.
-        inv CONTRA.
-      }
+    rewrite H3; auto.
     }
 
     apply orutt_bind with (RR:=uvalue_refine_strict); eauto with ORUTT.
@@ -20381,6 +20395,9 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         ].
   Qed.
 
+  #[global] Hint Extern 1 ( forall (dt : dtyp) (dv1 : DV1.dvalue) (dv2 : DV2.dvalue) (t1 : DV1.uvalue) (t2 : DV2.uvalue),
+  instr_E_res_refine_strict DV1.uvalue DV2.uvalue (MemoryE_instrE (Load dt dv1)) t1 (MemoryE_instrE (Load dt dv2)) t2 -> uvalue_refine_strict t1 t2) => cbn; tauto : ORUTT.
+  
   #[global] Hint Extern 1 (forall x y, x=y -> (orutt _ _ _ (bind _ _) (bind _ _))) => intros ? ? ?; subst : ORUTT.
   #[global] Hint Resolve denote_atomic_rmw_operation_orutt_strict : ORUTT.
   Lemma denote_atomicrmw_orutt_strict :
@@ -20391,7 +20408,19 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     intros id a.
     destruct a, a_ptr, a_val.
     cbn.
-    eauto 20 with ORUTT.
+    run_orutt_bind. eauto with ORUTT.
+    intros.
+    run_orutt_bind. eauto with ORUTT.
+    intros.
+    run_orutt_bind. eauto with ORUTT.
+    intros.
+    run_orutt_bind. eauto with ORUTT.
+    intros.
+    run_orutt_bind. eauto with ORUTT.
+    intros.
+    run_orutt_bind; eauto with ORUTT. 
+    intros.
+    run_orutt_bind; eauto with ORUTT. 
   Qed.
 
   #[global] Hint Resolve denote_atomicrmw_orutt_strict : ORUTT.
@@ -20399,20 +20428,20 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma orutt_trigger_Intrinsic :
     forall E1 E2
       `{OOM1 : OOME -< E1} `{OOM2 : OOME -< E2}
-      `{INT1 : IS1.LP.Events.IntrinsicE -< E1} `{INT2 : IS2.LP.Events.IntrinsicE -< E2}
+      `{INT1 : IntrinsicE DV1.dvalue DV1.uvalue -< E1} `{INT2 : IntrinsicE DV2.dvalue DV2.uvalue -< E2}
       (pre : prerel E1 E2) (post : postrel E1 E2)
       (INTDISC : forall e (o : OOME _), INT2 _ e <> subevent (DV2.uvalue + DV2.dvalue) o)
       dt s
       (args1 : list DV1.dvalue) (args2 : list DV2.dvalue)
       (REF: pre (DV1.uvalue + DV1.dvalue)%type (DV2.uvalue + DV2.dvalue)%type
-                                    (INT1 (DV1.uvalue + DV1.dvalue)%type (IS1.LP.Events.Intrinsic dt s args1))
-                                    (INT2 (DV2.uvalue + DV2.dvalue)%type (Intrinsic dt s args2)))
+                                    (INT1 (DV1.uvalue + DV1.dvalue)%type (@Intrinsic DV1.dvalue DV1.uvalue dt s args1))
+                                    (INT2 (DV2.uvalue + DV2.dvalue)%type (@Intrinsic _ _ dt s args2)))
       (POST: forall dt s (t1 : DV1.uvalue + DV1.dvalue) (t2 : DV2.uvalue + DV2.dvalue),
           post (DV1.uvalue + DV1.dvalue)%type (DV2.uvalue + DV2.dvalue)%type
-            (INT1 (DV1.uvalue + DV1.dvalue)%type (IS1.LP.Events.Intrinsic dt s args1)) t1
-            (INT2 (DV2.uvalue + DV2.dvalue)%type (Intrinsic dt s args2)) t2 ->
+            (INT1 (DV1.uvalue + DV1.dvalue)%type (@Intrinsic _ _ dt s args1)) t1
+            (INT2 (DV2.uvalue + DV2.dvalue)%type (@Intrinsic _ _ dt s args2)) t2 ->
           sum_rel uvalue_refine_strict dvalue_refine_strict t1 t2),
-      orutt (OOM:=OOME) pre post (sum_rel uvalue_refine_strict dvalue_refine_strict) (trigger (IS1.LP.Events.Intrinsic dt s args1))
+      orutt (OOM:=OOME) pre post (sum_rel uvalue_refine_strict dvalue_refine_strict) (trigger (@Intrinsic _ _ dt s args1))
     (trigger (Intrinsic dt s args2)).
   Proof.
     intros.
@@ -20422,21 +20451,23 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma orutt_trigger_Call :
     forall E1 E2
       `{OOM1 : OOME -< E1} `{OOM2 : OOME -< E2}
-      `{CALL1 : IS1.LP.Events.CallE -< E1} `{CALL2 : IS2.LP.Events.CallE -< E2}
+      `{CALL1 : CallE DV1.uvalue -< E1} `{CALL2 : CallE DV2.uvalue -< E2}
       (pre : prerel E1 E2) (post : postrel E1 E2)
       (CALLDISC : forall e (o : OOME _), CALL2 _ e <> subevent (DV2.uvalue + DV2.uvalue) o)
       dt (f1 : DV1.uvalue) (f2 : DV2.uvalue)
       (args1 : list DV1.uvalue) (args2 : list DV2.uvalue)
       (REF: pre (DV1.uvalue + DV1.uvalue)%type (DV2.uvalue + DV2.uvalue)%type
-                                    (CALL1 (DV1.uvalue + DV1.uvalue)%type (IS1.LP.Events.Call dt f1 args1))
-                                    (CALL2 (DV2.uvalue + DV2.uvalue)%type (Call dt f2 args2)))
+              (CALL1 (DV1.uvalue + DV1.uvalue)%type (LLVMEvents.Call dt f1 args1))
+              (CALL2 (DV2.uvalue + DV2.uvalue)%type (LLVMEvents.Call dt f2 args2)))
       (POST: forall dt f1 f2 (t1 : DV1.uvalue + DV1.uvalue) (t2 : DV2.uvalue + DV2.uvalue),
           post (DV1.uvalue + DV1.uvalue)%type (DV2.uvalue + DV2.uvalue)%type
-            (CALL1 (DV1.uvalue + DV1.uvalue)%type (IS1.LP.Events.Call dt f1 args1)) t1
-            (CALL2 (DV2.uvalue + DV2.uvalue)%type (Call dt f2 args2)) t2 ->
+            (CALL1 (DV1.uvalue + DV1.uvalue)%type (LLVMEvents.Call dt f1 args1)) t1
+            (CALL2 (DV2.uvalue + DV2.uvalue)%type (LLVMEvents.Call dt f2 args2)) t2 ->
           sum_rel uvalue_refine_strict uvalue_refine_strict t1 t2),
-      orutt (OOM:=OOME) pre post (sum_rel uvalue_refine_strict uvalue_refine_strict) (trigger (IS1.LP.Events.Call dt f1 args1))
-    (trigger (Call dt f2 args2)).
+      orutt (OOM:=OOME) pre post
+        (sum_rel uvalue_refine_strict uvalue_refine_strict)
+        (trigger (LLVMEvents.Call dt f1 args1))
+        (trigger (LLVMEvents.Call dt f2 args2)).
   Proof.
     intros.
     apply orutt_trigger; eauto.
@@ -20449,8 +20480,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
   #[global] Hint Extern 1 (forall (dt : dtyp) (s0 : string) (t1 : DV1.uvalue + DV1.dvalue) (t2 : DV2.uvalue + DV2.dvalue),
   instr_E_res_refine_strict (DV1.uvalue + DV1.dvalue) (DV2.uvalue + DV2.dvalue)
-    (ReSum_inr IFun sum1 IS1.LP.Events.IntrinsicE (IS1.LP.Events.IntrinsicE +' IS1.LP.Events.exp_E)
-       IS1.LP.Events.CallE (DV1.uvalue + DV1.dvalue)%type (IS1.LP.Events.Intrinsic dt s0 _))
+    (ReSum_inr IFun sum1 (IntrinsicE DV1.dvalue DV1.uvalue)  (IntrinsicE DV1.dvalue DV1.uvalue +' exp_E DV1.dvalue DV1.uvalue)
+       CallE (DV1.uvalue + DV1.dvalue)%type (Intrinsic dt s0 _))
     t1
     (ReSum_inr IFun sum1 IntrinsicE (IntrinsicE +' exp_E) CallE (DV2.uvalue + DV2.dvalue)%type
        (Intrinsic dt s0 _))
@@ -20460,12 +20491,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   #[global] Hint Extern 1 (forall _ _ , ReSum_inl _ _ _ _ _ _ _ <> subevent _ _) => solve [intros * CONTRA; inv CONTRA] : ORUTT.
 
 #[global] Hint Extern 1
-  (forall (dt : dtyp) (f1 : IS1.LP.Events.DV.uvalue) (f2 : uvalue) (t1 : DV1.uvalue + DV1.uvalue)
+  (forall (dt : dtyp) (f1 : DV1.uvalue) (f2 : uvalue) (t1 : DV1.uvalue + DV1.uvalue)
    (t2 : DV2.uvalue + DV2.uvalue),
  instr_E_res_refine_strict (DV1.uvalue + DV1.uvalue) (DV2.uvalue + DV2.uvalue)
-   (ReSum_inl IFun sum1 IS1.LP.Events.CallE IS1.LP.Events.CallE
-      (IS1.LP.Events.IntrinsicE +' IS1.LP.Events.exp_E) (DV1.uvalue + DV1.uvalue)%type
-      (IS1.LP.Events.Call dt f1 _))
+   (ReSum_inl IFun sum1 (CallE DV1.uvalue) (CallE DV1.uvalue)
+      (IntrinsicE DV1.dvalue DV1.uvalue +' exp_E DV1.dvalue DV1.uvalue) (DV1.uvalue + DV1.uvalue)%type
+      (LLVMEvents.Call dt f1 _))
    t1
    (ReSum_inl IFun sum1 CallE CallE (IntrinsicE +' exp_E) (DV2.uvalue + DV2.uvalue)%type
       (Call dt f2 _))
@@ -20515,16 +20546,16 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma orutt_trigger_Alloca :
     forall E1 E2
       `{OOM1 : OOME -< E1} `{OOM2 : OOME -< E2}
-      `{MEM1 : IS1.LP.Events.MemoryE -< E1} `{MEM2 : IS2.LP.Events.MemoryE -< E2}
+      `{MEM1 : MemoryE DV1.dvalue DV1.uvalue -< E1} `{MEM2 : MemoryE DV2.dvalue DV2.uvalue -< E2}
       (pre : prerel E1 E2) (post : postrel E1 E2)
       (MEMPOST : forall dt sz align (t1 : DV1.dvalue) (t2 : DV2.dvalue),
-          post DV1.dvalue DV2.dvalue (MEM1 DV1.dvalue (IS1.LP.Events.Alloca dt sz align)) t1
+          post DV1.dvalue DV2.dvalue (MEM1 DV1.dvalue (Alloca dt sz align)) t1
             (MEM2 DV2.dvalue (Alloca dt sz align)) t2 ->
           dvalue_refine_strict t1 t2)
       (MEMDISC : forall e (o : OOME DV2.dvalue), MEM2 DV2.dvalue e <> subevent DV2.dvalue o)
       dt sz align
-      (MEMPRE : pre DV1.dvalue DV2.dvalue (MEM1 DV1.dvalue (IS1.LP.Events.Alloca dt sz align)) (MEM2 DV2.dvalue (Alloca dt sz align))),
-      orutt (OOM:=OOME) pre post dvalue_refine_strict (trigger (IS1.LP.Events.Alloca dt sz align)) (trigger (Alloca dt sz align)).
+      (MEMPRE : pre DV1.dvalue DV2.dvalue (MEM1 DV1.dvalue (Alloca dt sz align)) (MEM2 DV2.dvalue (Alloca dt sz align))),
+      orutt (OOM:=OOME) pre post dvalue_refine_strict (trigger (Alloca dt sz align)) (trigger (Alloca dt sz align)).
   Proof.
     intros.
     apply orutt_trigger; eauto.
@@ -20601,19 +20632,24 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
               eauto 200 with ORUTT.
           - (* va_end *)
             eauto 200 with ORUTT.
-          - run_orutt_bind; eauto 200 with ORUTT.
-            run_orutt_bind; eauto 200 with ORUTT.
+          - run_orutt_bind; eauto 10 with ORUTT.
+            run_orutt_bind; eauto 10 with ORUTT.
             intros r0 r3 H0.
             run_orutt_bind; eauto 200 with ORUTT.
+            eapply orutt_trigger_Intrinsic; eauto with ORUTT.
+
+            intros ? ? [? | ?] [? | ?] ?; cbn; inv H1; eauto with ORUTT; tauto.
             intros [? | ?] [? | ?] ?; cbn; inv H1; eauto with ORUTT.
         }
 
-        run_orutt_bind; eauto 200 with ORUTT.
-        run_orutt_bind; eauto 200 with ORUTT.
+        run_orutt_bind; eauto 10 with ORUTT.
+        run_orutt_bind; eauto 10 with ORUTT.
         intros r0 r3 H0.
-        run_orutt_bind; eauto 200 with ORUTT.
-
+        run_orutt_bind; eauto 10 with ORUTT.
+        eapply orutt_trigger_Call; eauto with ORUTT.
+        intros ? ? ? [? | ?] [? | ?] ?; cbn; inv H1; eauto with ORUTT; tauto.
         intros [? | ?] [? | ?] ?; cbn; inv H1; eauto with ORUTT.
+
       - break_inner_match.
         { run_orutt_bind; eauto 200 with ORUTT.
           break_match.
@@ -20732,10 +20768,15 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
           - (* va_end *)
             eauto 200 with ORUTT.
           - repeat (intros; run_orutt_bind; eauto 200 with ORUTT).
+            eapply orutt_trigger_Intrinsic; eauto with ORUTT.
+            intros ? ? [? | ?] [? | ?] ? ; cbn; inv H1; eauto with ORUTT; tauto.
             intros [? | ?] [? | ?] ?; cbn; inv H1; eauto with ORUTT.
         }
 
         repeat (intros; run_orutt_bind; eauto 200 with ORUTT).
+        eapply orutt_trigger_Call; eauto with ORUTT.
+        intros ? ? ? [? | ?] [? | ?] ? ; cbn; inv H1; eauto with ORUTT; tauto.
+        
         intros [? | ?] [? | ?] ?; cbn; inv H1; eauto with ORUTT.
       - destruct val, ptr.
         repeat (intros; run_orutt_bind; eauto 200 with ORUTT).
@@ -20977,7 +21018,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         intros [dt ex].
         eauto with ORUTT.
       }
-
+      eapply orutt_trigger_Call; eauto with ORUTT.
+      intros ? ? ? [? | ?] [? | ?] ?; cbn; inv H1; eauto with ORUTT; tauto.
       intros [? | ?] [? | ?] ?; cbn; inv H1; eauto 10 with ORUTT.
       destruct i; cbn; eauto 10 with ORUTT.
   Qed.
@@ -21087,7 +21129,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Lemma dtyp_of_uvalue_fun_fin_inf :
     forall uv_fin uv_inf,
       uvalue_refine_strict uv_inf uv_fin ->
-      IS1.LP.Events.DV.dtyp_of_uvalue_fun uv_inf = dtyp_of_uvalue_fun uv_fin.
+      DV1.dtyp_of_uvalue_fun uv_inf = dtyp_of_uvalue_fun uv_fin.
   Proof.
     intros uv_fin.
     induction uv_fin using uvalue_ind;
@@ -21315,7 +21357,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
           destruct (uvalue_convert_strict x) eqn:?; inv H0.
           cbn in Heqb0.
           rewrite <- H1, H4, Heqb0, sizeof_dtyp_fin_inf in IHForall2.
-          destruct ((N.of_nat (Datatypes.length l) =? SIZEOF.sizeof_dtyp dt)%N); inv IHForall2.
+          destruct ((N.of_nat (Datatypes.length l) =? SZ.sizeof_dtyp dt)%N); inv IHForall2.
           apply forallb_false in Heqb0 as (?&?&?).
           eapply Forall2_In_exists2 in FORALL; eauto.
           destruct FORALL as (?&?&?).
@@ -21345,7 +21387,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     cbn.
     eapply orutt_bind with (RR:=dvalue_refine_strict).
     apply rutt_orutt. apply GlobalRead_L0_E1E2_rutt.
-    solve_dec_oom.
+    { intros ? s. repeat destruct s; try (solve [ left; intros o CONTRA; inv CONTRA ]); right; eexists; reflexivity. } 
 
     intros r1 r2 R1R2.
     destruct r2;
@@ -21758,7 +21800,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma catch_llvm_exc_L0'_orutt :
-    forall (t1 : itree IS1.LP.Events.L0' DV1.uvalue) (t2 : itree IS2.LP.Events.L0' DV2.uvalue),
+    forall (t1 : itree (L0' DV1.dvalue DV1.uvalue) DV1.uvalue) (t2 : itree (L0' _ _) DV2.uvalue),
       orutt (OOM:=OOME) L0'_refine_strict L0'_res_refine_strict uvalue_refine_strict t1 t2 ->
       orutt (OOM:=OOME) L0'_refine_strict L0'_res_refine_strict (sum_rel uvalue_refine_strict uvalue_refine_strict)
         (EitherMonad.unEitherT (IS1.LLVM.D.catch_llvm_exc_L0' t1))
@@ -21828,33 +21870,36 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         setoid_rewrite bind_trigger.
         cbn.
         pstep; red; cbn.
-        change (@subevent L0' L0' (@ReSum_id (Type -> Type) IFun Id_IFun L0') B
-          (@inr1 CallE L0 B
-             (@inr1 ExternalCallE
-                (IntrinsicE +'
-                 LLVMGEnvE +'
-                 (LLVMEnvE +' LLVMStackE) +'
-                 MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+        change (@subevent (L0' dvalue uvalue) (L0' dvalue uvalue) (@ReSum_id (forall _ : Type, Type) IFun Id_IFun (L0' dvalue uvalue)) B
+          (@inr1 (CallE DV2.uvalue) (L0 DV2.dvalue DV2.uvalue) B
+             (@inr1 (ExternalCallE DV2.dvalue DV2.uvalue)
+                (sum1 (IntrinsicE DV2.dvalue DV2.uvalue)
+                   (sum1 (LLVMGEnvE DV2.dvalue)
+                      (sum1 (sum1 (LLVMEnvE DV2.uvalue) (LLVMStackE DV2.uvalue))
+                         (sum1 (MemoryE DV2.dvalue DV2.uvalue)
+                            (sum1 (PickUvalueE DV2.dvalue DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))))))))
                 B
-                (@inr1 IntrinsicE
-                   (LLVMGEnvE +'
-                    (LLVMEnvE +' LLVMStackE) +'
-                    MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                (@inr1 (IntrinsicE DV2.dvalue DV2.uvalue)
+                   (sum1 (LLVMGEnvE DV2.dvalue)
+                      (sum1 (sum1 (LLVMEnvE DV2.uvalue) (LLVMStackE DV2.uvalue))
+                         (sum1 (MemoryE DV2.dvalue DV2.uvalue)
+                            (sum1 (PickUvalueE DV2.dvalue DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))))))))
                    B
-                   (@inr1 LLVMGEnvE
-                      ((LLVMEnvE +' LLVMStackE) +'
-                       MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                   (@inr1 (LLVMGEnvE DV2.dvalue)
+                      (sum1 (sum1 (LLVMEnvE DV2.uvalue) (LLVMStackE DV2.uvalue))
+                         (sum1 (MemoryE DV2.dvalue DV2.uvalue)
+                            (sum1 (PickUvalueE DV2.dvalue DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))))))
                       B
-                      (@inr1 (LLVMEnvE +' LLVMStackE)
-                         (MemoryE +'
-                          PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                      (@inr1 (sum1 (LLVMEnvE DV2.uvalue) (LLVMStackE DV2.uvalue))
+                         (sum1 (MemoryE DV2.dvalue DV2.uvalue)
+                            (sum1 (PickUvalueE DV2.dvalue DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))))))
                          B
-                         (@inr1 MemoryE
-                            (PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) B
-                            (@inr1 PickUvalueE (OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
-                               B (@inl1 OOME (LLVMExcE uvalue +' UBE +' DebugE +' FailureE) B o0)))))))))
+                         (@inr1 (MemoryE DV2.dvalue DV2.uvalue)
+                            (sum1 (PickUvalueE DV2.dvalue DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))))) B
+                            (@inr1 (PickUvalueE DV2.dvalue DV2.uvalue) (sum1 OOME (sum1 (LLVMExcE DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE)))) B
+                               (@inl1 OOME (sum1 (LLVMExcE DV2.uvalue) (sum1 UBE (sum1 DebugE FailureE))) B o0)))))))))
           with
-          (@subevent OOME L0' _ B o0).
+          (@subevent OOME (L0' dvalue uvalue) _ B o0).                 
         eapply EqVisOOM.
       }
 
@@ -21881,8 +21926,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       IM_Refine function_denotation_refine_strict dfns1 dfns2 ->
       (uvalue_refine_strict f1 f2) ->
       (Forall2 uvalue_refine_strict args1 args2) ->
-      call_refine_strict _ _ (IS1.LP.Events.Call dt f1 args1) (Call dt f2 args2) ->
-      orutt event_refine_strict event_res_refine_strict (fun res1 res2 => call_res_refine_strict _ _ (IS1.LP.Events.Call dt f1 args1) res1 (Call dt f2 args2) res2)
+      call_refine_strict _ _ (LLVMEvents.Call dt f1 args1) (LLVMEvents.Call dt f2 args2) ->
+      orutt event_refine_strict event_res_refine_strict (fun res1 res2 => call_res_refine_strict _ _ (LLVMEvents.Call dt f1 args1) res1 (LLVMEvents.Call dt f2 args2) res2)
         (IS1.LLVM.D.denote_mcfg dfns1 dt f1 args1)
         (IS2.LLVM.D.denote_mcfg dfns2 dt f2 args2)
         (OOM:=OOME).
@@ -21999,7 +22044,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 
   Lemma denote_mcfg_E1E2_orutt'_orutt :
     forall dfns1 dfns2 dt f1 f2 args1 args2,
-      orutt event_refine_strict event_res_refine_strict (fun res1 res2 => call_res_refine_strict (IS1.LP.Events.DV.uvalue + IS1.LP.Events.DV.uvalue) (IS2.LP.Events.DV.uvalue + IS2.LP.Events.DV.uvalue) (IS1.LP.Events.Call dt f1 args1) res1 (Call dt f2 args2) res2)
+      orutt event_refine_strict event_res_refine_strict (fun res1 res2 => call_res_refine_strict (DV1.uvalue + DV1.uvalue) (DV2.uvalue + DV2.uvalue) (LLVMEvents.Call dt f1 args1) res1 (LLVMEvents.Call dt f2 args2) res2)
         (IS1.LLVM.D.denote_mcfg dfns1 dt f1 args1)
         (IS2.LLVM.D.denote_mcfg dfns2 dt f2 args2)
         (OOM:=OOME) ->
@@ -22085,7 +22130,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       }
 
       (* Finite conversion *)
-      destruct (ITOP.int_to_ptr (PTOI.ptr_to_int addr2 + Z.of_N (SIZEOF.sizeof_dtyp (DTYPE_I 8)) * IP.to_Z r2)
+      destruct (ITOP.int_to_ptr (PTOI.ptr_to_int addr2 + Z.of_N (SZ.sizeof_dtyp (DTYPE_I 8)) * IP.to_Z r2)
                   (PROV.address_provenance addr2)) eqn:HITOP.
       2: apply orutt_raiseOOM.
 
@@ -22150,7 +22195,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dvalue_refine_strict r1 r2 ->
       orutt (OOM:=OOME) L0'_refine_strict L0'_res_refine_strict uvalue_refine_strict
         match r1 with
-        | IS1.LP.Events.DV.DVALUE_Addr strptr =>
+        | DV1.DVALUE_Addr strptr =>
             ITree.bind (LLVM1.i8_str_index strptr 0)
               (fun (char : @Integers.bit_int 8) =>
                  ITree.bind
@@ -22163,8 +22208,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
                              (fun (next_char : @Integers.bit_int 8) => Ret (inl (next_char, c :: bytes, (offset + 1)%Z))))
                       (char, [], 1%Z))
                    (fun (bytes : list int8) =>
-                      ITree.bind (trigger (IS1.LP.Events.IO_stdout (DList.rev_tail_rec bytes)))
-                        (fun _ : unit => Ret (@IS1.LP.Events.DV.UVALUE_I 8 (@Integers.zero 8)))))
+                      ITree.bind (trigger (LLVMEvents.IO_stdout (DList.rev_tail_rec bytes)))
+                        (fun _ : unit => Ret (@DV1.UVALUE_I 8 (@Integers.zero 8)))))
         | _ => raiseUB "puts got non-address argument"
         end
         match r2 with
@@ -22503,7 +22548,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
   Qed.
 
   Lemma model_E1E2_L0_orutt_strict_sound
-    (args1 : list IS1.LP.Events.DV.uvalue)
+    (args1 : list DV1.uvalue)
     (args2 : list uvalue)
     (ARGS : Forall2 uvalue_refine_strict args1 args2)
     (p : list
@@ -22527,7 +22572,17 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     intros r1 r2 R1R2.
     eapply orutt_bind;
       [apply rutt_orutt;
-       [try apply GlobalRead_L0_E1E2_rutt | solve_dec_oom]|].
+       [try apply GlobalRead_L0_E1E2_rutt | idtac]|].
+    intros ? s; repeat destruct s;
+    try solve
+      [
+        left;
+        intros o CONTRA;
+        inv CONTRA
+      ];
+    right;
+    eexists; reflexivity.
+
 
     intros r3 r4 R3R4.
     eapply orutt_bind.
@@ -22984,15 +23039,16 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
         setoid_rewrite bind_trigger.
         cbn.
         pstep; red; cbn.
-        change 
-          (@subevent ((LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (ExternalCallE +' IntrinsicE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
-             (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 ((LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (IntrinsicE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) ExternalCallE
-                (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 ((LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) ((LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) IntrinsicE
-                   (@ReSum_id (Type -> Type) IFun Id_IFun ((LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE))))
+        (* SAZ: There has got to be a better way !*)
+           change 
+          (@subevent ((LLVMEnvE _ +' LLVMStackE _) +' MemoryE _ _ +' PickUvalueE _ _ +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (ExternalCallE _ _ +' IntrinsicE _ _ +' (LLVMEnvE _ +' LLVMStackE _) +' MemoryE _ _ +' PickUvalueE _ _+' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+             (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 ((LLVMEnvE _ +' LLVMStackE _) +' MemoryE _ _ +' PickUvalueE _ _ +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (IntrinsicE _ _ +' (LLVMEnvE _ +' LLVMStackE _) +' MemoryE _ _ +' PickUvalueE _ _ +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (ExternalCallE _ _)
+                (@ReSum_inr (Type -> Type) IFun sum1 Cat_IFun Inr_sum1 ((LLVMEnvE _ +' LLVMStackE _) +' MemoryE _ _ +' PickUvalueE _ _ +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) ((LLVMEnvE _ +' LLVMStackE _) +' MemoryE _ _ +' PickUvalueE _ _ +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (IntrinsicE _ _)
+                   (@ReSum_id (Type -> Type) IFun Id_IFun ((LLVMEnvE _ +' LLVMStackE _) +' MemoryE _ _ +' PickUvalueE _ _ +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE))))
              void
-             (@inr1 (LLVMEnvE +' LLVMStackE) (MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) void
-                (@inr1 MemoryE (PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) void (@inr1 PickUvalueE (OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) void (@inl1 OOME (LLVMExcE uvalue +' UBE +' DebugE +' FailureE) void o0)))))
-          with (@subevent OOME (ExternalCallE +' IntrinsicE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) _ _ o0).
+             (@inr1 (LLVMEnvE _ +' LLVMStackE _) (MemoryE _ _ +' PickUvalueE _ _ +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) void
+                (@inr1 (MemoryE _ _) (PickUvalueE _ _ +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) void (@inr1 (PickUvalueE _ _) (OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) void (@inl1 OOME (LLVMExcE uvalue +' UBE +' DebugE +' FailureE) void o0)))))
+          with (@subevent OOME (@L1 DV2.dvalue DV2.uvalue) _ _ o0).
 
         apply EqVisOOM.
       }
@@ -24126,8 +24182,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       pstep; red; cbn.
       change (inr1 (inr1 (inr1 (inr1 (inl1 o0))))) with
         (@subevent _ _ (ReSum_inr IFun sum1 OOME
-                          ((LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
-                          LLVMGEnvE
+                          ((LLVMEnvE DV2.uvalue +' LLVMStackE DV2.uvalue) +' (MemoryE DV2.dvalue DV2.uvalue) +' (PickUvalueE DV2.dvalue DV2.uvalue) +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                          (@LLVMGEnvE DV2.dvalue)
 
            ) B o0).
       rewrite subevent_subevent.
@@ -24139,17 +24195,18 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       pstep; red; cbn.
       change (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 u0))))))) with
         (@subevent _ _ (ReSum_inr IFun sum1 UBE
-                          ((LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
-                          LLVMGEnvE
+                          ((LLVMEnvE DV2.uvalue +' LLVMStackE DV2.uvalue) +' (MemoryE DV2.dvalue DV2.uvalue) +' (PickUvalueE DV2.dvalue DV2.uvalue) +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                          (@LLVMGEnvE DV2.dvalue)
 
            ) B u0).
       rewrite subevent_subevent.
       change (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 u))))))) with
         (@subevent _ _ (ReSum_inr IFun sum1 UBE
-                                  ((IS1.LP.Events.LLVMEnvE +' IS1.LP.Events.LLVMStackE) +'
-  IS1.LP.Events.MemoryE +'
-  IS1.LP.Events.PickUvalueE +' OOME +' LLVMExcE IS1.LP.Events.DV.uvalue +' UBE +' DebugE +' FailureE)
-                          IS1.LP.Events.LLVMGEnvE
+                          ((LLVMEnvE DV1.uvalue +'
+                            LLVMStackE DV1.uvalue ) +'
+                           (MemoryE DV1.dvalue DV1.uvalue) +'
+                                                                                                            (PickUvalueE DV1.dvalue DV1.uvalue) +' OOME +' LLVMExcE DV1.uvalue +' UBE +' DebugE +' FailureE)
+                          (LLVMGEnvE DV1.dvalue)
 
            ) A u).
       rewrite subevent_subevent.
@@ -24271,7 +24328,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       `{OOME -< E2}
       `{FailureE -< E1} `{FailureE -< E2}
       (NOOM : forall A (e : FailureE A) (o : OOME A), @subevent FailureE E2 _ _ e <> @subevent OOME E2 _ _ o)
-      (l1 : LocalE LLVMAst.raw_id E1.DV.uvalue A) (l2 : LocalE LLVMAst.raw_id E2.DV.uvalue B)
+      (l1 : LocalE LLVMAst.raw_id DV1.uvalue A) (l2 : LocalE LLVMAst.raw_id DV2.uvalue B)
       (REF : localE_refine_strict l1 l2)
       (s1 : IS1.LLVM.Stack.lstack_frame) (s2 : IS2.LLVM.Stack.lstack_frame)
       (SREF : stack_frame_refine_strict s1 s2)
@@ -24325,7 +24382,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       `{OOME -< E2}
       `{FailureE -< E1} `{FailureE -< E2}
       (NOOM : forall A (e : FailureE A) (o : OOME A), @subevent FailureE E2 _ _ e <> @subevent OOME E2 _ _ o)
-      (e1 : StackE LLVMAst.raw_id E1.DV.uvalue E1.DV.uvalue A) (e2 : StackE LLVMAst.raw_id E2.DV.uvalue E2.DV.uvalue B)
+      (e1 : StackE LLVMAst.raw_id DV1.uvalue DV1.uvalue A) (e2 : StackE LLVMAst.raw_id DV2.uvalue DV2.uvalue B)
       (REF : stackE_refine_strict e1 e2)
       (s1 : IS1.LLVM.Stack.lstack_frame * IS1.LLVM.Stack.lstack) (s2 : IS2.LLVM.Stack.lstack_frame * IS2.LLVM.Stack.lstack)
       (SREF : (prod_rel stack_frame_refine_strict stack_refine_strict) s1 s2)
@@ -24390,7 +24447,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       orutt L2_refine_strict L2_res_refine_strict
         (fun '(s0, a) '(s3, b) =>
            L1_res_refine_strict A B e1 a e2 b /\ (stack_frame_refine_strict × stack_refine_strict) s0 s3)
-        (interp_local_stack_h (handle_local (v:=IS1.LP.Events.DV.uvalue)) e1 ls1)
+        (interp_local_stack_h (handle_local (v:=DV1.uvalue)) e1 ls1)
         (interp_local_stack_h (handle_local (v:=uvalue)) e2 ls2)
         (OOM:=OOME).
   Proof.
@@ -24484,8 +24541,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       pstep; red; cbn.
       change (inr1 (inr1 (inl1 o0))) with
         (@subevent _ _ (ReSum_inr IFun sum1 OOME
-                          (PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
-                          MemoryE
+                          ((PickUvalueE DV2.dvalue DV2.uvalue) +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                          (MemoryE DV2.dvalue DV2.uvalue)
 
            ) B o0).
       rewrite subevent_subevent.
@@ -24529,7 +24586,7 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       orutt L2_refine_strict L2_res_refine_strict
         (fun '(s0, a) '(s3, b) =>
            L1_res_refine_strict A B e1 a e2 b /\ (stack_frame_refine_strict × stack_refine_strict) s0 s3)
-        (interp_local_stack_h (handle_local_debug_stack (exc:=IS1.LP.Events.DV.uvalue)) e1 ls1)
+        (interp_local_stack_h (handle_local_debug_stack (exc:=DV1.uvalue)) e1 ls1)
         (interp_local_stack_h (handle_local_debug_stack (exc:=uvalue)) e2 ls2)
         (OOM:=OOME).
   Proof.
@@ -24626,8 +24683,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       pstep; red; cbn.
       change (inr1 (inr1 (inl1 o0))) with
         (@subevent _ _ (ReSum_inr IFun sum1 OOME
-                          (PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
-                          MemoryE
+                          (PickUvalueE DV2.dvalue DV2.uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                          (MemoryE DV2.dvalue DV2.uvalue)
 
            ) B o0).
       rewrite subevent_subevent.
@@ -24698,8 +24755,8 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       dvalue_refine_strict r1 r2 ->
       uvalue_refine_strict r3 r4 ->
       rutt event_refine_strict event_res_refine_strict eq
-        (trigger (IS1.LP.Events.Store dt r1 r3))
-        (trigger (IS2.LP.Events.Store dt r2 r4)).
+        (trigger (Store dt r1 r3))
+        (trigger (Store dt r2 r4)).
   Proof.
     intros dt r1 r2 r3 r4 R1R2 R3R4.
     apply rutt_trigger.
@@ -24775,12 +24832,12 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
       intros r0 r3 H0.
       eapply rutt_bind.
       { apply Store_E1E2_rutt'; auto.
-        change ((IS1.LP.Events.DV.UVALUE_Array (DTYPE_Array (N.of_nat (Datatypes.length args)) DTYPE_Pointer)
-                   (map IS1.LP.Events.DV.dvalue_to_uvalue r0))) with
-          (IS1.LP.Events.DV.dvalue_to_uvalue (IS1.LP.Events.DV.DVALUE_Array (DTYPE_Array (N.of_nat (Datatypes.length args)) DTYPE_Pointer) r0)).
+        change ((DV1.UVALUE_Array (DTYPE_Array (N.of_nat (Datatypes.length args)) DTYPE_Pointer)
+                   (map DV1.dvalue_to_uvalue r0))) with
+          (DV1.dvalue_to_uvalue (DV1.DVALUE_Array (DTYPE_Array (N.of_nat (Datatypes.length args)) DTYPE_Pointer) r0)).
         change (UVALUE_Array (DTYPE_Array (N.of_nat (Datatypes.length args)) DTYPE_Pointer)
                   (map dvalue_to_uvalue r3)) with
-          (IS2.LP.Events.DV.dvalue_to_uvalue
+          (DV2.dvalue_to_uvalue
              (DVALUE_Array (DTYPE_Array (N.of_nat (Datatypes.length args)) DTYPE_Pointer)
                 r3)).
         apply dvalue_refine_strict_dvalue_to_uvalue.
@@ -24820,7 +24877,15 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
     - eapply orutt_bind with (RR:=Forall2 uvalue_refine_strict).
       + apply rutt_orutt.
         apply build_main_args_fin_inf.
-        solve_dec_oom.
+        intros ? s. repeat destruct s;
+    try solve
+      [
+        left;
+        intros o CONTRA;
+        inv CONTRA
+      ];
+    right;
+    eexists; reflexivity.
       + intros r1 r2 H.
         intros *; apply model_E1E2_L0_orutt_strict_sound; auto.
     - apply global_refine_strict_empty.
@@ -24843,8 +24908,23 @@ Module Type LangRefine (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : 
 End LangRefine.
 
 Module MakeLangRefine
-  (IS1 : InterpreterStack) (IS2 : InterpreterStack) (AC1 : AddrConvert IS1.LP.ADDR IS1.LP.PTOI IS2.LP.ADDR IS2.LP.PTOI) (AC2 : AddrConvert IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI) (LLVM1 : LLVMTopLevel IS1) (LLVM2 : LLVMTopLevel IS2) (TLR1 : TopLevelRefinements IS1 LLVM1) (TLR2 : TopLevelRefinements IS2 LLVM2) (IPS : IPConvertSafe IS2.LP.IP IS1.LP.IP) (ACS : AddrConvertSafe IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI AC2 AC1) (DVC : DVConvert IS1.LP IS2.LP AC1 IS1.LP.Events IS2.LP.Events) (DVCrev : DVConvert IS2.LP IS1.LP AC2 IS2.LP.Events IS1.LP.Events) (EC : EventConvert IS1.LP IS2.LP AC1 AC2 IS1.LP.Events IS2.LP.Events DVC DVCrev) (TC : TreeConvert IS1 IS2 AC1 AC2 DVC DVCrev EC) (VMEM_IP_PROP1 : VMemInt_Intptr_Properties IS1.LP.IP) (VMEM_IP_PROP2 : VMemInt_Intptr_Properties IS2.LP.IP) (VMEM_REF : VMemInt_Refine IS1.LP.IP IS2.LP.IP) (SIZEOF_REF : Sizeof_Refine IS1.LP.SIZEOF IS2.LP.SIZEOF) (ITOP_REF : ItoP_Refine IS1 IS2 AC1 AC2) : LangRefine IS1 IS2 AC1 AC2 LLVM1 LLVM2 TLR1 TLR2 IPS ACS DVC DVCrev EC TC VMEM_IP_PROP1 VMEM_IP_PROP2 VMEM_REF SIZEOF_REF ITOP_REF.
-  Include LangRefine IS1 IS2 AC1 AC2 LLVM1 LLVM2 TLR1 TLR2 IPS ACS DVC DVCrev EC TC VMEM_IP_PROP1 VMEM_IP_PROP2 VMEM_REF SIZEOF_REF ITOP_REF.
+  (IS1 : InterpreterStack) (IS2 : InterpreterStack)
+  (AC1 : AddrConvert IS1.LP.ADDR IS1.LP.PTOI IS2.LP.ADDR IS2.LP.PTOI)
+  (AC2 : AddrConvert IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI)
+  (LLVM1 : LLVMTopLevel IS1) (LLVM2 : LLVMTopLevel IS2)
+  (TLR1 : TopLevelRefinements IS1 LLVM1) (TLR2 : TopLevelRefinements IS2 LLVM2)
+  (IPS : IPConvertSafe IS2.LP.IP IS1.LP.IP)
+  (ACS : AddrConvertSafe IS2.LP.ADDR IS2.LP.PTOI IS1.LP.ADDR IS1.LP.PTOI AC2 AC1)
+  (DVC : DVConvert IS1.LP IS2.LP AC1)
+  (DVCrev : DVConvert IS2.LP IS1.LP AC2)
+  (EC : EventConvert IS1.LP IS2.LP AC1 AC2 DVC DVCrev)
+  (TC : TreeConvert IS1 IS2 AC1 AC2 DVC DVCrev EC)
+  (VMEM_IP_PROP1 : VMemInt_Intptr_Properties IS1.LP.IP)
+  (VMEM_IP_PROP2 : VMemInt_Intptr_Properties IS2.LP.IP)
+  (VMEM_REF : VMemInt_Refine IS1.LP.IP IS2.LP.IP)
+  (SZ_REF : Sizeof_Refine IS1.LP.SZ IS2.LP.SZ)
+  (ITOP_REF : ItoP_Refine IS1 IS2 AC1 AC2) : LangRefine IS1 IS2 AC1 AC2 LLVM1 LLVM2 TLR1 TLR2 IPS ACS DVC DVCrev EC TC VMEM_IP_PROP1 VMEM_IP_PROP2 VMEM_REF SZ_REF ITOP_REF.
+  Include LangRefine IS1 IS2 AC1 AC2 LLVM1 LLVM2 TLR1 TLR2 IPS ACS DVC DVCrev EC TC VMEM_IP_PROP1 VMEM_IP_PROP2 VMEM_REF SZ_REF ITOP_REF.
 End MakeLangRefine.
 
 Module InfFinLangRefine := MakeLangRefine InterpreterStackBigIntptr InterpreterStack64BitIntptr InfToFinAddrConvert FinToInfAddrConvert TopLevelBigIntptr TopLevel64BitIntptr TopLevelRefinementsBigIntptr TopLevelRefinements64BitIntptr FinToInfIntptrConvertSafe FinToInfAddrConvertSafe DVCInfFin DVCFinInf ECInfFin TCInfFin VMemInt_Intptr_Properties_Inf VMemInt_Intptr_Properties_Fin VMemInt_Refine_InfFin Sizeof_Refine_InfFin ItoP_Refine_InfFin.

--- a/src/rocq/Semantics/InterpretationStack.v
+++ b/src/rocq/Semantics/InterpretationStack.v
@@ -34,7 +34,7 @@ From Stdlib Require Import
 Module Type InterpreterStack_common (LP : LLVMParams) (MEM : Memory LP).
   Module LLVM := Lang.Make LP MEM.
 
-  Import LP.Events.
+  Import LP.DV.
   Import LP.PROV.
   Import LLVM.Intrinsics.
   Import MEM.MEM_MODEL.
@@ -43,11 +43,11 @@ Module Type InterpreterStack_common (LP : LLVMParams) (MEM : Memory LP).
   Import MEM.MEM_EXEC_INTERP.
   Import MEM.MEM_SPEC_INTERP.
   Import MEM.GEP.
-  Import LLVM.Pick.
   Import LLVM.Global.
   Import LLVM.Local.
   Import LLVM.Stack.
   Import LLVM.D.
+  Import LLVM.Pick.
 
   Section InterpreterMCFG.
     Context {MemM : Type -> Type}.
@@ -62,42 +62,42 @@ Module Type InterpreterStack_common (LP : LLVMParams) (MEM : Memory LP).
      *)
 
     (* TODO: just make these types, instead of duplicating the definitions? *)
-    Definition interp_mcfg1 {R} (t: itree L0 R) g : itree L1 (global_env * R) :=
+    Definition interp_mcfg1 {R} (t: itree (L0 dvalue uvalue) R) g : itree (L1 dvalue uvalue) (global_env * R) :=
       let uvalue_trace       := interp_intrinsics t in
       let L1_trace           := interp_global uvalue_trace g in
       L1_trace.
 
-    Definition interp_mcfg2 {R} (t: itree L0 R) (g : global_env) (l : @stack_frame uvalue local_env * @stack uvalue local_env) : itree L2 (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)) :=
+    Definition interp_mcfg2 {R} (t: itree (L0 dvalue uvalue) R) (g : global_env) (l : @stack_frame uvalue local_env * @stack uvalue local_env) : itree (L2 dvalue uvalue) (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)) :=
       let L1_trace       := interp_mcfg1 t g in
       let L2_trace       := interp_local_stack L1_trace l in
       L2_trace.
 
-    Definition interp_mcfg3 {R} (RR : Relation_Definitions.relation (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))  (t: itree L0 R) (g : global_env) (l : @stack_frame uvalue local_env * @stack uvalue local_env) (sid : store_id) (m : MemState) : PropT L3 (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
+    Definition interp_mcfg3 {R} (RR : Relation_Definitions.relation (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))  (t: itree (L0 dvalue uvalue) R) (g : global_env) (l : @stack_frame uvalue local_env * @stack uvalue local_env) (sid : store_id) (m : MemState) : PropT (L3 dvalue uvalue) (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
       let L2_trace       := interp_mcfg2 t g l in
       let L3_trace       := interp_memory_spec RR L2_trace sid m in
       L3_trace.
 
-    Definition interp_mcfg3_exec {R} (t: itree L0 R) g l sid m : itree L3 (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
+    Definition interp_mcfg3_exec {R} (t: itree (L0 dvalue uvalue) R) g l sid m : itree (L3 dvalue uvalue) (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
       let L2_trace       := interp_mcfg2 t g l in
       let L3_trace       := interp_memory L2_trace sid m in
       L3_trace.
 
-    Definition interp_mcfg4 {R} RR_mem RR_pick (t: itree L0 R) g l sid m : PropT L4 (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
+    Definition interp_mcfg4 {R} RR_mem RR_pick (t: itree (L0 dvalue uvalue) R) g l sid m : PropT (L4 dvalue uvalue) (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
       let L3_trace       := interp_mcfg3 RR_mem t g l sid m in
       let L4_trace       := model_undef RR_pick L3_trace in
       L4_trace.
 
-    Definition interp_mcfg4_exec {R} (t: itree L0 R) g l sid m : itree L4 (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
+    Definition interp_mcfg4_exec {R} (t: itree (L0 dvalue uvalue) R) g l sid m : itree (L4 dvalue uvalue) (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
       let L3_trace       := interp_mcfg3_exec t g l sid m in
       let L4_trace       := exec_undef L3_trace in
       L4_trace.
 
-    Definition interp_mcfg5 {R} RR_mem RR_pick (t: itree L0 R) g l sid m : PropT L5 (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
+    Definition interp_mcfg5 {R} RR_mem RR_pick (t: itree (L0 dvalue uvalue) R) g l sid m : PropT (L5 dvalue uvalue) (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
       let L4_trace       := interp_mcfg4 RR_mem RR_pick t g l sid m in
       let L5_trace       := model_UB L4_trace in
       L5_trace.
-
-    Definition interp_mcfg6 {R} RR_mem RR_pick RR_oom (t: itree L0 R) g l sid m : PropT L6 (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
+    
+    Definition interp_mcfg6 {R} RR_mem RR_pick RR_oom (t: itree (L0 dvalue uvalue) R) g l sid m : PropT (L6 dvalue uvalue) (MemState * (store_id * (@stack_frame uvalue local_env * @stack uvalue local_env * (global_env * R)))) :=
       let L5_trace       := interp_mcfg5 RR_mem RR_pick t g l sid m in
       let L6_trace       := refine_OOM RR_oom L5_trace in
       L6_trace.
@@ -139,42 +139,42 @@ Module Type InterpreterStack_common (LP : LLVMParams) (MEM : Memory LP).
    NOTE: Can we avoid this duplication w.r.t. [interpi]?
      *)
 
-    Definition interp_cfg1 {R} (t: itree instr_E R) (g: global_env) : itree (CallE +' IntrinsicE +' LLVMEnvE +' MemoryE +' PickE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (global_env * R) :=
+    Definition interp_cfg1 {R} (t: itree (instr_E dvalue uvalue) R) (g: global_env) : itree (CallE uvalue +' IntrinsicE dvalue uvalue +' LLVMEnvE uvalue +' MemoryE dvalue uvalue +' PickE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (global_env * R) :=
       let L0_trace       := interp_intrinsics t in
       let L1_trace       := interp_global L0_trace g in
       L1_trace.
 
-    Definition interp_cfg2 {R} (t: itree instr_E R) (g: global_env) (l: local_env) : itree (CallE +' IntrinsicE +' MemoryE +' PickE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (local_env * (global_env * R)) :=
+    Definition interp_cfg2 {R} (t: itree (instr_E dvalue uvalue) R) (g: global_env) (l: local_env) : itree (CallE uvalue +' IntrinsicE dvalue uvalue +' MemoryE dvalue uvalue +' PickE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (local_env * (global_env * R)) :=
       let L1_trace       := interp_cfg1 t g in
       let L2_trace       := interp_local L1_trace l in
       L2_trace.
 
-    Definition interp_cfg3 {R} RR (t: itree instr_E R) (g: global_env) (l: local_env) sid (m: MemState) : PropT (CallE +' PickE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
+    Definition interp_cfg3 {R} RR (t: itree (instr_E dvalue uvalue) R) (g: global_env) (l: local_env) sid (m: MemState) : PropT (CallE uvalue +' PickE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
       let L2_trace       := interp_cfg2 t g l in
       let L3_trace       := interp_memory_spec RR L2_trace sid m in
       L3_trace.
 
-    Definition interp_cfg3_exec {R} (t: itree instr_E R) (g: global_env) (l: local_env) sid (m: MemState) : itree (CallE +' PickE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
+    Definition interp_cfg3_exec {R} (t: itree (instr_E dvalue uvalue) R) (g: global_env) (l: local_env) sid (m: MemState) : itree (CallE uvalue +' PickE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
       let L2_trace       := interp_cfg2 t g l in
       let L3_trace       := interp_memory L2_trace sid m in
       L3_trace.
 
-    Definition interp_cfg4 {R} RR_mem RR_pick (t: itree instr_E R) (g: global_env) (l: local_env) sid (m: MemState) : PropT (CallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
+    Definition interp_cfg4 {R} RR_mem RR_pick (t: itree (instr_E dvalue uvalue) R) (g: global_env) (l: local_env) sid (m: MemState) : PropT (CallE uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
       let L3_trace       := interp_cfg3 RR_mem t g l sid m in
       let L4_trace       := model_undef RR_pick L3_trace in
       L4_trace.
 
-    Definition interp_cfg4_exec {R} (t: itree instr_E R) (g: global_env) (l: local_env) sid (m: MemState) : itree (CallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
+    Definition interp_cfg4_exec {R} (t: itree (instr_E dvalue uvalue) R) (g: global_env) (l: local_env) sid (m: MemState) : itree (CallE uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
       let L3_trace       := interp_cfg3_exec t g l sid m in
       let L4_trace       := exec_undef L3_trace in
       L4_trace.
 
-    Definition interp_cfg5 {R} RR_mem RR_pick (t: itree instr_E R) (g: global_env) (l: local_env) sid (m: MemState) : PropT (CallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
+    Definition interp_cfg5 {R} RR_mem RR_pick (t: itree (instr_E dvalue uvalue) R) (g: global_env) (l: local_env) sid (m: MemState) : PropT (CallE uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
       let L4_trace       := interp_cfg4 RR_mem RR_pick t g l sid m in
       let L5_trace       := model_UB L4_trace in
       L5_trace.
 
-    Definition interp_cfg6 {R} RR_mem RR_pick (t: itree instr_E R) (g: global_env) (l: local_env) sid (m: MemState) : PropT (CallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
+    Definition interp_cfg6 {R} RR_mem RR_pick (t: itree (instr_E dvalue uvalue) R) (g: global_env) (l: local_env) sid (m: MemState) : PropT (CallE uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) (MemState * (store_id * (local_env * (global_env * R)))) :=
       let L5_trace       := interp_cfg5 RR_mem RR_pick t g l sid m in
       let L6_trace       := refine_OOM
                               (fun '(ms, (sid, (lenv, (genv, x))))
@@ -230,15 +230,15 @@ Module Type InterpreterStack_common (LP : LLVMParams) (MEM : Memory LP).
     Notation "⟦ e 'at?' t '⟧e'" :=  (denote_exp t e).
     Notation "⟦ e 'at' t '⟧e'" :=   (denote_exp (Some t) e).
     Notation "⟦ e '⟧e'" :=          (denote_exp None e).
-    Notation "⟦ e 'at?' t '⟧e1'" := (ℑ1 (translate exp_to_instr ⟦ e at? t ⟧e)).
-    Notation "⟦ e 'at' t '⟧e1'" :=  (ℑ1 (translate exp_to_instr ⟦ e at t ⟧e)).
-    Notation "⟦ e '⟧e1'" :=         (ℑ1 (translate exp_to_instr ⟦ e ⟧e )).
-    Notation "⟦ e 'at?' t '⟧e2'" := (ℑ2 (translate exp_to_instr ⟦ e at? t ⟧e)).
-    Notation "⟦ e 'at' t '⟧e2'" :=  (ℑ2 (translate exp_to_instr ⟦ e at t ⟧e)).
-    Notation "⟦ e '⟧e2'" :=         (ℑ2 (translate exp_to_instr ⟦ e ⟧e )).
-    Notation "⟦ e 'at?' t '⟧e3'" := (ℑ3 (translate exp_to_instr ⟦ e at? t ⟧e)).
-    Notation "⟦ e 'at' t '⟧e3'" :=  (ℑ3 (translate exp_to_instr ⟦ e at t ⟧e)).
-    Notation "⟦ e '⟧e3'" :=         (ℑ3 (translate exp_to_instr ⟦ e ⟧e )).
+    Notation "⟦ e 'at?' t '⟧e1'" := (ℑ1 (translate (@exp_to_instr dvalue uvalue) ⟦ e at? t ⟧e)).
+    Notation "⟦ e 'at' t '⟧e1'" :=  (ℑ1 (translate (@exp_to_instr dvalue uvalue) ⟦ e at t ⟧e)).
+    Notation "⟦ e '⟧e1'" :=         (ℑ1 (translate (@exp_to_instr dvalue uvalue) ⟦ e ⟧e )).
+    Notation "⟦ e 'at?' t '⟧e2'" := (ℑ2 (translate (@exp_to_instr dvalue uvalue) ⟦ e at? t ⟧e)).
+    Notation "⟦ e 'at' t '⟧e2'" :=  (ℑ2 (translate (@exp_to_instr dvalue uvalue) ⟦ e at t ⟧e)).
+    Notation "⟦ e '⟧e2'" :=         (ℑ2 (translate (@exp_to_instr dvalue uvalue) ⟦ e ⟧e )).
+    Notation "⟦ e 'at?' t '⟧e3'" := (ℑ3 (translate (@exp_to_instr dvalue uvalue) ⟦ e at? t ⟧e)).
+    Notation "⟦ e 'at' t '⟧e3'" :=  (ℑ3 (translate (@exp_to_instr dvalue uvalue) ⟦ e at t ⟧e)).
+    Notation "⟦ e '⟧e3'" :=         (ℑ3 (translate (@exp_to_instr dvalue uvalue) ⟦ e ⟧e )).
 
     Notation "⟦ i '⟧i'" :=        (denote_instr i).
     Notation "⟦ i 'at' v '⟧i1'" :=       (ℑ1 (⟦ i ⟧i v)).

--- a/src/rocq/Semantics/IntrinsicsDefinitions.v
+++ b/src/rocq/Semantics/IntrinsicsDefinitions.v
@@ -21,7 +21,7 @@ From ExtLib Require Import
 From Vellvm Require Import
      Utilities
      Syntax
-     Semantics.LLVMEvents
+     Semantics.LLVMParams
      Semantics.Memory.Sizeof
      Numeric.Rocqlib
      Numeric.Integers
@@ -375,11 +375,10 @@ Definition intrinsic_exp {T} (e:exp T) : option string :=
    any other effects.
 
 *)
-Module Make(A:MemoryAddress.ADDRESS)(IP:MemoryAddress.INTPTR)(SIZEOF:Sizeof)(LLVMIO: LLVM_INTERACTIONS(A)(IP)(SIZEOF)).
+Module Make(LP:LLVMParams).
   Open Scope string_scope.
 
-  Import LLVMIO.
-  Import DV.
+  Import LP.DV.
   Import VellvmIntegers.
 
   (* Each (pure) intrinsic is defined by a function of the following type.

--- a/src/rocq/Semantics/LLVMEvents.v
+++ b/src/rocq/Semantics/LLVMEvents.v
@@ -31,8 +31,6 @@ From ITree Require Import
 From Vellvm Require Import
      Utilities
      Syntax
-     Semantics.Memory.Sizeof
-     Semantics.DynamicValues
      Semantics.VellvmIntegers.
 
 Import ITreeNotations.
@@ -180,19 +178,13 @@ Set Contextual Implicit.
       end
     end.
 
-
+(* REFACTOR: This should not be a module type.  DynamicValues should not be instantiated here.   *)
 (* TODO: decouple these definitions from the instance of DVALUE and DTYP by using polymorphism not functors. *)
-Module Type LLVM_INTERACTIONS (ADDR : MemoryAddress.ADDRESS) (IP:MemoryAddress.INTPTR) (SIZEOF : Sizeof).
-
-  #[global] Instance eq_dec_addr : RelDec (@eq ADDR.addr) := RelDec_from_dec _ ADDR.eq_dec.
-  #[global] Instance Eqv_addr : Eqv ADDR.addr := (@eq ADDR.addr).
-
-  Module DV := DynamicValues.DVALUE(ADDR)(IP)(SIZEOF).
-  Export DV.
-
   Section Events.
     Variable memory : Type.
-
+    Variable dvalue : Set.
+    Variable uvalue : Type.
+    
     (* Generic calls, refined by [denote_mcfg] *)
     Variant CallE : Type -> Type :=
     | Call        : forall (t:dtyp) (f:uvalue) (args:list uvalue), CallE (uvalue + uvalue).
@@ -310,12 +302,371 @@ Module Type LLVM_INTERACTIONS (ADDR : MemoryAddress.ADDRESS) (IP:MemoryAddress.I
 
   Definition FUBO_to_L4 : (FailureE +' UBE +' OOME) ~> L4:= subevent.
 
+
+  
+  (* Event Inclusions -------------------------------- *)
+
+  #[global]
+    Instance Global_lookup : GlobalE raw_id dvalue -< lookup_E :=
+    inl1.
+
+  #[global]
+    Instance Local_lookup : LocalE raw_id uvalue -< lookup_E :=
+    inr1.
+
+  
+  (* expE *)
+  (*   Definition exp_E := LLVMGEnvE +' LLVMEnvE +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE. *)
+  #[global]
+    Instance Failure_expE : `{FailureE -< exp_E} := 
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 e)))))))).
+
+  #[global]
+    Instance DebugE_expE : `{DebugE -< exp_E} := 
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))))).
+
+  #[global]
+    Instance UBE_expE : `{UBE -< exp_E} := 
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e))))))).
+
+  #[global]
+    Instance LLVMExcE_expE : `{LLVMExcE uvalue -< exp_E} := 
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))).
+  
+  #[global]
+    Instance OOME_expE : `{OOME -< exp_E} := 
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inl1 e))))).
+
+  #[global]
+    Instance PickE_expE : `{PickE -< exp_E} := 
+    fun T e => (inr1 (inr1 (inr1 (inl1 e)))).
+
+  #[global]
+    Instance MemoryE_expE : `{MemoryE -< exp_E} := 
+    fun T e => (inr1 (inr1 (inl1 e))).
+
+  #[global]
+    Instance LLVMEnvE_expE : `{LLVMEnvE -< exp_E} := 
+    fun T e => (inr1 (inl1 e)).
+
+  #[global]
+    Instance LLVMGEnvE_expE : `{LLVMGEnvE -< exp_E} := 
+    fun T e => (inl1 e).
+
+  (* instr_E *)
+  
+  #[global]
+    Instance Failure_instrE : `{FailureE -< instr_E} := 
+    fun T e => (inr1 (inr1 (Failure_expE e))).
+
+  #[global]
+    Instance DebugE_instrE : `{DebugE -< instr_E} := 
+    fun T e => (inr1 (inr1 (DebugE_expE e))).
+  
+  #[global]
+    Instance UBE_instrE : `{UBE -< instr_E} := 
+    fun T e => (inr1 (inr1 (UBE_expE e))).
+
+  #[global]
+    Instance LLVMExcE_instrE : `{LLVMExcE uvalue -< instr_E } := 
+    fun T e => (inr1 (inr1 (LLVMExcE_expE e))).
+  
+  #[global]
+    Instance OOME_instrE : `{OOME -< instr_E} := 
+    fun T e => (inr1 (inr1 (OOME_expE e))).
+
+  #[global]
+    Instance PickE_instrE : `{PickE -< instr_E} := 
+    fun T e => (inr1 (inr1 (PickE_expE e))).
+
+  #[global]
+    Instance MemoryE_instrE : `{MemoryE -< instr_E} := 
+    fun T e => (inr1 (inr1 (MemoryE_expE e))).
+
+  #[global]
+    Instance LLVMEnvE_instrE : `{LLVMEnvE -< instr_E } := 
+    fun T e => (inr1 (inr1 (LLVMEnvE_expE e))).
+  
+  #[global]
+    Instance LLVMGEnvE_instrE : `{LLVMGEnvE -< instr_E } := 
+    fun T e => (inr1 (inr1 (LLVMGEnvE_expE e))).
+
+  #[global]
+    Instance IntrinsicE_instrE : `{IntrinsicE -< instr_E } := 
+    fun T e => (inr1 (inl1 e)).
+
+  #[global]
+    Instance CallE_instrE : `{CallE -< instr_E} := 
+    fun T e => (inl1 e).
+
+  (* L0' *)
+  (*   Definition L0' := CallE +' ExternalCallE +' IntrinsicE +' LLVMGEnvE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE. *)
+
+  #[global]
+    Instance FailureE_L0' : `{FailureE -< L0'} := 
+    fun T e => inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 e)))))))))).
+
+  #[global]
+    Instance DebugE_L0' : `{DebugE -< L0'} := 
+    fun T e => inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))))))).
+  
+  #[global]
+    Instance UBE_L0' : UBE -< L0' :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))))))).
+
+  #[global]
+    Instance LLVMExcE_L0' : LLVMExcE uvalue -< L0' :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e))))))))).
+  
+  #[global]
+    Instance OOME_L0' : OOME -< L0' :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))))).
+
+  #[global]
+    Instance PickE_L0' : PickE -< L0' :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e))))))).
+  
+    #[global]
+    Instance MemoryE_L0' : `{MemoryE -< L0'} := 
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))).
+
+  #[global]
+    Instance LLVMEnvE_L0' : `{LLVMEnvE  -< L0'} := 
+    fun T e => inr1 (inr1 (inr1 (inr1 (inl1 (inl1 e))))).
+
+  #[global]
+    Instance StackE_L0' : `{StackE local_id uvalue _  -< L0'} := 
+    fun T e => inr1 (inr1 (inr1 (inr1 (inl1 (inr1 e))))).
+
+  #[global]
+    Instance GEnvE_L0' : `{LLVMGEnvE  -< L0'} := 
+    fun T e => (inr1 (inr1 (inr1 (inl1 e)))).
+
+  #[global]
+    Instance IntrinsicE_L0' : `{IntrinsicE  -< L0'} := 
+    fun T e => (inr1 (inr1 (inl1 e))).
+
+  #[global]
+    Instance ExternalCallE_L0' : `{ExternalCallE  -< L0'} := 
+    fun T e => (inr1 (inl1 e)).
+
+  #[global]
+    Instance CallE_L0' : `{CallE  -< L0'} := 
+    fun T e => (inl1 e).
+
+  (* L0 *)
+  (*   Definition L0 := ExternalCallE +' IntrinsicE +' LLVMGEnvE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE. *)
+
+  #[global]
+    Instance FailureE_L0 : FailureE -< L0 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 e)))))))))).
+
+  #[global]
+    Instance DebugE_L0 : DebugE -< L0 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))))))).
+
+  #[global]
+    Instance UBE_L0 : UBE -< L0 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e))))))))).
+
+  #[global]
+    Instance LLVMExcE_L0 : LLVMExcE uvalue -< L0 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))))).
+  
+  #[global]
+    Instance OOME_L0 : OOME -< L0  :=
+    fun T e => inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))).
+
+  #[global]
+    Instance PickE_L0 : PickE -< L0 :=
+    fun T e => inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e))))).
+  
+  #[global]
+    Instance MemoryE_L0 : MemoryE  -< L0 :=
+    fun T e => inr1 (inr1 (inr1 (inr1 (inl1 e)))).
+
+  #[global]
+    Instance LocalE_expE_L0 : LocalE raw_id uvalue -< L0 :=
+    fun T e => inr1 (inr1 (inr1 (inl1 (inl1 e)))).
+
+  #[global]
+    Instance StackE_expE_L0 : StackE raw_id uvalue uvalue -< L0 :=
+    fun T e => inr1 (inr1 (inr1 (inl1 (inr1 e)))).
+  
+  #[global]
+    Instance GlobalE_L0 : GlobalE raw_id dvalue -< L0 :=
+    fun T e => (inr1 (inr1 (inl1 e))).
+
+  #[global]
+    Instance IntrinsincE_L0 : IntrinsicE -< L0 :=
+    fun T e => (inr1 (inl1 e)).
+
+  #[global]
+    Instance ExternalCallE_L0 : ExternalCallE -< L0 :=
+    fun T e => (inl1 e).
+
+
+  #[global]
+    Instance IntrinsiceE_expE_L0 : IntrinsicE  +' exp_E -< L0  :=
+    fun T e =>
+      match e with
+      | inl1 e => inr1 (inl1 e)
+      | inr1 e => exp_to_L0 e
+      end.
+
+
+  (* L1 *)
+  (*     Definition L1 := ExternalCallE +' IntrinsicE +' (LLVMEnvE +' LLVMStackE) +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE. *)
+
+  #[global]
+    Instance FailureE_L1 : FailureE -< L1 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 e))))))))).
+
+  #[global]
+    Instance DebugE_L1 : DebugE -< L1 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e))))))))).
+
+  #[global]
+    Instance UBE_L1 : UBE -< L1 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))))).
+
+  #[global]
+    Instance LLVMExcE_L1 : LLVMExcE uvalue -< L1 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e))))))).
+  
+  #[global]
+    Instance OOME_L1 : OOME -< L1  :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))).
+
+  #[global]
+    Instance PickE_L1 : PickE -< L1 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inl1 e))))).
+  
+  #[global]
+    Instance MemoryE_L1 : MemoryE  -< L1 :=
+    fun T e => (inr1 (inr1 (inr1 (inl1 e)))).
+
+  #[global]
+    Instance LocalE_expE_L1 : LocalE raw_id uvalue -< L1 :=
+    fun T e => (inr1 (inr1 (inl1 (inl1 e)))).
+
+  #[global]
+    Instance StackE_expE_L1 : StackE raw_id uvalue uvalue -< L1 :=
+    fun T e =>  (inr1 (inr1 (inl1 (inr1 e)))).
+  
+  #[global]
+    Instance IntrinsincE_L1 : IntrinsicE -< L1 :=
+    fun T e => (inr1 (inl1 e)).
+
+  #[global]
+    Instance ExternalCallE_L1 : ExternalCallE -< L1 :=
+    fun T e => (inl1 e).
+
+  (* L2 *)
+  (* ExternalCallE +' IntrinsicE +' MemoryE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE.    *)
+
+  #[global]
+    Instance FailureE_L2 : FailureE -< L2 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 e)))))))).
+
+  #[global]
+    Instance DebugE_L2 : DebugE -< L2 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))))).
+
+  #[global]
+    Instance UBE_L2 : UBE -< L2 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e))))))).
+
+  #[global]
+    Instance LLVMExcE_L2 : LLVMExcE uvalue -< L2 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))).
+  
+  #[global]
+    Instance OOME_L2 : OOME -< L2  :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inl1 e))))).
+
+  #[global]
+    Instance PickE_L2 : PickE -< L2 :=
+    fun T e => (inr1 (inr1 (inr1 (inl1 e)))).
+  
+  #[global]
+    Instance MemoryE_L2 : MemoryE  -< L2 :=
+    fun T e => (inr1 (inr1 (inl1 e))).
+
+  #[global]
+    Instance IntrinsincE_L2 : IntrinsicE -< L2 :=
+    fun T e => (inr1 (inl1 e)).
+
+  #[global]
+    Instance ExternalCallE_L2 : ExternalCallE -< L2 :=
+    fun T e => (inl1 e).
+
+
+    (* L3 *)
+  (* ExternalCallE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE. *)
+
+  #[global]
+    Instance FailureE_L3 : FailureE -< L3 :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 (inr1 e)))))).
+
+  #[global]
+    Instance DebugE_L3 : DebugE -< L3 :=
+    fun T e =>  (inr1 (inr1 (inr1 (inr1 (inr1 (inl1 e)))))).
+
+  #[global]
+    Instance UBE_L3 : UBE -< L3 :=
+    fun T e =>  (inr1 (inr1 (inr1 (inr1 (inl1 e))))).
+
+  #[global]
+    Instance LLVMExcE_L3 : LLVMExcE uvalue -< L3 :=
+    fun T e =>  (inr1 (inr1 (inr1 (inl1 e)))).
+  
+  #[global]
+    Instance OOME_L3 : OOME -< L3  :=
+    fun T e =>  (inr1 (inr1 (inl1 e))).
+
+  #[global]
+    Instance PickE_L3 : PickE -< L3 :=
+    fun T e =>  (inr1 (inl1 e)).
+  
+  #[global]
+    Instance ExternalCallE_L3 : ExternalCallE -< L3 :=
+    fun T e => (inl1 e).
+
+    (* L4 *)
+  (* ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE. *)
+
+  #[global]
+    Instance FailureE_L4 : FailureE -< (ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) :=
+    fun T e => (inr1 (inr1 (inr1 (inr1 (inr1 e))))).
+
+  #[global]
+    Instance DebugE_L4 : DebugE -< (ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) :=
+    fun T e =>  (inr1 (inr1 (inr1 (inr1 (inl1 e))))).
+
+  #[global]
+    Instance UBE_L4 : UBE -< (ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) :=
+    fun T e =>  (inr1 (inr1 (inr1 (inl1 e)))).
+
+  #[global]
+    Instance LLVMExcE_L4 : LLVMExcE uvalue -< (ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) :=
+    fun T e =>  (inr1 (inr1 (inl1 e))).
+  
+  #[global]
+    Instance OOME_L4 : OOME -< (ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) :=
+    fun T e =>  (inr1 (inl1 e)).
+
+  #[global]
+    Instance ExternalCallE_L4 : ExternalCallE -< (ExternalCallE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) :=
+    fun T e => (inl1 e).
+  
   End Events.
 
-  #[export] Hint Unfold L0 L0' L1 L2 L3 L4 L5 L6 : core.
+  #[export] Hint Unfold L0 L0' L1 L2 L4 L4 L5 L6 : core.
 
-End LLVM_INTERACTIONS.
-
+  
+(*
 Module Make(ADDR : MemoryAddress.ADDRESS)(IP:MemoryAddress.INTPTR)(SIZEOF : Sizeof) <: LLVM_INTERACTIONS(ADDR)(IP)(SIZEOF).
 Include LLVM_INTERACTIONS(ADDR)(IP)(SIZEOF).
 End Make.
+*)

--- a/src/rocq/Semantics/LLVMParams.v
+++ b/src/rocq/Semantics/LLVMParams.v
@@ -1,18 +1,27 @@
 From Vellvm Require Import
      Semantics.LLVMEvents
      Semantics.MemoryAddress
-     Semantics.Memory.Sizeof.
+     Semantics.Memory.Sizeof
+     Semantics.DynamicValues.
+
+From ExtLib Require Import
+  Core.RelDec
+  Programming.Eqv.  
+
 
 (** Parameters for LLVM instances. *)
 Module Type LLVMParams.
   Declare Module ADDR : ADDRESS.
   Declare Module IP : INTPTR.
-  Declare Module SIZEOF : Sizeof.
+  Declare Module SZ : SIZEOF.
   Declare Module PTOI : PTOI ADDR.
   Declare Module PROV : PROVENANCE ADDR.
   Declare Module ITOP : ITOP ADDR PROV PTOI.
 
-  Module Events := LLVMEvents.Make ADDR IP SIZEOF.
+  #[global] Instance eq_dec_addr : RelDec (@eq ADDR.addr) := RelDec_from_dec _ ADDR.eq_dec.
+  #[global] Instance Eqv_addr : Eqv ADDR.addr := (@eq ADDR.addr).
+
+  Module DV := DynamicValues.DVALUE(ADDR)(IP)(SZ).
 End LLVMParams.
 
 Module Type LLVMParamsBig <: LLVMParams.
@@ -23,26 +32,30 @@ Module Type LLVMParamsBig <: LLVMParams.
   Declare Module I2P_BIG : ITOP_BIG ADDR PROV PTOI ITOP.
 End LLVMParamsBig.
 
-Module Make (ADDR' : ADDRESS) (IP' : INTPTR) (SIZEOF' : Sizeof) (PTOI' : PTOI ADDR') (PROV' : PROVENANCE ADDR') (ITOP' : ITOP ADDR' PROV' PTOI') : LLVMParams
+Module Make (ADDR' : ADDRESS) (IP' : INTPTR) (SZ' : SIZEOF) (PTOI' : PTOI ADDR') (PROV' : PROVENANCE ADDR') (ITOP' : ITOP ADDR' PROV' PTOI') : LLVMParams
 with Module ADDR := ADDR'
 with Module IP := IP'
-with Module SIZEOF := SIZEOF'
+with Module SZ := SZ'
 with Module PTOI := PTOI'
 with Module PROV := PROV'
 with Module ITOP := ITOP'.
   Module ADDR := ADDR'.
   Module IP := IP'.
-  Module SIZEOF := SIZEOF'.
+  Module SZ := SZ'.
   Module PTOI := PTOI'.
   Module PROV := PROV'.
   Module ITOP := ITOP'.
-  Module Events := LLVMEvents.Make ADDR IP SIZEOF.
+  #[global] Instance eq_dec_addr : RelDec (@eq ADDR.addr) := RelDec_from_dec _ ADDR.eq_dec.
+  #[global] Instance Eqv_addr : Eqv ADDR.addr := (@eq ADDR.addr).
+
+  Module DV := DynamicValues.DVALUE(ADDR)(IP)(SZ).
+
 End Make.
 
-Module MakeBig (ADDR' : ADDRESS) (IP' : INTPTR) (SIZEOF' : Sizeof) (PTOI' : PTOI ADDR') (PROV' : PROVENANCE ADDR') (ITOP' : ITOP ADDR' PROV' PTOI') (IP_BIG' : INTPTR_BIG IP') (I2P_BIG' : ITOP_BIG ADDR' PROV' PTOI' ITOP') : LLVMParamsBig
+Module MakeBig (ADDR' : ADDRESS) (IP' : INTPTR) (SZ' : SIZEOF) (PTOI' : PTOI ADDR') (PROV' : PROVENANCE ADDR') (ITOP' : ITOP ADDR' PROV' PTOI') (IP_BIG' : INTPTR_BIG IP') (I2P_BIG' : ITOP_BIG ADDR' PROV' PTOI' ITOP') : LLVMParamsBig
 with Module ADDR := ADDR'
 with Module IP := IP'
-with Module SIZEOF := SIZEOF'
+with Module SZ := SZ'
 with Module PTOI := PTOI'
 with Module PROV := PROV'
 with Module ITOP := ITOP'
@@ -50,11 +63,15 @@ with Module IP_BIG := IP_BIG'
 with Module I2P_BIG := I2P_BIG'.
   Module ADDR := ADDR'.
   Module IP := IP'.
-  Module SIZEOF := SIZEOF'.
+  Module SZ := SZ'.
   Module PTOI := PTOI'.
   Module PROV := PROV'.
   Module ITOP := ITOP'.
-  Module Events := LLVMEvents.Make ADDR IP SIZEOF.
+
+  #[global] Instance eq_dec_addr : RelDec (@eq ADDR.addr) := RelDec_from_dec _ ADDR.eq_dec.
+  #[global] Instance Eqv_addr : Eqv ADDR.addr := (@eq ADDR.addr).
+
+  Module DV := DynamicValues.DVALUE(ADDR)(IP)(SZ).
   Module IP_BIG := IP_BIG'.
   Module I2P_BIG := I2P_BIG'.
 End MakeBig.

--- a/src/rocq/Semantics/Lang.v
+++ b/src/rocq/Semantics/Lang.v
@@ -15,8 +15,8 @@ From Vellvm Require Import
   Module Type Memory (LP: LLVMParams).
     Import LP.
 
-    Declare Module GEP  : GEPM ADDR PTOI PROV ITOP IP SIZEOF Events.
-    Declare Module Byte : ByteImpl ADDR IP SIZEOF Events.
+    Declare Module GEP  : GEPM LP.
+    Declare Module Byte : ByteImpl LP.
     Declare Module DVALUE_BYTE : DvalueByte LP.
 
     Module MP := MemoryParams.Make LP GEP Byte DVALUE_BYTE.
@@ -27,7 +27,7 @@ From Vellvm Require Import
     Module MEM_EXEC_INTERP := MakeMemoryExecInterpreter LP MP MMEP MEM_MODEL MEM_SPEC_INTERP.
 
     (* Concretization *)
-    Module ByteM := MemBytes.Byte ADDR IP SIZEOF LP.Events MP.BYTE_IMPL.
+    Module ByteM := MemBytes.Byte LP MP.BYTE_IMPL.
     Module CP := ConcretizationParams.Make LP MP ByteM.
 
     Export GEP Byte DVALUE_BYTE MP MEM_MODEL CP.
@@ -37,10 +37,10 @@ From Vellvm Require Import
     Export LP.
 
     (* Handlers *)
-    Module Global     := Global.Make ADDR IP SIZEOF LP.Events.
-    Module Local      := Local.Make ADDR IP SIZEOF LP.Events.
-    Module Stack      := Stack.Make ADDR IP SIZEOF LP.Events.
-    Module Intrinsics := Intrinsics.Make ADDR IP SIZEOF LP.Events.
+    Module Global     := Global.Make LP.
+    Module Local      := Local.Make LP.
+    Module Stack      := Stack.Make LP.
+    Module Intrinsics := Intrinsics.Make LP.
 
     (* Memory *)
     Declare Module MEM : Memory LP.
@@ -52,7 +52,7 @@ From Vellvm Require Import
     (* Denotation *)
     Module D := Denotation LP MP ByteM CP.
 
-    Export Events Events.DV Global Local Stack Pick Intrinsics
+    Export DV Global Local Stack Pick Intrinsics
            CP.CONC D.
   End Lang.
 

--- a/src/rocq/Semantics/Memory/DvalueBytes.v
+++ b/src/rocq/Semantics/Memory/DvalueBytes.v
@@ -16,7 +16,8 @@ From Vellvm Require Import
   Utils.Poisonable
   Utils.ErrOomPoison
   Utils.ListUtil
-  Syntax.LLVMAst.
+  Syntax.LLVMAst
+  Memory.Sizeof.
 
 From ExtLib Require Import
      Structures.Monads
@@ -103,9 +104,8 @@ Module Type DvalueByte (LP : LLVMParams).
   Import PTOI.
   Import ITOP.
   Import PROV.
-  Import SIZEOF.
-  Import Events.DV.
-  Import Sizeof.
+  Import SZ.
+  Import DV.
 
   (* Walk through a list *)
   (* Returns field index + number of bytes remaining *)
@@ -149,7 +149,7 @@ Module Type DvalueByte (LP : LLVMParams).
             let padding :=
               match pad with
               | Some max_pad
-                => pad_amount max_pad offset
+                => Sizeof.pad_amount max_pad offset
               | None =>
                   0%N
               end

--- a/src/rocq/Semantics/Memory/ErrSID.v
+++ b/src/rocq/Semantics/Memory/ErrSID.v
@@ -13,9 +13,8 @@ From Vellvm Require Import
      Utils.UBAndErrors
      Semantics.MemoryAddress
      Semantics.DynamicValues
-     Semantics.LLVMEvents
+     Semantics.LLVMParams
      Semantics.Memory.FiniteProvenance
-     Semantics.Memory.Sizeof
      Semantics.StoreId
      Utils.StateMonads
      Utils.Monads
@@ -30,8 +29,8 @@ Import Basics.Basics.Monads.
 Import MonadNotation.
 
 (* TODO: Provenance is an issue... *)
-Module ERRSID (Addr:ADDRESS) (IP:INTPTR) (SIZEOF:Sizeof) (PROV:PROVENANCE(Addr)).
-  Import PROV.
+Module ERRSID (LP:LLVMParams).
+  Import LP.PROV.
 
   (* Need failure, UB, state for store_ids, and state for provenances *)
   Inductive ErrSID_T M A := mkErrSID_T { unErrSID_T : @err_ub_oom_T (stateT store_id (stateT Provenance M)) A }.

--- a/src/rocq/Semantics/Memory/MemBytes.v
+++ b/src/rocq/Semantics/Memory/MemBytes.v
@@ -7,7 +7,7 @@ From Vellvm Require Import
      Semantics.DynamicValues
      Semantics.MemoryAddress
      Semantics.Memory.Sizeof
-     Semantics.LLVMEvents
+     Semantics.LLVMParams
      Semantics.StoreId
      Utils.Monads
      Utils.OptionUtil
@@ -22,9 +22,8 @@ Import Basics.Basics.Monads.
 Import ListNotations.
 Import MonadNotation.
 
-Module Type ByteImpl(Addr:ADDRESS)(IP:INTPTR)(SIZEOF:Sizeof)(LLVMEvents: LLVM_INTERACTIONS(Addr)(IP)(SIZEOF)).
-  Import LLVMEvents.
-  Import DV.
+Module Type ByteImpl (LP:LLVMParams).
+  Import LP.DV.
 
   Parameter SByte : Set.
 
@@ -51,11 +50,10 @@ Module Type ByteImpl(Addr:ADDRESS)(IP:INTPTR)(SIZEOF:Sizeof)(LLVMEvents: LLVM_IN
       sbyte_to_extractbyte (uvalue_sbyte uv dt idx sid) =  UVALUE_ExtractByte uv dt idx sid.
 End ByteImpl.
 
-Module Type ByteModule(Addr:ADDRESS)(IP:INTPTR)(SIZEOF:Sizeof)(LLVMEvents:LLVM_INTERACTIONS(Addr)(IP)(SIZEOF))(Byte:ByteImpl(Addr)(IP)(SIZEOF)(LLVMEvents)).
+Module Type ByteModule (LP:LLVMParams)(Byte:ByteImpl(LP)).
   Export Byte.
-  Import LLVMEvents.
-  Import DV.
-  Import SIZEOF.
+  Import LP.DV.
+  Import LP.SZ.
 
   Fixpoint all_bytes_from_uvalue_helper (idx' : N) (sid' : store_id) (parent : uvalue) (bytes : list SByte) : option uvalue
     := match bytes with
@@ -207,6 +205,6 @@ Module Type ByteModule(Addr:ADDRESS)(IP:INTPTR)(SIZEOF:Sizeof)(LLVMEvents:LLVM_I
     end.
 End ByteModule.
 
-Module Byte (Addr:ADDRESS)(IP:INTPTR)(SIZEOF:Sizeof)(LLVMEvents:LLVM_INTERACTIONS(Addr)(IP)(SIZEOF))(Byte:ByteImpl(Addr)(IP)(SIZEOF)(LLVMEvents)) : ByteModule Addr IP SIZEOF LLVMEvents Byte.
-  Include (ByteModule Addr IP SIZEOF LLVMEvents Byte).
+Module Byte (LP:LLVMParams)(Byte:ByteImpl LP). 
+  Include (ByteModule LP Byte).
 End Byte.

--- a/src/rocq/Semantics/Memory/Overlaps.v
+++ b/src/rocq/Semantics/Memory/Overlaps.v
@@ -4,7 +4,7 @@ Require Import Vellvm.Semantics.MemoryAddress.
 Require Import Vellvm.Semantics.Memory.Sizeof.
 From Vellvm Require Import DynamicTypes.
 
-Module Type Overlaps (Addr:MemoryAddress.ADDRESS).
+Module Type OVERLAPS (Addr:MemoryAddress.ADDRESS).
   Import Addr.
 
   (** Do two memory regions overlap each other?
@@ -17,12 +17,12 @@ Module Type Overlaps (Addr:MemoryAddress.ADDRESS).
 
   Parameter overlaps :
     forall (a1 : addr) (sz1 : Z) (a2 : addr) (sz2 : Z), bool.
-End Overlaps.
+End OVERLAPS.
 
-Module OverlapHelpers (Addr : MemoryAddress.ADDRESS) (Size : Sizeof) (Over : Overlaps Addr).
+Module OverlapHelpers (Addr : MemoryAddress.ADDRESS) (S : SIZEOF) (O : OVERLAPS Addr).
   Import Addr.
-  Import Over.
-  Import Size.
+  Import O.
+  Import S.
 
   (** Checks if two regions of memory overlap each other. The types
    *τ1* and *τ2* are used to determine the size of the two memory
@@ -43,10 +43,10 @@ Module OverlapHelpers (Addr : MemoryAddress.ADDRESS) (Size : Sizeof) (Over : Ove
 End OverlapHelpers.
 
 (* Define overlapping of memory addresses when PTOI is defined. *)
-Module PTOIOverlaps (Addr:MemoryAddress.ADDRESS) (PTOI:PTOI(Addr)) (Size:Sizeof).
+Module PTOIOverlaps (Addr:MemoryAddress.ADDRESS) (PTOI:PTOI(Addr)) (S:SIZEOF).
   Import Addr.
   Import PTOI.
-  Import Size.
+  Import S.
 
   Local Open Scope Z.
 

--- a/src/rocq/Semantics/Memory/Sizeof.v
+++ b/src/rocq/Semantics/Memory/Sizeof.v
@@ -23,7 +23,7 @@ Definition pad_to_align (align : alignment) (sz : N) :=
 Definition pad_to_align_bitwise (align : alignment) (sz : N) :=
   pad_to ((preferred_alignment align) * 8) sz.
 
-Module Type Sizeof.
+Module Type SIZEOF.
   (** ** Size of a dynamic type in bits *)
   Parameter bit_sizeof_dtyp : dtyp -> N.
 
@@ -64,11 +64,11 @@ Module Type Sizeof.
 
   Parameter sizeof_dtyp_i8 :
     sizeof_dtyp (DTYPE_I 8) = 1%N.
-End Sizeof.
+End SIZEOF.
 
 (* Derived functions / constants on Sizeof. *)
-Module Sizeof_helpers(SIZEOF:Sizeof).
-  Import SIZEOF.
+Module SizeofHelpers(S:SIZEOF).
+  Import S.
 
   Definition ptr_size : N := sizeof_dtyp DTYPE_Pointer.
-End Sizeof_helpers.
+End SizeofHelpers.

--- a/src/rocq/Semantics/MemoryParams.v
+++ b/src/rocq/Semantics/MemoryParams.v
@@ -4,13 +4,13 @@ From Vellvm Require Import
      Semantics.Memory.MemBytes
      Semantics.Memory.DvalueBytes.
 
-Module Type MemoryParams (LP : LLVMParams).
-  Declare Module GEP : GEPM LP.ADDR LP.PTOI LP.PROV LP.ITOP LP.IP LP.SIZEOF LP.Events.
-  Declare Module BYTE_IMPL : ByteImpl LP.ADDR LP.IP LP.SIZEOF LP.Events.
+Module Type MEMORY_PARAMS (LP : LLVMParams).
+  Declare Module GEP : GEPM LP.
+  Declare Module BYTE_IMPL : ByteImpl LP.
   Declare Module DVALUE_BYTES : DvalueByte LP.
-End MemoryParams.
+End MEMORY_PARAMS.
 
-Module Make (LP' : LLVMParams) (GEP' : GEPM LP'.ADDR LP'.PTOI LP'.PROV LP'.ITOP LP'.IP LP'.SIZEOF LP'.Events) (BYTE_IMPL' : ByteImpl LP'.ADDR LP'.IP LP'.SIZEOF LP'.Events) (DVALUE_BYTES' : DvalueByte LP') : MemoryParams LP'
+Module Make (LP : LLVMParams) (GEP' : GEPM LP) (BYTE_IMPL' : ByteImpl LP) (DVALUE_BYTES' : DvalueByte LP) : MEMORY_PARAMS LP
 with Module GEP := GEP'
 with Module BYTE_IMPL := BYTE_IMPL'
 with Module DVALUE_BYTES := DVALUE_BYTES'.

--- a/src/rocq/Semantics/TopLevel.v
+++ b/src/rocq/Semantics/TopLevel.v
@@ -49,7 +49,7 @@ Open Scope string_scope.
  *)
 Module Type LLVMTopLevel (IS : InterpreterStack).
   Export IS.
-  Export IS.LP.Events.
+  Export IS.LP.DV.
   Export IS.LLVM.D.
   Export IS.LLVM.MEM.
   Export IS.LLVM.MEM.MEM_MODEL.
@@ -91,9 +91,10 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
     the character comes in as an i32, so the function truncates to an i8
     to match types with IO_stdout. *)
 
+  
   Definition putchar_denotation : function_denotation.
     refine
-      (let putchar_body (u_char:uvalue) : itree L0' uvalue :=
+      (let putchar_body (u_char:uvalue) : itree (L0' dvalue uvalue) uvalue :=
          dv <- concretize_or_pick u_char ;;
          match dv with
          | @DVALUE_I sz x32 =>
@@ -118,22 +119,20 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
          | char::[] => putchar_body char
          | _ => raise "putc called with zero or more than one arguments"
          end).
-
     subst.
     exact (trigger (IO_stdout [x8])).
   Defined.
-
 
   (** A semantic function to read an i8 value at [strptr + index] from the memory.
       Propagates all memory failures and raises a Vellvm "Failure" if the
       value read does not concretize to a DVALUE_I8.
    *)
-  Definition i8_str_index (strptr : addr) (index : Z) : itree L0' (@Integers.bit_int 8) :=
-    iptr <- (@lift_OOM (itree L0') _ _ _ (LP.IP.from_Z index)) ;;
+  Definition i8_str_index (strptr : addr) (index : Z) : itree (L0' dvalue uvalue) (@Integers.bit_int 8) :=
+    iptr <- (@lift_OOM (itree (L0' dvalue uvalue)) _ _ _ (LP.IP.from_Z index)) ;;
     addr <-
       match handle_gep_addr (DTYPE_I 8) strptr [DVALUE_IPTR iptr] with
             | inl msg => raise msg
-            | inr c => @lift_OOM (itree L0') _ _ _ c
+            | inr c => @lift_OOM (itree (L0' dvalue uvalue)) _ _ _ c
             end ;;
     u_byte <- trigger (Load (DTYPE_I 8) (DVALUE_Addr addr)) ;;
     d_byte <- concretize_or_pick u_byte;;
@@ -148,7 +147,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
       - triggers an IO_stdout event with the bytes plus a newline
    *)
   Definition puts_denotation : function_denotation :=
-    let puts_body (u_strptr:uvalue) : itree L0' uvalue :=
+    let puts_body (u_strptr:uvalue) : itree (L0' dvalue uvalue) uvalue :=
       dv <- concretize_or_pick u_strptr;;
       match dv with
       | DVALUE_Addr strptr =>
@@ -363,8 +362,8 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
       (tl is a Definition with name n /\ tl' is a Declaration with name n)
 
       Will write tomorrow if so.  *)
-
-
+  
+    
   (** * Initialization
 
     The initialization phase allocates and initializes globals, and allocates
@@ -372,7 +371,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
    is an [itree] as any other.  *)
 
   (** Allocate space for a global *)
-  Definition allocate_global (g:global dtyp) : itree L0 unit :=
+  Definition allocate_global (g:global dtyp) : itree (L0 dvalue uvalue) unit :=
     if (g_alias g) then
       (* Aliases don't allocate new storage space. *)
       ret tt 
@@ -380,7 +379,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
       v <- trigger (Alloca (g_typ g) 1%N None);;
       trigger (GlobalWrite (g_ident g) v).
 
-  Definition allocate_globals (gs:list (global dtyp)) : itree L0 unit :=
+  Definition allocate_globals (gs:list (global dtyp)) : itree (L0 dvalue uvalue) unit :=
     map_monad_ allocate_global gs.
 
   Definition i8 : dtyp := DTYPE_I 8%positive.
@@ -397,14 +396,14 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
             Stdlib.Strings.Ascii.N_of_ascii ) (Stdlib.Strings.String.list_ascii_of_string s))
             [@UVALUE_I 8%positive (@Integers.zero 8%positive)]).
 
-  Definition allocate_arg (arg : string) : itree L0 dvalue :=
+  Definition allocate_arg (arg : string) : itree (L0 dvalue uvalue) dvalue :=
     let len := N.of_nat (String.length arg) + 1%N in
     (* tl;dr allocating the string in a C-like manner; + 1 for null terminator *)
     v <- trigger (Alloca i8 len None);;
     trigger (Store (DTYPE_Array len i8) v (i8_array_of_string arg));;
     ret v.
 
-  Definition allocate_args (args : list string) : itree L0 dvalue :=
+  Definition allocate_args (args : list string) : itree (L0 dvalue uvalue) dvalue :=
     let len := N.of_nat (Datatypes.length args) in
       v <- trigger (Alloca DTYPE_Pointer len None);;
       arg_addrs <- map_monad allocate_arg args;;
@@ -413,10 +412,10 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
                                    (map dvalue_to_uvalue arg_addrs)));;
       ret v.
 
-  Definition build_main_args (args : list string) : itree L0 (list uvalue) :=
+  Definition build_main_args (args : list string) : itree (L0 dvalue uvalue) (list uvalue) :=
     v <- allocate_args args;;
     let main_args :=
-      [@DV.UVALUE_I 32 ((@Integers.repr 32%positive ∘ Z.of_nat) (List.length args)); dvalue_to_uvalue v]
+      [@LP.DV.UVALUE_I 32 ((@Integers.repr 32%positive ∘ Z.of_nat) (List.length args)); dvalue_to_uvalue v]
     in
     ret main_args.
 
@@ -428,7 +427,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
        combines two mcfgs coherently
    *)
 
-  Definition allocate_declaration (d:declaration dtyp) : itree L0 unit :=
+  Definition allocate_declaration (d:declaration dtyp) : itree (L0 dvalue uvalue) unit :=
     match lookup_intrinsic_declaration (dc_name d) with
     | Some _ => Ret tt (* Don't allocate pointers for LLVM intrinsics declarations *)
     | None =>
@@ -436,14 +435,14 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
         trigger (GlobalWrite (dc_name d) v)
     end.
 
-  Definition allocate_declarations (ds:list (declaration dtyp)) : itree L0 unit :=
+  Definition allocate_declarations (ds:list (declaration dtyp)) : itree (L0 dvalue uvalue) unit :=
     map_monad_ allocate_declaration ds.
 
   (* We have to initialize the global definitions after allocating them because they
      might be mutually recursive.  It is possible to declare cyclic data structures
      statically at the global level in LLVM.
    *)
-  Definition initialize_global (g:global dtyp) : itree exp_E unit :=
+  Definition initialize_global (g:global dtyp) : itree (exp_E dvalue uvalue) unit :=
     if (g_alias g) then
       (* aliases simply populate the global ID map *)
       match (g_exp g) with
@@ -463,13 +462,13 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
          end ;;
     trigger (Store dt a uv).
 
-  Definition initialize_globals (gs:list (global dtyp)): itree exp_E unit :=
+  Definition initialize_globals (gs:list (global dtyp)): itree (exp_E dvalue uvalue) unit :=
     map_monad_ initialize_global gs.
 
-  Definition build_global_environment (CFG : CFG.mcfg dtyp) : itree L0 unit :=
+  Definition build_global_environment (CFG : CFG.mcfg dtyp) : itree (L0 dvalue uvalue) unit :=
     allocate_declarations ((m_declarations CFG) ++ (List.map (df_prototype) (m_definitions CFG)));;
     allocate_globals (m_globals CFG) ;;
-    translate exp_to_L0 (initialize_globals (m_globals CFG)).
+    translate (@exp_to_L0 dvalue uvalue) (initialize_globals (m_globals CFG)).
 
   (** Local environment implementation
     The map-based handlers are defined parameterized over a domain of key and value.
@@ -484,7 +483,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
    *)
 
   Definition address_one_function (df : definition dtyp (CFG.cfg dtyp))
-    : itree L0 (Z * function_denotation) :=
+    : itree (L0 dvalue uvalue) (Z * function_denotation) :=
     let fid := (dc_name (df_prototype df)) in
     fv <- trigger (GlobalRead fid) ;;
     match fv with
@@ -497,7 +496,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
    Denotes a builtin function
    *)
   Definition address_one_builtin_function (builtin : function_id * function_denotation)
-    : itree L0 (Z * function_denotation) :=
+    : itree (L0 dvalue uvalue) (Z * function_denotation) :=
     let (fid, den) := builtin in
     fv <- trigger (GlobalRead fid) ;;
     match fv with
@@ -541,7 +540,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
              (ret_typ : dtyp)
              (entry : function_id)
              (args : list uvalue)
-             (mcfg : CFG.mcfg dtyp) : itree L0 dvalue :=
+             (mcfg : CFG.mcfg dtyp) : itree (L0 dvalue uvalue) dvalue :=
     build_global_environment mcfg ;;
     'defns <- map_monad address_one_function (m_definitions mcfg) ;;
     'builtins <- map_monad address_one_builtin_function (built_in_functions (m_declarations mcfg));;
@@ -579,9 +578,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   Definition interpreter_gen
     (ret_typ : dtyp)
     (entry : function_id)
-    (arg_gen : itree L0 (list uvalue))
+    (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
     (prog: ll_toplevel_entities)
-    : itree L4 res_L4 :=
+    : itree (L4 dvalue uvalue) res_L4 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
@@ -595,7 +594,7 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   Definition interpreter
              (args : list string)
              (prog : ll_toplevel_entities)
-              : itree L4 res_L4
+              : itree (L4 dvalue uvalue) res_L4
     :=
     interpreter_gen (DTYPE_I 32%positive) (Name "main") (build_main_args args) prog.
 
@@ -613,9 +612,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   Definition model_gen
              (ret_typ : dtyp)
              (entry : function_id)
-             (arg_gen : itree L0 (list uvalue))
+             (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
              (prog: ll_toplevel_entities)
-    : PropT L4 res_L4 :=
+    : PropT (L4 dvalue uvalue) res_L4 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
@@ -625,9 +624,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   Definition model_gen_oom
              (ret_typ : dtyp)
              (entry : function_id)
-             (arg_gen : itree L0 (list uvalue))
+             (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
              (prog: ll_toplevel_entities)
-    : PropT L4 res_L4 :=
+    : PropT (L4 dvalue uvalue) res_L4 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
@@ -637,9 +636,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   Definition model_gen_oom_L1
              (ret_typ : dtyp)
              (entry : function_id)
-             (arg_gen : itree L0 (list uvalue))
+             (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
              (prog: ll_toplevel_entities)
-    : itree L1 res_L1 :=
+    : itree (L1 dvalue uvalue) res_L1 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
@@ -649,9 +648,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
   Definition model_gen_oom_L2
              (ret_typ : dtyp)
              (entry : function_id)
-             (arg_gen : itree L0 (list uvalue))
+             (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
              (prog: ll_toplevel_entities)
-    : itree L2 res_L2 :=
+    : itree (L2 dvalue uvalue) res_L2 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
@@ -662,9 +661,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
     (RR : relation res_L2)
     (ret_typ : dtyp)
     (entry : function_id)
-    (arg_gen : itree L0 (list uvalue))
+    (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
     (prog: ll_toplevel_entities)
-    : PropT L3 res_L3 :=
+    : PropT (L3 dvalue uvalue) res_L3 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
@@ -676,9 +675,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
     RR_pick
     (ret_typ : dtyp)
     (entry : function_id)
-    (arg_gen : itree L0 (list uvalue))
+    (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
     (prog: ll_toplevel_entities)
-    : PropT L4 res_L4 :=
+    : PropT (L4 dvalue uvalue) res_L4 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
@@ -690,9 +689,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
     RR_pick
     (ret_typ : dtyp)
     (entry : function_id)
-    (arg_gen : itree L0 (list uvalue))
+    (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
     (prog: ll_toplevel_entities)
-    : PropT L5 res_L5 :=
+    : PropT (L5 dvalue uvalue) res_L5 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
@@ -705,9 +704,9 @@ Module Type LLVMTopLevel (IS : InterpreterStack).
     RR_oom
     (ret_typ : dtyp)
     (entry : function_id)
-    (arg_gen : itree L0 (list uvalue))
+    (arg_gen : itree (L0 dvalue uvalue) (list uvalue))
     (prog: ll_toplevel_entities)
-    : PropT L6 res_L6 :=
+    : PropT (L6 dvalue uvalue) res_L6 :=
     let t :=
       args <- arg_gen;;
       denote_vellvm ret_typ entry args

--- a/src/rocq/Syntax/AstLib.v
+++ b/src/rocq/Syntax/AstLib.v
@@ -575,6 +575,40 @@ Definition is_void_instr (i:instr typ) : bool :=
   | _ => false
   end.
 
+  (* Check if this is an instruction which can trigger UB with division by 0. *)
+  Definition iop_is_div (iop : ibinop) : bool :=
+    match iop with
+    | UDiv _ => true
+    | SDiv _ => true
+    | URem   => true
+    | SRem   => true
+    | _      => false
+    end.
+
+  Definition iop_is_signed (iop : ibinop) : bool :=
+    match iop with
+    | SDiv _ => true
+    | SRem   => true
+    | _      => false
+    end.
+
+  Definition iop_is_shift (iop : ibinop) : bool :=
+    match iop with
+    | Shl _ _ => true
+    | LShr _ => true
+    | AShr _ => true
+    | _ => false
+    end.
+
+  (* Check if this is an instruction which can trigger UB with division by 0. *)
+  Definition fop_is_div (fop : fbinop) : bool :=
+    match fop with
+    | FDiv => true
+    | FRem => true
+    | _    => false
+    end.
+
+
 Ltac unfold_eqv :=
   repeat (unfold eqv in *; unfold eqv_raw_id in *; unfold eqv_instr_id in * ).
 

--- a/src/rocq/Theory/ExpLemmas.v
+++ b/src/rocq/Theory/ExpLemmas.v
@@ -50,65 +50,66 @@ Module ExpLemmas (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   Import SemNotations.
 
   Section Translations.
+    (* SAZ: TODO -- these are all generic in [dvalue] [uvalue], move to the llvm events module? *)
 
     (* Technicality: translations by [lookup_E_to_exp_E] and [exp_E_to_instr_E] leave these events unphased *)
 
-    Lemma LU_to_exp_Global : forall {X} (e : LLVMGEnvE X),
-        subevent X (LU_to_exp (subevent X e)) = subevent (F:=exp_E) X e.
+    Lemma LU_to_exp_Global : forall {X} (e : (LLVMGEnvE dvalue) X),
+        subevent X (LU_to_exp (subevent X e)) = subevent (F:=(exp_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
-    Lemma exp_to_instr_Global : forall {X} (e : LLVMGEnvE X),
-        subevent X (exp_to_instr (subevent X e)) = subevent (F:=instr_E) X e.
+    Lemma exp_to_instr_Global : forall {X} (e : (LLVMGEnvE dvalue) X),
+        subevent X (exp_to_instr (subevent X e)) = subevent (F:=(instr_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
-    Lemma LU_to_exp_Local : forall {X} (e : LLVMEnvE X),
-        subevent X (LU_to_exp (subevent X e)) = subevent (F:=exp_E) X e.
+    Lemma LU_to_exp_Local : forall {X} (e : (LLVMEnvE uvalue) X),
+        subevent X (LU_to_exp (subevent X e)) = subevent (F:=(exp_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
-    Lemma exp_to_instr_Local : forall {X} (e : LLVMEnvE X),
-        subevent X (exp_to_instr (subevent X e)) = subevent (F:=instr_E) X e.
+    Lemma exp_to_instr_Local : forall {X} (e : (LLVMEnvE uvalue) X),
+        subevent X (exp_to_instr (subevent X e)) = subevent (F:=(instr_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
-    Lemma exp_to_instr_Memory : forall {X} (e : MemoryE X),
-        subevent X (exp_to_instr (subevent X e)) = subevent (F:=instr_E) X e.
+    Lemma exp_to_instr_Memory : forall {X} (e : (MemoryE dvalue uvalue) X),
+        subevent X (exp_to_instr (subevent X e)) = subevent (F:=(instr_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
     Lemma exp_to_instr_Pick : forall {X} (e : PickE X),
-        subevent X (exp_to_instr (subevent X e)) = subevent (F:=instr_E) X e.
+        subevent X (exp_to_instr (subevent X e)) = subevent (F:=(instr_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
     Lemma exp_to_instr_UB : forall {X} (e : UBE X),
-        subevent X (exp_to_instr (subevent X e)) = subevent (F:=instr_E) X e.
+        subevent X (exp_to_instr (subevent X e)) = subevent (F:=(instr_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
     Lemma exp_to_instr_Fail : forall {X} (e : FailureE X),
-        subevent X (exp_to_instr (subevent X e)) = subevent (F:=instr_E) X e.
+        subevent X (exp_to_instr (subevent X e)) = subevent (F:=(instr_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
     Lemma FUB_to_exp_UB : forall {X} (e : UBE X),
-        subevent X (FUB_to_exp (subevent X e)) = subevent (F:=exp_E) X e.
+        subevent X (FUB_to_exp (subevent X e)) = subevent (F:=(exp_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
 
     Lemma FUB_to_exp_Fail : forall {X} (e : FailureE X),
-        subevent X (FUB_to_exp (subevent X e)) = subevent (F:=exp_E) X e.
+        subevent X (FUB_to_exp (subevent X e)) = subevent (F:=(exp_E dvalue uvalue)) X e.
     Proof using.
       reflexivity.
     Qed.
@@ -322,6 +323,7 @@ Module ExpLemmas (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
       reflexivity.
     Qed.
 
+    (* TYPECLASS resolution breaks for this 
     Lemma denote_exp_GR :forall g l id v τ,
         Maps.lookup id g = Some v ->
         ⟦ EXP_Ident (ID_Global id) at τ ⟧e2 g l
@@ -340,6 +342,7 @@ Module ExpLemmas (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
       reflexivity.
     Qed.
 
+     *)
     (* This doesn't necessarily hold because we don't know if `v` was
        concretized eagerly. We should know that `v` is equivalent to
        the value on the left-hand-side, though.

--- a/src/rocq/Theory/InterpreterCFG.v
+++ b/src/rocq/Theory/InterpreterCFG.v
@@ -94,7 +94,7 @@ Module CFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
     repeat (autorewrite with VELLVM_REWRITE; cbn).
 
   Lemma interp_cfg1_bind :
-    forall {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g,
+    forall {R S} (t: itree (instr_E dvalue uvalue) R) (k: R -> itree (instr_E dvalue uvalue) S) g,
       ℑ1 (t >>= k) g ≈ '(g',x) <- ℑ1 t g ;; ℑ1 (k x) g'.
   Proof.
     intros.
@@ -115,7 +115,7 @@ Module CFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
     : VELLVM_REWRITE.
 
   Lemma interp_cfg2_bind :
-    forall {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g l,
+    forall {R S} (t: itree (instr_E dvalue uvalue) R) (k: R -> itree (instr_E dvalue uvalue) S) g l,
       ℑ2 (t >>= k) g l ≈ '(g',(l',x)) <- ℑ2 t g l ;; ℑ2 (k x) l' g'.
   Proof.
     intros.
@@ -131,7 +131,7 @@ Module CFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   Qed.
 
   (* Lemma interp_cfg3_bind : *)
-  (*   forall {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g l m, *)
+  (*   forall {R S} (t: itree (instr_E dvalue uvalue) R) (k: R -> itree (instr_E dvalue uvalue) S) g l m, *)
   (*     ℑ3 (t >>= k) g l m ≈ *)
   (*        '(m',(l',(g',x))) <- ℑ3 t g l m ;; ℑ3 (k x) g' l' m'. *)
   (* Proof. *)
@@ -176,7 +176,7 @@ Module CFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   (* Qed. *)
 
   Lemma interp_cfg2_vis :
-    forall T R (e : instr_E T) (k : T -> itree instr_E R) g l,
+    forall T R (e : (instr_E dvalue uvalue) T) (k : T -> itree (instr_E dvalue uvalue) R) g l,
       ℑ2 (Vis e k) g l ≈ '(l, (g, x)) <- ℑ2 (trigger e) g l;; ℑ2 (k x) g l.
   Proof.
     intros.
@@ -188,7 +188,7 @@ Module CFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   Qed.
 
   Lemma interp_cfg2_bind_trigger :
-    forall T R (e : instr_E T) (k : T -> itree instr_E R) g l,
+    forall T R (e : (instr_E dvalue uvalue) T) (k : T -> itree (instr_E dvalue uvalue) R) g l,
       ℑ2 (trigger e >>= k) g l ≈
          '(l, (g, x)) <- ℑ2 (trigger e) g l ;; ℑ2 (k x) g l.
   Proof.

--- a/src/rocq/Theory/InterpreterMCFG.v
+++ b/src/rocq/Theory/InterpreterMCFG.v
@@ -122,7 +122,7 @@ Module Type MCFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   Import MCFGTactics.
 
   Lemma interp1_bind :
-    forall {R S} (t: itree L0 R) (k: R -> itree L0 S) g, 
+    forall {R S} (t: itree (L0 dvalue uvalue) R) (k: R -> itree (L0 dvalue uvalue) S) g, 
       ℑs1 (t >>= k) g ≈ '(g',x) <- ℑs1 t g ;; ℑs1 (k x) g'.
   Proof.
     intros; unfold ℑs1.
@@ -137,7 +137,7 @@ Module Type MCFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   Qed.
 
   Lemma interp2_bind :
-    forall {R S} (t: itree L0 R) (k: R -> itree L0 S) g l,
+    forall {R S} (t: itree (L0 dvalue uvalue) R) (k: R -> itree (L0 dvalue uvalue) S) g l,
       ℑs2 (t >>= k) g l ≈ '(g',(l',x)) <- ℑs2 t g l;; ℑs2 (k x) l' g'.
   Proof.
     intros; unfold ℑs2.
@@ -153,7 +153,7 @@ Module Type MCFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   Qed.
 
   (* Lemma interp3_bind : *)
-  (*   forall {R S} (t: itree L0 R) (k: R -> itree L0 S) g l m, *)
+  (*   forall {R S} (t: itree (L0 dvalue uvalue) R) (k: R -> itree (L0 dvalue uvalue) S) g l m, *)
   (*     ℑs3 (t >>= k) g l m ≈ '(m',(l',(g',x))) <- ℑs3 t g l m;; ℑs3 (k x) g' l' m'. *)
   (* Proof. *)
   (*   intros. *)
@@ -200,7 +200,7 @@ Module Type MCFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   (* Qed. *)
 
   (* Lemma interp3_vis:  *)
-  (*   forall T R (e : L0 T) (k : T -> itree L0 R) g l m, *)
+  (*   forall T R (e : (L0 dvalue uvalue) T) (k : T -> itree (L0 dvalue uvalue) R) g l m, *)
   (*     ℑs3 (Vis e k) g l m ≈  *)
   (*         '(m, (l, (g, x))) <- ℑs3 (trigger e) g l m;; ℑs3 (k x) g l m. *)
   (* Proof. *)
@@ -215,7 +215,7 @@ Module Type MCFGTheory (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   (* Qed. *)
 
   (* Lemma interp3_bind_trigger : *)
-  (*   forall T R (e : L0 T) (k : T -> itree L0 R) g l m, *)
+  (*   forall T R (e : (L0 dvalue uvalue) T) (k : T -> itree (L0 dvalue uvalue) R) g l m, *)
   (*     ℑs3 (trigger e >>= k) g l m ≈  *)
   (*         '(m, (l, (g, x))) <- ℑs3 (trigger e) g l m;; ℑs3 (k x) g l m. *)
   (* Proof. *)

--- a/src/rocq/Theory/OOMRefinementExamples.v
+++ b/src/rocq/Theory/OOMRefinementExamples.v
@@ -130,7 +130,7 @@ Module Infinite.
 
   Module EL := ExpLemmas InterpreterStackBigIntptr TopLevelBigIntptr.
   Import EL.
-
+  Import InterpreterStackBigIntptr.LP.DV.
 
   #[global] Instance interp_mem_prop_Proper3 :
   forall {E}
@@ -383,17 +383,17 @@ Module Infinite.
   Definition denote_program prog :=
     block_to_dvalue (denote_block prog (Name "blk") None).
 
-  Definition alloc_tree : itree instr_E dvalue :=
+  Definition alloc_tree : itree (instr_E dvalue uvalue) dvalue :=
     denote_program alloc_block.
 
-  Definition ptoi_tree : itree instr_E dvalue :=
+  Definition ptoi_tree : itree (instr_E dvalue uvalue) dvalue :=
     denote_program ptoi_block.
 
-  Definition ret_tree : itree instr_E dvalue :=
+  Definition ret_tree : itree (instr_E dvalue uvalue) dvalue :=
     denote_program ret_block.
 
-  Definition instr_E_to_L0 {T : Type} : instr_E T -> itree L0 T :=
-    fun (e : instr_E T) =>
+  Definition instr_E_to_L0 {T : Type} : (instr_E dvalue uvalue) T -> itree (L0 dvalue uvalue) T :=
+    fun (e : (instr_E dvalue uvalue) T) =>
       match e with
       | inl1 call =>
           match call with
@@ -433,7 +433,7 @@ Module Infinite.
 
   Lemma interp_concretize_uvalue :
     forall u,
-      interp (fun (T : Type) (e : exp_E T) => instr_E_to_L0 (exp_to_instr e))
+      interp (fun (T : Type) (e : exp_E dvalue uvalue T) => instr_E_to_L0 (exp_to_instr e))
       (concretize_uvalue u)
       ≈ concretize_uvalue u.
   Proof.
@@ -451,7 +451,7 @@ Module Infinite.
 
   Lemma interp_concretize_if_no_undef_or_poison :
     forall u,
-      interp (fun (T : Type) (e : exp_E T) => instr_E_to_L0 (exp_to_instr e))
+      interp (fun (T : Type) (e : exp_E dvalue uvalue T) => instr_E_to_L0 (exp_to_instr e))
       (concretize_if_no_undef_or_poison u)
       ≈ concretize_if_no_undef_or_poison u.
   Proof.
@@ -562,7 +562,7 @@ Module Infinite.
 
   (* Few remarks about [L3_trace] used in [interp_mcfg4] *)
   Remark L3_trace_MemoryE:
-    forall R X (g : global_env) (l : lstack_frame * lstack) sid m (e : MemoryE X) (k : X -> itree L0 R) t,
+    forall R X (g : global_env) (l : lstack_frame * lstack) sid m (e : MemoryE dvalue uvalue X) (k : X -> itree (L0 dvalue uvalue) R) t,
       interp_memory_spec eq
         (vis e (fun x : X => interp_local_stack (interp_global (interp_intrinsics (k x)) g) l)) sid m t <->
       interp_memory_spec eq (interp_local_stack (interp_global (interp_intrinsics (vis e k)) g) l) sid m t.
@@ -582,7 +582,7 @@ Module Infinite.
   Qed.
 
   Remark L3_trace_LocalWrite:
-    forall R (g : global_env) (l : lstack_frame) (s : lstack) sid m (k : itree L0 R) t id dv,
+    forall R (g : global_env) (l : lstack_frame) (s : lstack) sid m (k : itree (L0 dvalue uvalue) R) t id dv,
       interp_memory_spec eq
         (interp_local_stack (interp_global (interp_intrinsics k) g) (Maps.add id dv l, s)) sid m t <->
       interp_memory_spec eq (interp_local_stack (interp_global (interp_intrinsics (trigger (LocalWrite id dv);; k)) g) (l, s)) sid m t.
@@ -607,7 +607,7 @@ Module Infinite.
   Qed.
 
   Remark L3_trace_LocalRead:
-    forall R (g : global_env) (l : lstack_frame) (s : lstack) sid m (k: _ -> itree L0 R) t id x,
+    forall R (g : global_env) (l : lstack_frame) (s : lstack) sid m (k: _ -> itree (L0 dvalue uvalue) R) t id x,
       Maps.lookup id l = ret x ->
       (interp_memory_spec eq (interp_local_stack (interp_global (interp_intrinsics (k (snd (l, s, x)))) g) (fst (l, s, x)))
         sid m t <->
@@ -635,7 +635,7 @@ Module Infinite.
 
   Remark L3_trace_ret:
     forall R (g : global_env) (l : lstack_frame * lstack) sid m r
-      (t : itree (ExternalCallE +' LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
+      (t : itree (ExternalCallE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE _ +' UBE +' DebugE +' FailureE)
             (_ * (store_id * (lstack_frame * lstack * (FMapAList.alist raw_id dvalue * R))))),
       interp_memory_spec eq (Ret2 g l r) sid m t <->
       interp_memory_spec eq (interp_local_stack (interp_global (interp_intrinsics (ret r)) g) l) sid m t.
@@ -694,7 +694,7 @@ Module Infinite.
                       x
                       return
                       (itree
-                         (ExternalCallE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                         (ExternalCallE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
                          (MMEP.MMSP.MemState * (store_id * (stack_frame uvalue * Stack.stack uvalue * res_L1))))
                     with
                     end)) with
@@ -704,7 +704,7 @@ Module Infinite.
                                x
                                return
                                (itree
-                                  (ExternalCallE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                                  (ExternalCallE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
                                   (MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1))))
                              with
                              end))).
@@ -860,7 +860,7 @@ Module Infinite.
                       x
                       return
                       (itree
-                         (ExternalCallE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                         (ExternalCallE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
                          (MMEP.MMSP.MemState * (store_id * (stack_frame uvalue * Stack.stack uvalue * res_L1))))
                     with
                     end)) with
@@ -870,7 +870,7 @@ Module Infinite.
                                x
                                return
                                (itree
-                                  (ExternalCallE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                                  (ExternalCallE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
                                   (MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1))))
                              with
                              end))).
@@ -989,15 +989,15 @@ Module Infinite.
 
   Lemma interp_memory_spec_vis_inv:
     forall E R X
-      (e : (E +' LLVMParamsBigIntptr.Events.IntrinsicE +' LLVMParamsBigIntptr.Events.MemoryE +' LLVMParamsBigIntptr.Events.PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) X)
+      (e : (E +' IntrinsicE dvalue uvalue +' MemoryE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) X)
       k sid m t,
       interp_memory_spec (E:=E) (R2 := R) eq (Vis e k) sid m t ->
       ((exists ta k2 s1 s2 ,
            eutt (MMEP.MemSpec.MemState_eqv × eq) t (a <- ta;; k2 a) /\
              interp_memory_spec_h e s1 s2 ta /\
              (forall (a : X) (b : MMEP.MMSP.MemState * (store_id * X)),
-                 @Returns (E +' IntrinsicE +' MemoryE +' PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE) X a (trigger e) ->
-                 @Returns (E +' PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE) (MMEP.MMSP.MemState * (store_id * X)) b ta ->
+                 @Returns (E +' IntrinsicE dvalue uvalue +' MemoryE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' _ +' UBE +' DebugE +' FailureE) X a (trigger e) ->
+                 @Returns (E +' PickUvalueE dvalue uvalue +' OOME +' _ +' UBE +' DebugE +' FailureE) (MMEP.MMSP.MemState * (store_id * X)) b ta ->
                  a = snd (snd b) ->
                  interp_memory_spec (E := E) eq (k a) sid m (k2 b))) \/
          (exists ta s1 s2, interp_memory_spec_h e s1 s2 ta /\ contains_UB_Extra ta)%type \/
@@ -1060,9 +1060,9 @@ Module Infinite.
 
   Lemma refine_OOM_h_model_undef_h_raise_OOM:
     forall R t1 oom_msg (k1 : R -> _) t3,
-      refine_OOM_h (E := L4) refine_res3 t1 (raiseOOM oom_msg) ->
+      refine_OOM_h (E := L4 dvalue uvalue) refine_res3 t1 (raiseOOM oom_msg) ->
       model_undef_h (prod_rel MemoryBigIntptr.MMEP.MemSpec.MemState_eqv eq) (x <- Error.raise_oom oom_msg;; k1 x) t3 ->
-      refine_OOM_h (E := L4) refine_res3 t1 t3.
+      refine_OOM_h (E := L4 dvalue uvalue) refine_res3 t1 t3.
   Proof.
     intros. punfold H. red in H.
     unfold Error.raise_oom, RAISE_OOM_ITREE_OOME, bind, Monad_itree, raiseOOM in *.
@@ -1126,9 +1126,9 @@ Module Infinite.
 
   Lemma refine_OOM_h_model_undef_h_raise_ret:
     forall t1 t3 r,
-      refine_OOM_h (E := L4) refine_res3 t1 (ret r) ->
+      refine_OOM_h (E := L4 dvalue uvalue) refine_res3 t1 (ret r) ->
       model_undef_h (prod_rel MemoryBigIntptr.MMEP.MemSpec.MemState_eqv eq) (ret r) t3 ->
-      refine_OOM_h (E := L4) refine_res3 t1 t3.
+      refine_OOM_h (E := L4 dvalue uvalue) refine_res3 t1 t3.
   Proof.
     intros.
     eapply interp_prop_oom_ret_inv in H0.
@@ -1202,7 +1202,7 @@ Module Infinite.
                       x0
                       return
                       (itree
-                         (ExternalCallE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                         (ExternalCallE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
                          (MMEP.MMSP.MemState * (store_id * (stack_frame uvalue * Stack.stack uvalue * res_L1))))
                     with
                     end)) with
@@ -1212,7 +1212,7 @@ Module Infinite.
                                x0
                                return
                                (itree
-                                  (ExternalCallE +' PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+                                  (ExternalCallE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
                                   (MMEP.MMSP.MemState * (store_id * (lstack_frame * lstack * res_L1))))
                              with
                              end))).
@@ -1375,10 +1375,10 @@ Module Infinite.
 
     assert (alloca_returns:
              forall x, Returns
-                    (E := ExternalCallE +'
-                        LLVMParamsBigIntptr.Events.IntrinsicE +'
-                        LLVMParamsBigIntptr.Events.MemoryE +'
-                        LLVMParamsBigIntptr.Events.PickUvalueE +'
+                    (E := ExternalCallE dvalue uvalue +'
+                        IntrinsicE dvalue uvalue +'
+                        MemoryE dvalue uvalue +'
+                        PickUvalueE dvalue uvalue +'
                         OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
                                    x (trigger (Alloca (DTYPE_I 64) 1 None))).
     { intros. unfold trigger.
@@ -1510,6 +1510,7 @@ Module Finite.
 
   Module EL := ExpLemmas InterpreterStack64BitIntptr TopLevel64BitIntptr.
   Import EL.
+  Import InterpreterStack64BitIntptr.LP.DV.
 
   Definition alloc_code : code dtyp :=
     [ (IId (Name "ptr"), INSTR_Alloca (DTYPE_I 64%positive) [], [])
@@ -1565,23 +1566,23 @@ Module Finite.
   Definition denote_program prog :=
     block_to_dvalue (denote_block prog (Name "blk") None).
 
-  Definition alloc_tree : itree instr_E dvalue :=
+  Definition alloc_tree : itree (instr_E dvalue uvalue) dvalue :=
     denote_program alloc_block.
 
-  Definition ptoi_tree : itree instr_E dvalue :=
+  Definition ptoi_tree : itree (instr_E dvalue uvalue) dvalue :=
     denote_program ptoi_block.
 
-  Definition ret_tree : itree instr_E dvalue :=
+  Definition ret_tree : itree (instr_E dvalue uvalue) dvalue :=
     denote_program ret_block.
 
-  Definition t_alloc : itree L0 dvalue
+  Definition t_alloc : itree (L0 dvalue uvalue) dvalue
     := trigger (Alloca (DTYPE_I 64%positive) 1 None);; ret (@DVALUE_I 1 one).
 
-  Definition t_ret : itree L0 dvalue
+  Definition t_ret : itree (L0 dvalue uvalue) dvalue
     := ret (@DVALUE_I 1 one).
-
-  Definition instr_E_to_L0 {T : Type} : instr_E T -> itree L0 T :=
-    fun (e : instr_E T) =>
+  
+  Definition instr_E_to_L0 {T : Type} : (instr_E dvalue uvalue) T -> itree (L0 dvalue uvalue) T :=
+    fun (e : (instr_E dvalue uvalue) T) =>
       match e with
       | inl1 call =>
           match call with
@@ -1636,9 +1637,9 @@ Module Finite.
 
   Lemma refine_OOM_h_model_undef_h_raise_OOM:
     forall R t1 oom_msg (k1 : R -> _) t3,
-      refine_OOM_h (E := L4) refine_res3 t1 (raiseOOM oom_msg) ->
+      refine_OOM_h (E := (L4 dvalue uvalue)) refine_res3 t1 (raiseOOM oom_msg) ->
       model_undef_h (prod_rel Memory64BitIntptr.MMEP.MemSpec.MemState_eqv eq) (x <- Error.raise_oom oom_msg;; k1 x) t3 ->
-      refine_OOM_h (E := L4) refine_res3 t1 t3.
+      refine_OOM_h (E := (L4 dvalue uvalue)) refine_res3 t1 t3.
   Proof.
     intros. punfold H. red in H.
     unfold Error.raise_oom, RAISE_OOM_ITREE_OOME, bind, Monad_itree, raiseOOM in *.
@@ -1702,9 +1703,9 @@ Module Finite.
 
   Lemma refine_OOM_h_model_undef_h_raise_ret:
     forall t1 t3 r,
-      refine_OOM_h (E := L4) refine_res3 t1 (ret r) ->
+      refine_OOM_h (E := (L4 dvalue uvalue)) refine_res3 t1 (ret r) ->
       model_undef_h (prod_rel Memory64BitIntptr.MMEP.MemSpec.MemState_eqv eq) (ret r) t3 ->
-      refine_OOM_h (E := L4) refine_res3 t1 t3.
+      refine_OOM_h (E := (L4 dvalue uvalue)) refine_res3 t1 t3.
   Proof.
     intros.
     eapply interp_prop_oom_ret_inv in H0.
@@ -1735,7 +1736,7 @@ Module Finite.
 
   (* Few remarks about [L3_trace] used in [interp_mcfg4] *)
   Remark L3_trace_MemoryE:
-    forall R X (g : global_env) (l : lstack_frame * lstack) sid m (e : MemoryE X) (k : X -> itree L0 R) t,
+    forall R X (g : global_env) (l : lstack_frame * lstack) sid m (e : MemoryE dvalue uvalue X) (k : X -> itree (L0 dvalue uvalue) R) t,
       interp_memory_spec eq
             (vis e (fun x : X => interp_local_stack (interp_global (interp_intrinsics (k x)) g) l)) sid m t <->
       interp_memory_spec eq (interp_local_stack (interp_global (interp_intrinsics (vis e k)) g) l) sid m t.
@@ -1755,7 +1756,7 @@ Module Finite.
   Qed.
 
   Remark L3_trace_LocalWrite:
-    forall R (g : global_env) (l : lstack_frame) (s : lstack) sid m (k : unit -> itree L0 R) t id dv,
+    forall R (g : global_env) (l : lstack_frame) (s : lstack) sid m (k : unit -> itree (L0 dvalue uvalue) R) t id dv,
       interp_memory_spec eq
         (interp_local_stack (interp_global (interp_intrinsics (k tt)) g) (Maps.add id dv l, s)) sid m t <->
       interp_memory_spec eq (interp_local_stack (interp_global (interp_intrinsics (vis (LocalWrite id dv) k)) g) (l, s)) sid m t.
@@ -1778,7 +1779,7 @@ Module Finite.
   Qed.
 
   Remark L3_trace_LocalRead:
-    forall R (g : global_env) (l : lstack_frame) (s : lstack) sid m (k: _ -> itree L0 R) t id x,
+    forall R (g : global_env) (l : lstack_frame) (s : lstack) sid m (k: _ -> itree (L0 dvalue uvalue) R) t id x,
       Maps.lookup id l = ret x ->
       (interp_memory_spec eq (interp_local_stack (interp_global (interp_intrinsics (k (snd (l, s, x)))) g) (fst (l, s, x)))
         sid m t <->
@@ -1803,7 +1804,7 @@ Module Finite.
 
   Remark L3_trace_ret:
     forall R g l sid m (r : R)
-       (t : itree (ExternalCallE +' LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
+       (t : itree (ExternalCallE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
          (MMEP.MMSP.MemState *
           (store_id * (lstack_frame * lstack * (FMapAList.alist raw_id dvalue * R))))),
       interp_memory_spec eq (Ret2 g l r) sid m t <->
@@ -1817,15 +1818,15 @@ Module Finite.
 
   Lemma interp_memory_spec_vis_inv:
     forall E R X
-      (e : (E +' LLVMParams64BitIntptr.Events.IntrinsicE +' LLVMParams64BitIntptr.Events.MemoryE +' LLVMParams64BitIntptr.Events.PickUvalueE +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) X)
+      (e : (E +' IntrinsicE dvalue uvalue +' MemoryE dvalue uvalue  +' PickUvalueE dvalue uvalue +' OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE) X)
       k sid m t,
       interp_memory_spec (E:=E) (R2 := R) eq (Vis e k) sid m t ->
       ((exists ta k2 s1 s2 ,
            eutt (MMEP.MemSpec.MemState_eqv × eq) t (a <- ta;; k2 a) /\
              interp_memory_spec_h e s1 s2 ta /\
              (forall (a : X) (b : MMEP.MMSP.MemState * (store_id * X)),
-                 @Returns (E +' IntrinsicE +' MemoryE +' PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE) X a (trigger e) ->
-                 @Returns (E +' PickUvalueE +' OOME +' _ +' UBE +' DebugE +' FailureE) (MMEP.MMSP.MemState * (store_id * X)) b ta ->
+                 @Returns (E +' IntrinsicE dvalue uvalue +' MemoryE dvalue uvalue +' PickUvalueE dvalue uvalue +' OOME +' _ +' UBE +' DebugE +' FailureE) X a (trigger e) ->
+                 @Returns (E +' PickUvalueE dvalue uvalue +' OOME +' _ +' UBE +' DebugE +' FailureE) (MMEP.MMSP.MemState * (store_id * X)) b ta ->
                  a = snd (snd b) ->
                  interp_memory_spec (E := E) eq (k a) sid m (k2 b))) \/
          (exists ta s1 s2, interp_memory_spec_h e s1 s2 ta /\ contains_UB_Extra ta)%type \/
@@ -2217,10 +2218,10 @@ Module Finite.
 
     assert (alloca_returns:
              forall x, Returns
-                    (E := ExternalCallE +'
-                        LLVMParams64BitIntptr.Events.IntrinsicE +'
-                        LLVMParams64BitIntptr.Events.MemoryE +'
-                        LLVMParams64BitIntptr.Events.PickUvalueE +'
+                    (E := ExternalCallE dvalue uvalue +'
+                        IntrinsicE dvalue uvalue +'
+                        MemoryE dvalue uvalue +'
+                        PickUvalueE dvalue uvalue +'
                         OOME +' LLVMExcE uvalue +' UBE +' DebugE +' FailureE)
                                    x (trigger (Alloca (DTYPE_I 64) 1 None))).
     { intros. unfold trigger.

--- a/src/rocq/Theory/Refinement.v
+++ b/src/rocq/Theory/Refinement.v
@@ -366,41 +366,41 @@ Module Make (LP : LLVMParams) (LLVM : Lang LP).
   (* Lemma 5.7 - uses this definition of refinement
    note that refine_uvalue is the basic Uvalue refinement given by Definition 5.6 *)
   (* Refinement of uninterpreted mcfg *)
-  Definition refine_L0: relation (itree L0 dvalue) := eutt eq.
+  Definition refine_L0: relation (itree (L0 dvalue uvalue) dvalue) := eutt eq.
 
   (* Refinement of mcfg after globals *)
   Definition refine_res1 : relation (global_env * dvalue)
     := TT × eq.
 
-  Definition refine_L1 : relation (itree L1 (global_env * dvalue))
+  Definition refine_L1 : relation (itree (L1 dvalue uvalue) (global_env * dvalue))
     := eutt refine_res1.
 
   (* Refinement of mcfg after locals *)
   Definition refine_res2 : relation (lstack_frame * lstack * (global_env * dvalue))
     := TT × refine_res1.
 
-  Definition refine_L2 : relation (itree L2 (lstack_frame * lstack * (global_env * dvalue)))
+  Definition refine_L2 : relation (itree (L2 dvalue uvalue) (lstack_frame * lstack * (global_env * dvalue)))
     := eutt refine_res2.
 
   (* For multiple CFG, after interpreting [LocalE] and [MemoryE] and [IntrinsicE] that are memory intrinsics *)
   Definition refine_res3 : relation (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue))))
     := TT × (TT × refine_res2).
 
-  Definition refine_L3 : relation (itree L3 (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue)))) -> Prop)
+  Definition refine_L3 : relation (itree (L3 dvalue uvalue) (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue)))) -> Prop)
     := fun ts ts' => forall t', ts' t' -> exists t, ts t /\ eutt refine_res3 t t'.
 
   (* Refinement for after interpreting pick. *)
-  Definition refine_L4 : relation ((itree L4 (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue))))) -> Prop)
+  Definition refine_L4 : relation ((itree (L4 dvalue uvalue) (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue))))) -> Prop)
     := fun ts ts' => forall t', ts' t' -> exists t, ts t /\ eutt refine_res3 t t'.
 
-  Definition refine_L5 : relation ((itree L4 (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue))))) -> Prop)
+  Definition refine_L5 : relation ((itree (L4 dvalue uvalue) (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue))))) -> Prop)
     := fun ts ts' =>
          (* For any tree in the target set *)
          forall t', ts' t' ->
                (* There is a tree in the source set that is eutt our target tree *)
                exists t, ts t /\ eutt refine_res3 t t'.
-
-  Definition refine_L6 : relation ((itree L4 (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue))))) -> Prop)
+  
+  Definition refine_L6 : relation ((itree (L4 dvalue uvalue) (MemState * (store_id * (lstack_frame * lstack * (global_env * dvalue))))) -> Prop)
     := fun ts ts' =>
          forall t', ts' t' ->
                exists t, ts t /\ refine_OOM_h refine_res3 t t'.

--- a/src/rocq/Theory/TopLevelRefinements.v
+++ b/src/rocq/Theory/TopLevelRefinements.v
@@ -456,9 +456,9 @@ Module Type TopLevelRefinements (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
     #[global] Instance adhoc_Proper F E A e `{UBE -< F}  `{FailureE -< F}  `{OOME -< F} :
 @Proper (forall _ : itree (sum1 E F) A, Prop)
         (@respectful (itree (sum1 E F) A) Prop (@eutt (sum1 E F) A A (@eq A)) (@flip Prop Prop Prop impl))
-        (@case_ (forall _ : Type, Type) IFun sum1 Case_sum1 E (sum1 PickUvalueE F)
+        (@case_ (forall _ : Type, Type) IFun sum1 Case_sum1 E (sum1 (PickUvalueE dvalue uvalue) F)
            (fun T : Type => forall _ : itree (sum1 E F) T, Prop) (@E_trigger_prop E F)
-           (@case_ (forall _ : Type, Type) IFun sum1 Case_sum1 PickUvalueE F
+           (@case_ (forall _ : Type, Type) IFun sum1 Case_sum1 (PickUvalueE dvalue uvalue) F
               (fun T : Type => forall _ : itree (sum1 E F) T, Prop)
               (@PickUvalue_handler (sum1 E F)
                  (@ReSum_inr (forall _ : Type, Type) IFun sum1 Cat_IFun Inr_sum1 FailureE F E H0)
@@ -2743,7 +2743,7 @@ Module Type TopLevelRefinements (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
   (** We hence can also commute them at the various levels of interpretation *)
 
   Lemma interp2_bind:
-    forall {R S} (t: itree L0 R) (k: R -> itree L0 S) s1 s2,
+    forall {R S} (t: itree (L0 dvalue uvalue) R) (k: R -> itree (L0 dvalue uvalue) S) s1 s2,
       ℑs2 (ITree.bind t k) s1 s2 ≈
           (ITree.bind (ℑs2 t s1 s2) (fun '(s1',(s2',x)) => ℑs2 (k x) s2' s1')).
   Proof using.
@@ -2761,7 +2761,7 @@ Module Type TopLevelRefinements (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
     rewrite interp_intrinsics_ret, interp_global_ret, interp_local_stack_ret; reflexivity.
   Qed.
 
-  Definition interp_cfg {R: Type} (trace: itree instr_E R) (g : global_env) (l : local_env) sid m :=
+  Definition interp_cfg {R: Type} (trace: itree (instr_E dvalue uvalue) R) (g : global_env) (l : local_env) sid m :=
     let uvalue_trace   := interp_intrinsics trace in
     let L1_trace       := interp_global uvalue_trace g in
     let L2_trace       := interp_local L1_trace l in
@@ -2773,7 +2773,7 @@ Module Type TopLevelRefinements (IS : InterpreterStack) (TOP : LLVMTopLevel IS).
     let trace := denote_cfg prog varargs in
     interp_cfg trace [] [] 0 initial_memory_state.
 
-  Definition refine_cfg_ret: relation (PropT L5 (MemState * (local_env * (global_env * uvalue)))) :=
+  Definition refine_cfg_ret: relation (PropT (L5 dvalue uvalue) (MemState * (local_env * (global_env * uvalue)))) :=
     fun ts ts' => forall t, ts t -> exists t', ts' t' /\ eutt  (TT × (TT × (TT × refine_uvalue))) t t'.
 
 End TopLevelRefinements.

--- a/src/rocq/Transformations/EquivExpr.v
+++ b/src/rocq/Transformations/EquivExpr.v
@@ -344,7 +344,7 @@ Module Type EquivExpr (IS : InterpreterStack) (TOP : LLVMTopLevel IS) (DT : Deno
       Qed.
 
       Lemma exp_optim_correct_phi : forall phi f g l,
-          ℑ2 (translate exp_to_instr ⟦ phi ⟧Φ (f)) g l ≈ ℑ2 (translate exp_to_instr ⟦ endo phi ⟧Φ (f)) g l.
+          ℑ2 (translate (@exp_to_instr dvalue uvalue) ⟦ phi ⟧Φ (f)) g l ≈ ℑ2 (translate (@exp_to_instr dvalue uvalue) ⟦ endo phi ⟧Φ (f)) g l.
       Proof using opt_correct.
         intros [[id []] md] f.
         induction args as [| [] args IH]; intros; [reflexivity |].
@@ -451,7 +451,7 @@ Module Type EquivExpr (IS : InterpreterStack) (TOP : LLVMTopLevel IS) (DT : Deno
       Qed.
 
       Lemma interp_cfg2_bind_eq_itree :
-        forall {R S} (t: itree instr_E R) (k: R -> itree instr_E S) g l,
+        forall {R S} (t: itree (instr_E dvalue uvalue) R) (k: R -> itree (instr_E dvalue uvalue) S) g l,
           ℑ2 (t >>= k) g l ≅
              '(l',(g',x)) <- ℑ2 t g l ;; ℑ2 (k x) g' l'.
       Proof using Type.
@@ -462,7 +462,7 @@ Module Type EquivExpr (IS : InterpreterStack) (TOP : LLVMTopLevel IS) (DT : Deno
       Qed.
 
       Lemma interp_cfg2_Tau :
-        forall {R} (t: itree instr_E R) g l,
+        forall {R} (t: itree (instr_E dvalue uvalue) R) g l,
           ℑ2 (Tau t) g l ≅ Tau (ℑ2 t g l).
       Proof using Type.
         intros.

--- a/src/rocq/Utils/IntMaps.v
+++ b/src/rocq/Utils/IntMaps.v
@@ -955,3 +955,458 @@ split.
 intros m M conv s.
 apply (IM.Raw.fold (fun k _ acc => monoid_plus M (conv k) acc) s (monoid_unit M)).
 Defined.
+
+
+
+  Lemma filter_dom_map_eq :
+    forall {A B} (f : IntMaps.IM.key -> bool) (g : A -> B) (m : IntMaps.IntMap A) ,
+      forall k e,
+        IntMaps.IM.MapsTo k e (IntMaps.IM.map g (IntMaps.IP.filter_dom f m))
+        <->
+          IntMaps.IM.MapsTo k e (IntMaps.IP.filter_dom f (IntMaps.IM.map g m)).
+  Proof.
+    intros.
+    unfold IntMaps.IP.filter_dom.
+    split; intros H.
+    - rewrite IntMaps.IP.filter_iff.
+      apply IntMaps.IP.F.map_mapsto_iff in H.
+      destruct H as [a [EQ HM]].
+      apply IntMaps.IP.filter_iff in HM.
+      destruct HM.
+      split; auto.
+      apply IntMaps.IP.F.map_mapsto_iff.
+      exists a. tauto.
+      repeat red; intros; subst; auto.
+      repeat red; intros; subst; auto.
+    - rewrite IntMaps.IP.filter_iff in H.
+      destruct H.
+      apply IntMaps.IP.F.map_mapsto_iff in H.
+      destruct H as [a [EQ HM]].
+      apply IntMaps.IP.F.map_mapsto_iff.
+      exists a. split; auto.
+      apply IntMaps.IP.filter_iff; auto.
+      repeat red; intros; subst; auto.
+      repeat red; intros; subst; auto.
+  Qed.
+
+  Lemma MapsTo_filter_true :
+    forall {A} (f : IntMaps.IM.key -> A -> bool) m,
+    forall k e,
+       (f k e = true /\ IntMaps.IM.MapsTo k e m) <->
+        IntMaps.IM.MapsTo k e (IntMaps.IP.filter f m).
+  Proof.
+    intros.
+    split; intros.
+    - apply IntMaps.IP.filter_iff.
+      + repeat red; intros; subst; auto.
+      + tauto.
+    - apply IntMaps.IP.filter_iff in H.
+      + tauto.
+      + repeat red; intros; subst; auto.
+  Qed.
+
+  Lemma MapsTo_filter_subset :
+    forall {A} (f : IntMaps.IM.key -> A -> bool) m,
+    forall k e,
+      IntMaps.IM.MapsTo k e (IntMaps.IP.filter f m) ->
+      IntMaps.IM.MapsTo k e m.
+  Proof.
+    intros.
+    apply IntMaps.IP.filter_iff in H.
+    + tauto.
+    + repeat red; intros; subst; auto.
+  Qed.
+
+  Lemma not_MapsTo_filter :
+    forall {A} (f : IntMaps.IM.key -> A -> bool) m,
+    forall k e,
+      ~ IntMaps.IM.MapsTo k e m ->
+      ~ IntMaps.IM.MapsTo k e (IntMaps.IP.filter f m).
+  Proof.
+    intros.
+    intro C.
+    apply H.
+    eapply MapsTo_filter_subset.
+    eauto.
+  Qed.
+
+  Lemma MapsTo_filter_dom_true :
+    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
+    forall k e,
+      (f k = true /\ IntMaps.IM.MapsTo k e m) <->
+        IntMaps.IM.MapsTo k e (IntMaps.IP.filter_dom f m).
+  Proof.
+    intros.
+    unfold IntMaps.IP.filter_dom.
+    rewrite <- MapsTo_filter_true.
+    tauto.
+  Qed.
+
+  Lemma MapsTo_filter_dom_subset :
+    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
+    forall k e,
+      IntMaps.IM.MapsTo k e (IntMaps.IP.filter_dom f m) ->
+      IntMaps.IM.MapsTo k e m.
+  Proof.
+    intros.
+    unfold IntMaps.IP.filter_dom.
+    eapply MapsTo_filter_subset.
+    eauto.
+  Qed.
+
+  Lemma not_MapsTo_filter_dom :
+    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
+    forall k e,
+      ~ IntMaps.IM.MapsTo k e m ->
+      ~ IntMaps.IM.MapsTo k e (IntMaps.IP.filter_dom f m).
+  Proof.
+    intros.
+    intro C.
+    apply H.
+    eapply MapsTo_filter_dom_subset.
+    eauto.
+  Qed.
+
+  Lemma find_filter_true :
+    forall {A} (f : IntMaps.IM.key -> A -> bool) (m : IntMaps.IntMap A),
+      forall k a,
+        IntMaps.IM.find k (IntMaps.IP.filter f m) = Some a <->
+          IntMaps.IM.find k m = Some a /\ (f k a = true).
+  Proof.
+    intros.
+    split; intros H.
+    - apply IntMaps.IP.F.find_mapsto_iff in H.
+      apply IntMaps.IP.filter_iff in H.
+      destruct H.
+      split; auto.
+      apply IntMaps.IP.F.find_mapsto_iff. assumption.
+      repeat red; intros; subst; auto.
+    - destruct H.
+      apply IntMaps.IP.F.find_mapsto_iff.
+      apply IntMaps.IP.filter_iff.
+      repeat red; intros; subst; auto.
+      apply IntMaps.IP.F.find_mapsto_iff in H.
+      split; auto.
+  Qed.
+
+  Lemma find_filter_dom_true :
+    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
+      forall k a,
+        IntMaps.IM.find k (IntMaps.IP.filter_dom f m) = Some a <->
+          IntMaps.IM.find k m = Some a /\ (f k = true).
+  Proof.
+    intros.
+    unfold IntMaps.IP.filter_dom.
+    apply find_filter_true.
+  Qed.
+
+  Lemma IntMaps_find_None :
+    forall {A} (k : IntMaps.IM.key) (m:IntMaps.IntMap A),
+      IntMaps.IM.find k m = None <-> forall e, ~ IntMaps.IM.MapsTo k e m.
+  Proof.
+    intros.
+    split; intros H.
+    - intros. intro C.
+      apply IntMaps.IP.F.find_mapsto_iff in C.
+      rewrite H in C. inversion C.
+    - destruct (IntMaps.IM.find k m) eqn:EQ; auto.
+      apply IntMaps.IP.F.find_mapsto_iff in EQ.
+      apply H in EQ.
+      contradiction.
+  Qed.
+
+  Lemma find_filter_None :
+    forall {A} (f : IntMaps.IM.key -> A -> bool) (m : IntMaps.IntMap A),
+    forall k,
+      IntMaps.IM.find k m = None ->
+        IntMaps.IM.find k (IntMaps.IP.filter f m) = None.
+  Proof.
+    intros.
+    rewrite IntMaps_find_None.
+    intros e C.
+    rewrite IntMaps_find_None in H.
+    specialize (H e).
+    apply H.
+    apply (MapsTo_filter_subset f m).
+    auto.
+  Qed.
+
+  Lemma find_filter_dom_None :
+    forall {A} (f : IntMaps.IM.key -> bool) (m : IntMaps.IntMap A),
+    forall k,
+      IntMaps.IM.find k m = None ->
+        IntMaps.IM.find k (IntMaps.IP.filter_dom f m) = None.
+  Proof.
+    intros.
+    unfold IntMaps.IP.filter_dom.
+    apply find_filter_None.
+    assumption.
+  Qed.
+
+  Lemma find_filter_dom_false :
+    forall {elt m k f},
+      f k = false ->
+      IntMaps.IM.find (elt:=elt) k (IntMaps.IP.filter_dom f m) = None.
+  Proof.
+    intros elt m k f F.
+    unfold IntMaps.IP.filter_dom.
+    apply IntMaps_find_None.
+    intros e CONTRA.
+    apply IntMaps.IP.filter_iff in CONTRA; try typeclasses eauto.
+    destruct CONTRA as [_ CONTRA].
+    rewrite F in CONTRA; inv CONTRA.
+  Qed.
+
+  #[global] Instance filter_dom_Proper {elt f} :
+    Proper (IntMaps.IM.Equal (elt:=elt) ==> IntMaps.IM.Equal) (IntMaps.IP.filter_dom f).
+  Proof.
+    unfold Proper, respectful.
+    intros x y EQ.
+    red.
+    intros y0.
+    destruct (IntMaps.IM.find (elt:=elt) y0 (IntMaps.IP.filter_dom f x)) eqn:FIND.
+    - apply find_filter_dom_true in FIND as (FIND&TRUE).
+      red in EQ.
+      rewrite EQ in FIND.
+      symmetry.
+      apply find_filter_dom_true.
+      split; auto.
+    - (* Two ways for this to be none... Either y0 was filtered out,
+           or y0 was not in the original map *)
+      destruct (IntMaps.IM.find (elt:=elt) y0 x) eqn:FIND'.
+      + destruct (f y0) eqn:F.
+        * epose proof find_filter_dom_true f x y0 e.
+          destruct H.
+          forward H0; auto.
+          rewrite FIND in H0.
+          discriminate.
+        * symmetry.
+          apply find_filter_dom_false; auto.
+      + symmetry.
+        apply find_filter_dom_None.
+        rewrite <- EQ.
+        auto.
+  Qed.
+
+  Lemma IntMaps_map_empty_Equal :
+    forall {A B} (f : A -> B),
+      IntMaps.IM.Equal (IntMaps.IM.map f (IntMaps.IM.empty A)) (IntMaps.IM.empty B).
+  Proof.
+    intros A B f.
+    red.
+    intros y.
+    cbn; auto.
+  Qed.
+
+  Lemma IntMaps_map_id_Equal :
+    forall {A} (m : IntMaps.IntMap A),
+      IntMaps.IM.Equal (IntMaps.IM.map id m) m.
+  Proof.
+    intros A B f.
+    destruct (IntMaps.IM.find (elt:=A) f B) eqn:FIND.
+    - apply IntMaps.IP.F.find_mapsto_iff.
+      apply IntMaps.IP.F.find_mapsto_iff in FIND.
+      apply IntMaps.IP.F.map_mapsto_iff.
+      exists a.
+      split; cbn; eauto.
+    - eapply IntMaps_find_None.
+      intros e CONTRA.
+      apply IntMaps_find_None with (e:=e) in FIND.
+      apply FIND.
+      apply IntMaps.IP.F.map_mapsto_iff in CONTRA.
+      destruct CONTRA as (a & H & CONTRA); subst; auto.
+  Qed.
+
+  Lemma IntMaps_map_compose_Equal :
+    forall {A B C} (f : A -> B) (g : B -> C) (m : IntMaps.IntMap A),
+      IntMaps.IM.Equal (IntMaps.IM.map (fun a => g (f a)) m) (IntMaps.IM.map g (IntMaps.IM.map f m)).
+  Proof.
+    intros A B C f g m.
+    red.
+    intros y.
+    destruct (IntMaps.IM.find (elt:=C) y (IntMaps.IM.map g (IntMaps.IM.map f m))) eqn:FIND.
+    - apply IntMaps.IP.F.find_mapsto_iff.
+      apply IntMaps.IP.F.find_mapsto_iff in FIND.
+      apply IntMaps.IP.F.map_mapsto_iff in FIND.
+      destruct FIND as (?&?&FIND).
+      apply IntMaps.IP.F.map_mapsto_iff in FIND.
+      destruct FIND as (?&?&?).
+      subst.
+      apply IntMaps.IP.F.map_mapsto_iff.
+      exists x0.
+      split; cbn; eauto.
+    - eapply IntMaps_find_None.
+      intros e CONTRA.
+      apply IntMaps_find_None with (e:=e) in FIND.
+      apply FIND.
+      apply IntMaps.IP.F.map_mapsto_iff in CONTRA.
+      destruct CONTRA as (a & H & CONTRA); subst; auto.
+      apply IntMaps.IP.F.map_mapsto_iff.
+      exists (f a).
+      split; eauto.
+      apply IntMaps.IP.F.map_mapsto_iff.
+      exists a.
+      split; eauto.
+  Qed.
+
+  Lemma IntMaps_map_add_Equal :
+    forall {A B} (f : A -> B) (m : IntMaps.IntMap A) k a,
+      IntMaps.IM.Equal (IntMaps.IM.map f (IntMaps.IM.add k a m))
+        (IntMaps.IM.add k (f a) (IntMaps.IM.map f m)).
+  Proof.
+    intros A B f m k a.
+    red.
+    intros y.
+    destruct (IntMaps.IM.find (elt:=B) y (IntMaps.IM.add k (f a) (IntMaps.IM.map f m))) eqn:FIND.
+    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
+      + rewrite IntMaps.IP.F.add_eq_o in FIND; eauto.
+        inv FIND.
+        apply IntMaps.IP.F.find_mapsto_iff.
+        apply IntMaps.IP.F.map_mapsto_iff.
+        exists a.
+        split; eauto.
+        apply IntMaps.IP.F.add_mapsto_iff;
+          eauto.
+      + rewrite IntMaps.IP.F.add_neq_o in FIND; eauto.
+        apply IntMaps.IP.F.find_mapsto_iff in FIND.
+        eapply IntMaps.IP.F.map_mapsto_iff in FIND.
+        destruct FIND as (?&?&?); subst.
+
+        apply IntMaps.IP.F.find_mapsto_iff.
+        apply IntMaps.IP.F.map_mapsto_iff.
+        exists x.
+        split; eauto.
+        apply IntMaps.IP.F.add_mapsto_iff;
+          eauto.
+    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
+      + rewrite IntMaps.IP.F.add_eq_o in FIND; eauto.
+        discriminate.
+      + rewrite IntMaps.IP.F.add_neq_o in FIND; eauto.
+        eapply IntMaps_find_None.
+        intros e CONTRA.
+        apply IntMaps_find_None with (e:=e) in FIND.
+        apply FIND.
+        apply IntMaps.IP.F.map_mapsto_iff in CONTRA.
+        destruct CONTRA as (a' & H & CONTRA); subst; auto.        
+        apply IntMaps.IP.F.map_mapsto_iff.
+        exists a'.
+        split; eauto.
+        apply IntMaps.IP.F.add_neq_mapsto_iff in CONTRA; eauto.
+  Qed.
+
+  Lemma IntMaps_map_list_map_Equal :
+    forall {A B} (f : A -> B) l,
+      IntMaps.IM.Equal (IntMaps.IM.map f (IntMaps.IP.of_list l)) (IntMaps.IP.of_list (List.map (fun '(i, x) => (i, f x)) l)).
+  Proof.
+    intros A B f l.
+    induction l.
+    - cbn.
+      apply IntMaps_map_empty_Equal.
+    - cbn.
+      unfold IntMaps.IP.uncurry in *.
+      destruct a.
+      cbn in *.
+      rewrite <- IHl.
+      eapply IntMaps_map_add_Equal.
+  Qed.
+
+  Lemma IntMaps_filter_dom_add_true_Equal :
+    forall {A} f k (a : A) m,
+      f k = true ->
+      IntMaps.IM.Equal
+        (IntMaps.IP.filter_dom f (IntMaps.IM.add k a m))
+        (IntMaps.IM.add k a (IntMaps.IP.filter_dom f m)).
+  Proof.
+    intros A f k a m F.
+    red.
+    intros y.
+    destruct (IntMaps.IM.find (elt:=A) y (IntMaps.IM.add k a (IntMaps.IP.filter_dom f m))) eqn:FIND.
+    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
+      + rewrite IntMaps.IP.F.add_eq_o in FIND; eauto.
+        inv FIND.
+        apply find_filter_dom_true.
+        split; eauto.
+        rewrite IntMaps.IP.F.add_eq_o; eauto.
+      + rewrite IntMaps.IP.F.add_neq_o in FIND; eauto.
+        apply find_filter_dom_true in FIND.
+        destruct FIND.
+        apply find_filter_dom_true.
+        split; eauto.
+        rewrite IntMaps.IP.F.add_neq_o; eauto.
+    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
+      + rewrite IntMaps.IP.F.add_eq_o in FIND; eauto.
+        discriminate.
+      + rewrite IntMaps.IP.F.add_neq_o in FIND; eauto.
+        destruct (IntMaps.IM.find (elt:=A) y m) eqn:FIND'.
+        * destruct (f y) eqn:FY.
+          { pose proof conj FIND' FY.
+            apply find_filter_dom_true in H.
+            rewrite FIND in H.
+            discriminate.
+          }
+
+          eapply find_filter_dom_false; eauto.
+        * eapply find_filter_dom_None.
+          rewrite IntMaps.IP.F.add_neq_o; eauto.
+  Qed.
+
+  Lemma IntMaps_filter_dom_add_false_Equal :
+    forall {A} f k (a : A) m,
+      f k = false ->
+      IntMaps.IM.Equal
+        (IntMaps.IP.filter_dom f (IntMaps.IM.add k a m))
+        (IntMaps.IP.filter_dom f m).
+  Proof.
+    intros A f k a m F.
+    intros y.
+    destruct (IntMaps.IM.find (elt:=A) y (IntMaps.IP.filter_dom f m)) eqn:FIND.
+    - apply find_filter_dom_true in FIND.
+      destruct FIND.
+
+      pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
+      + rewrite F in H0; inv H0.
+      + apply find_filter_dom_true.
+        rewrite IntMaps.IP.F.add_neq_o; eauto.
+    - pose proof (Z.eq_dec y k) as [EQ | NEQ]; subst.
+      + eapply find_filter_dom_false; eauto.
+      + destruct (IntMaps.IM.find (elt:=A) y m) eqn:FIND'.
+        * destruct (f y) eqn:FY.
+          { pose proof conj FIND' FY.
+            apply find_filter_dom_true in H.
+            rewrite FIND in H.
+            discriminate.
+          }
+          eapply find_filter_dom_false; eauto.
+        * eapply find_filter_dom_None.
+          rewrite IntMaps.IP.F.add_neq_o; eauto.
+  Qed.
+
+  Lemma IntMaps_filter_dom_list_filter_Equal :
+    forall {A : Type} (f : IntMaps.IM.key -> bool) (l : list (IntMaps.IM.key * A)),
+      IntMaps.IM.Equal (IntMaps.IP.filter_dom f (IntMaps.IP.of_list l))
+        (IntMaps.IP.of_list (List.filter (fun '(i, x) => f i) l)).
+  Proof.
+    intros A f l.
+    induction l.
+    - cbn.
+      reflexivity.
+    - Opaque IntMaps.IM.Equal.
+      Opaque IntMaps.IP.filter_dom.
+      destruct a; cbn.
+      break_match_goal.
+      + cbn.
+        unfold IntMaps.IP.uncurry in *.
+        cbn.
+        rewrite IntMaps_filter_dom_add_true_Equal; eauto.
+        rewrite IHl.
+        reflexivity.
+      + cbn.
+        unfold IntMaps.IP.uncurry in *.
+        cbn.
+        rewrite IntMaps_filter_dom_add_false_Equal; eauto.
+
+        Transparent IntMaps.IM.Equal.
+        Transparent IntMaps.IP.filter_dom.
+  Qed.
+
+

--- a/src/rocq/Utils/ListUtil.v
+++ b/src/rocq/Utils/ListUtil.v
@@ -1836,6 +1836,17 @@ Proof.
 Qed.
 
 
+  Lemma Forall2_cons_inversion :
+    forall {A B} f (x:A) (y:B) xs ys,
+      Forall2 f (x::xs) (y::ys) -> f x y /\ Forall2 f xs ys.
+  Proof.
+    intros.
+    inversion H; subst.
+    tauto.
+  Qed.
+
+
+
 Lemma Forall2_repeat_OOM : forall {A B} (f : A -> OOM B) (a:A) (b:B) n (l:list B),
     f a = ret b ->
     Forall2 (fun a b => f a = ret b) (repeat a n) l ->
@@ -1910,6 +1921,7 @@ Proof.
       destruct (IH _ _ _ HL x X0) as [c [HFC HR]].
       exists c. split; auto. right. assumption.
 Qed.
+
 
 
 (*

--- a/src/rocq/Utils/NoEvent.v
+++ b/src/rocq/Utils/NoEvent.v
@@ -1138,13 +1138,14 @@ Section DeterministicSingleton.
   Proof using. Admitted.
 *)
 End DeterministicSingleton.
-
+(*
 Require Import MemoryAddress.
 Require Import Sizeof.
 
-Module PICK_REMOVE (ADDR : ADDRESS) (IP : INTPTR) (SIZE : Sizeof) (Events : LLVM_INTERACTIONS ADDR IP SIZE).
+Module PICK_REMOVE (ADDR : ADDRESS) (IP : INTPTR) (SZ : SIZEOF) (Events : LLVM_INTERACTIONS ADDR IP SIZE).
   Import Events.
 
   #[local] Parameter remove_pick_ub : itree (ExternalCallE +' PickUvalueE +' UBE +' DebugE +' FailureE) ~> itree (ExternalCallE +' DebugE +' FailureE).
   #[local] Parameter deterministic_vellvm : forall R, itree L0 R -> Prop.
 End PICK_REMOVE.
+*)


### PR DESCRIPTION
One pass of module refactoring.

- defunctorizes `LLVMEvents` so that the events are polymorphic
- packages the `DV` modules into the `LLVMParams` structures so there are fewer things to pass around
- propagates those changes everywhere

There is still a lot of detangling / cleanup to do.  I'm also not 100% sure that this improves compilation times at all (yet).