### PR TITLE
Dvalue refactor

### DIFF
--- a/src/_RocqProject
+++ b/src/_RocqProject
@@ -44,7 +44,7 @@
 ./rocq/Semantics/Interfaces/IPtr.v
 ./rocq/Semantics/Interfaces/Provenance.v
 ./rocq/Semantics/Interfaces/Sizeof.v
-./rocq/Semantics/Interfaces/Address.v
+./rocq/Semantics/Interfaces/Pointer.v
 ./rocq/Semantics/Interfaces/Params.v
 ./rocq/Semantics/DynamicValues.v
 ./rocq/Semantics/LLVMEvents.v
@@ -52,7 +52,7 @@
 ./rocq/Semantics/Implementations/IPtrFinite.v
 ./rocq/Semantics/Implementations/IPtrInfinite.v
 ./rocq/Semantics/Implementations/Provenance.v
-./rocq/Semantics/Implementations/Address.v
+./rocq/Semantics/Implementations/Pointer.v
 ./rocq/Semantics/Implementations/Sizeof.v
 ./rocq/Semantics/Implementations/ParamsV.v
 

--- a/src/ml/assertion.ml
+++ b/src/ml/assertion.ml
@@ -205,6 +205,7 @@ let dvalue_eq_assertion name (ty:DynamicTypes.dtyp) (expected : DV.dvalue) (got 
   begin match expected with
   | DVALUE_Base (DV.DVALUE_Poison _) -> compare_dvalues_exn expected result msg
   | _ ->
+     (* Use the semantic "cmp eq" for these types *)
      begin match ty with
      | DTYPE_Base (DTYPE_I _)
      | DTYPE_Base DTYPE_Iptr
@@ -213,12 +214,6 @@ let dvalue_eq_assertion name (ty:DynamicTypes.dtyp) (expected : DV.dvalue) (got 
         let v = ocaml_of_EOU @@ Compare.eval_icmp Interpreter.params false Eq expected result in
         if dvalue_i1_to_bool v then () else
           failwith msg
-     (* | DTYPE_FP _ -> (\* floating point comparison *\) *)
-     (*    (\* compare_dvalues_exn expected result msg         *\) *)
-     (*    let v = Assertion.ocaml_of_EOU @@ DV.eval_fcmp Interpreter.params FOeq expected result in *)
-     (*    if dvalue_i1_to_bool v then () else *)
-     (*      failwith msg *)
-     (* | DTYPE_Vector _  -> failwith "TODO: comparison on vectors" *)
      | _ -> (* Best effort comparison of other types *)
         compare_dvalues_exn expected result msg
      end

--- a/src/ml/assertion.ml
+++ b/src/ml/assertion.ml
@@ -33,11 +33,11 @@ let typ_to_dtyp_base (typ : LLVMAst.typ) : DynamicTypes.dtyp_base =
 
 let rec typ_to_dtyp (typ : LLVMAst.typ) : DynamicTypes.dtyp =
   match typ with
-  | TYPE_Array (sz, dtyp) -> DTYPE_Array (sz, typ_to_dtyp dtyp)
   | TYPE_Struct dtyps -> DTYPE_Struct (false, List.map typ_to_dtyp dtyps)
   | TYPE_Packed_struct dtyps ->
       DTYPE_Struct (true, List.map typ_to_dtyp dtyps)
-  | TYPE_Vector (sz, dtyp) -> DTYPE_Vector (sz, typ_to_dtyp_base dtyp)
+  | TYPE_Array (sz, dtyp) -> DTYPE_Array (false, sz, typ_to_dtyp dtyp)
+  | TYPE_Vector (sz, dtyp) -> DTYPE_Array (true, sz, typ_to_dtyp dtyp)
   | _ -> DTYPE_Base (typ_to_dtyp_base typ)
 
 let ocaml_of_EOU (c : 'x EOU.coq_EOU) : 'x =
@@ -76,19 +76,16 @@ let rec texp_to_dvalue ((typ, exp) : LLVMAst.typ * LLVMAst.typ LLVMAst.exp) : DV
         let s = Camlcoq.camlstring_of_coqstring (ShowAST.show_float_syntax f) in
         failwith @@ Printf.sprintf "assertion.ml: texp_to_dvalue failed float conversion: %s" s
      end
-  | TYPE_Array _, EXP_Array (t, elts) ->
-     let dt = typ_to_dtyp t in
-     DVALUE_Array (dt, (List.map texp_to_dvalue elts))
   | TYPE_Struct _, EXP_Struct elts ->
       DVALUE_Struct (false, List.map texp_to_dvalue elts)
   | TYPE_Packed_struct _, EXP_Packed_struct elts ->
       DVALUE_Struct (true, List.map texp_to_dvalue elts)
+  | TYPE_Array _, EXP_Array (t, elts) ->
+     let dt = typ_to_dtyp t in
+     DVALUE_Array (false, dt, (List.map texp_to_dvalue elts))
   | TYPE_Vector _, EXP_Vector (t, elts) ->
      let dt = typ_to_dtyp t in
-     DVALUE_Vector
-       (dt,
-        (List.map (fun x -> dvalue_to_dvalue_base_exn (texp_to_dvalue x)) elts)
-       )
+     DVALUE_Array (true, dt, (List.map texp_to_dvalue elts))
   | _, EXP_Poison -> (DVALUE_Base (DVALUE_Poison (typ_to_dtyp typ)))
   | _, _ ->
       failwith

--- a/src/ml/assertion.ml
+++ b/src/ml/assertion.ml
@@ -20,24 +20,25 @@ type test =
 
 (* Directly converts a piece of syntax to a dtyp without going through
    semantic interpretation. Only works on literals. *)
-let rec typ_to_dtyp (typ : LLVMAst.typ) : DynamicTypes.dtyp =
+let typ_to_dtyp_base (typ : LLVMAst.typ) : DynamicTypes.dtyp_base =
   match typ with
   | TYPE_Void -> DTYPE_Void
   | TYPE_I i -> DTYPE_I i
   | TYPE_FP FP_float -> DTYPE_FP FP_float
   | TYPE_FP FP_double -> DTYPE_FP FP_double
-  | TYPE_Array (sz, dtyp) -> DTYPE_Array (sz, typ_to_dtyp dtyp)
-  | TYPE_Struct dtyps -> DTYPE_Struct (List.map typ_to_dtyp dtyps)
-  | TYPE_Packed_struct dtyps ->
-      DTYPE_Packed_struct (List.map typ_to_dtyp dtyps)
-  | TYPE_Vector (sz, dtyp) -> DTYPE_Vector (sz, typ_to_dtyp dtyp)
   | _ ->
       failwith
         (Printf.sprintf "Assertion includes unsupported type:\n\t %s"
            (string_of_typ typ) )
 
-
-let addr_v = Address0.coq_AddressV IPtrInfinite.coq_IPZ
+let rec typ_to_dtyp (typ : LLVMAst.typ) : DynamicTypes.dtyp =
+  match typ with
+  | TYPE_Array (sz, dtyp) -> DTYPE_Array (sz, typ_to_dtyp dtyp)
+  | TYPE_Struct dtyps -> DTYPE_Struct (false, List.map typ_to_dtyp dtyps)
+  | TYPE_Packed_struct dtyps ->
+      DTYPE_Struct (true, List.map typ_to_dtyp dtyps)
+  | TYPE_Vector (sz, dtyp) -> DTYPE_Vector (sz, typ_to_dtyp_base dtyp)
+  | _ -> DTYPE_Base (typ_to_dtyp_base typ)
 
 let ocaml_of_EOU (c : 'x EOU.coq_EOU) : 'x =
   match c with
@@ -47,25 +48,30 @@ let ocaml_of_EOU (c : 'x EOU.coq_EOU) : 'x =
   | Coq_raise_ret x -> x
 
 
+let dvalue_to_dvalue_base_exn (dv : dvalue) : dvalue_base =
+  match dv with
+  | DVALUE_Base dv -> dv
+  | _ -> failwith "ocaml: dvalue_to_dvalue_base cast failed"
+
 let rec texp_to_dvalue ((typ, exp) : LLVMAst.typ * LLVMAst.typ LLVMAst.exp) : DV.dvalue =
   match (typ, exp) with
   (* Allow null pointers literals *)
   | TYPE_Pointer _, EXP_Null ->
-      DVALUE_Addr addr_v.null
+      DVALUE_Base (DVALUE_Pointer Interpreter.pointer_v.null)
   | TYPE_I bits, EXP_Integer x ->                 
-     ocaml_of_EOU
-       (DV.coerce_integer_to_int Interpreter.params (Some bits) (Denotation.denote_int_syntax x))
+     DVALUE_Base (ocaml_of_EOU
+       (DV.coerce_integer_to_int Interpreter.params (Some bits) (Denotation.denote_int_syntax x)))
 
   | TYPE_FP FP_float, EXP_Float f ->
      begin match float32_of_float_syntax f with
-     | Some v ->  DVALUE_Float v
+     | Some v ->  DVALUE_Base (DVALUE_Float v)
      | None ->
         let s = Camlcoq.camlstring_of_coqstring (ShowAST.show_float_syntax f) in
         failwith @@ Printf.sprintf "assertion.ml: texp_to_dvalue failed float32 conversion: %s" s
      end
   | TYPE_FP FP_double, EXP_Float f ->
      begin match float_of_float_syntax f with
-     | Some v ->  DVALUE_Double v
+     | Some v ->  DVALUE_Base (DVALUE_Double v)
      | None ->
         let s = Camlcoq.camlstring_of_coqstring (ShowAST.show_float_syntax f) in
         failwith @@ Printf.sprintf "assertion.ml: texp_to_dvalue failed float conversion: %s" s
@@ -74,13 +80,16 @@ let rec texp_to_dvalue ((typ, exp) : LLVMAst.typ * LLVMAst.typ LLVMAst.exp) : DV
      let dt = typ_to_dtyp t in
      DVALUE_Array (dt, (List.map texp_to_dvalue elts))
   | TYPE_Struct _, EXP_Struct elts ->
-      DVALUE_Struct (List.map texp_to_dvalue elts)
+      DVALUE_Struct (false, List.map texp_to_dvalue elts)
   | TYPE_Packed_struct _, EXP_Packed_struct elts ->
-      DVALUE_Packed_struct (List.map texp_to_dvalue elts)
+      DVALUE_Struct (true, List.map texp_to_dvalue elts)
   | TYPE_Vector _, EXP_Vector (t, elts) ->
      let dt = typ_to_dtyp t in
-     DVALUE_Vector (dt, (List.map texp_to_dvalue elts))
-  | _, EXP_Poison -> (DVALUE_Poison (typ_to_dtyp typ))
+     DVALUE_Vector
+       (dt,
+        (List.map (fun x -> dvalue_to_dvalue_base_exn (texp_to_dvalue x)) elts)
+       )
+  | _, EXP_Poison -> (DVALUE_Base (DVALUE_Poison (typ_to_dtyp typ)))
   | _, _ ->
       failwith
         (Printf.sprintf "Assertion includes unsupported expression:\n\t%s %s"
@@ -181,11 +190,11 @@ let compare_dvalues_exn expected got msg : unit =
 
 let dvalue_i1_to_bool (dv : DV.dvalue) : bool =
   match dv with 
-  | DV.DVALUE_I (sz,bitint) ->  Integers.eq sz bitint (Integers.one sz)
+  | DVALUE_Base (DV.DVALUE_I (sz,bitint)) ->  Integers.eq sz bitint (Integers.one sz)
   | _ -> failwith "non-i1 value"
 
 
-let dvalue_eq_assertion name ty (expected : DV.dvalue) (got : unit -> DV.dvalue) () =
+let dvalue_eq_assertion name (ty:DynamicTypes.dtyp) (expected : DV.dvalue) (got : unit -> DV.dvalue) () =
   let open DynamicTypes in
   Platform.verb (Printf.sprintf "running ASSERT in %s\n" name) ;  
   let result = got () in
@@ -194,12 +203,12 @@ let dvalue_eq_assertion name ty (expected : DV.dvalue) (got : unit -> DV.dvalue)
       (Interpreter.string_of_dvalue result) (Interpreter.string_of_dvalue expected) 
   in
   begin match expected with
-  | DV.DVALUE_Poison _ -> compare_dvalues_exn expected result msg
+  | DVALUE_Base (DV.DVALUE_Poison _) -> compare_dvalues_exn expected result msg
   | _ ->
      begin match ty with
-     | DTYPE_I _ 
-     | DTYPE_Iptr
-     | DTYPE_Pointer ->
+     | DTYPE_Base (DTYPE_I _)
+     | DTYPE_Base DTYPE_Iptr
+     | DTYPE_Base DTYPE_Pointer ->
         (* integral comparison *)
         let v = ocaml_of_EOU @@ Compare.eval_icmp Interpreter.params false Eq expected result in
         if dvalue_i1_to_bool v then () else

--- a/src/ml/interpreter.ml
+++ b/src/ml/interpreter.ml
@@ -12,7 +12,7 @@ module DV = DynamicValues
 
 let iptr   = IPtrInfinite.coq_IPZ
 let params = ParamsV.coq_ParamsV iptr
-let addr_v = Address0.coq_AddressV iptr
+let pointer_v = Pointer0.coq_PointerV iptr
 
 open LLVMEvents
 

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -134,37 +134,52 @@ Section Denotation.
     | FP_float =>
         match float32_of_float_syntax f with
         | None   => raise_error ("bad float literal: " ++ (show f))
-        | Some f => ret (DVALUE_Float f)
+        | Some f => ret (DVALUE_Base (DVALUE_Float f))
         end
     | FP_double =>
         match float_of_float_syntax f with
         | None   => raise_error ("bad double literal: " ++ (show f))
-        | Some f => ret (DVALUE_Double f)
+        | Some f => ret (DVALUE_Base (DVALUE_Double f))
         end
     | _ => raise_error "unsupported float type"
     end.
-  
-  Fixpoint freeze {E} `{DrawE -< E} (dv : dvalue) : itree E dvalue :=
+
+  Definition freeze_base {E} `{DrawE -< E} `{FailureE -< E} `{OOME -< E} `{UBE -< E} (dv : dvalue_base) : itree E dvalue_base :=
     match dv with
-    | DVALUE_Poison dt => draw dt
-    | DVALUE_Struct fields => 
+    | DVALUE_Poison dt =>
+        dv <- draw dt ;;
+        lift (dvalue_to_dvalue_base dv)
+    | _ => ret dv
+    end.
+    
+  Fixpoint freeze {E} `{DrawE -< E} `{FailureE -< E} `{OOME -< E} `{UBE -< E} (dv : dvalue) : itree E dvalue :=
+    match dv with
+    | DVALUE_Base (DVALUE_Poison dt) => draw dt
+    | DVALUE_Struct p fields => 
         val <- map_monad freeze fields;;
-        ret (DVALUE_Struct val)
-    | DVALUE_Packed_struct fields => 
-        val <- map_monad freeze fields;;
-        ret (DVALUE_Packed_struct val)
+        ret (DVALUE_Struct p val)
     | DVALUE_Array τ elts => 
         val <- map_monad freeze elts;;
         ret (DVALUE_Array τ val)
     | DVALUE_Vector τ elts =>
-        val <- map_monad freeze elts;;
+        val <- map_monad freeze_base elts;;
         ret (DVALUE_Vector τ val)
     | _ => ret dv
     end.
+
+  Definition NONE := DVALUE_Base (DVALUE_None).
   
-  Fixpoint denote_exp
-    (top:option dtyp) (o:exp dtyp) {struct o} : MCFGtop dvalue :=
-    let eval_texp '(dt,ex) := denote_exp (Some dt) ex
+  Fixpoint denote_exp (top:option dtyp) (o:exp dtyp) {struct o} : MCFGtop dvalue :=
+    let denote_exp_base top o :=
+      x <- denote_exp top o ;;
+      lift (dvalue_to_dvalue_base x)
+    in
+    let eval_texp '(dt,ex) :=
+      denote_exp (Some dt) ex
+    in
+    let eval_texp_base '(dt, ex) :=
+      x <- denote_exp (Some dt) ex ;;
+      lift (dvalue_to_dvalue_base x)
     in
     match o with
     | EXP_Ident i => lookup_id i
@@ -172,8 +187,8 @@ Section Denotation.
     | EXP_Integer x =>
         match top with
         | None                => raise ("denote_exp given untyped EXP_Integer")
-        | Some (DTYPE_I bits) => lift (coerce_integer_to_int (Some bits) (denote_int_syntax x))
-        | Some DTYPE_Iptr     => lift (coerce_integer_to_int None (denote_int_syntax x))
+        | Some (DTYPE_I bits) => DVALUE_Base <$> (lift (coerce_integer_to_int (Some bits) (denote_int_syntax x)))
+        | Some DTYPE_Iptr     => DVALUE_Base <$> (lift (coerce_integer_to_int None (denote_int_syntax x)))
         | Some typ            => raise ("bad type for constant int: " ++ show typ)
         end
 
@@ -186,11 +201,11 @@ Section Denotation.
 
     | EXP_Bool b =>
       match b with
-      | true  => ret (DVALUE_I 1 VellvmIntegers.one)
-      | false => ret (DVALUE_I 1 VellvmIntegers.zero)
+      | true  => ret (DVALUE_Base (DVALUE_I 1 VellvmIntegers.one))
+      | false => ret (DVALUE_Base (DVALUE_I 1 VellvmIntegers.zero))
       end
  
-    | EXP_Null => ret (DVALUE_Addr null)
+    | EXP_Null => ret (DVALUE_Base (DVALUE_Pointer null))
                      
     | EXP_Zero_initializer =>
       match top with
@@ -212,22 +227,22 @@ Section Denotation.
     | EXP_Poison =>
         match top with
         | None   => raise ("denote_exp given untyped EXP_Poison")
-        | Some t => ret (DVALUE_Poison t)
+        | Some t => ret (DVALUE_Base (DVALUE_Poison t))
         end
 
     (* Question: should we do any typechecking for aggregate types here? *)
     (* Option 1: do no typechecking: *)
     | EXP_Struct es =>
         vs <- map_monad eval_texp es ;;
-        ret (DVALUE_Struct vs)
+        ret (DVALUE_Struct false vs)
 
     (* Option 2: do a little bit of typechecking *)
     | EXP_Packed_struct es =>
         match top with
         | None => raise ("denote_exp given untyped EXP_Struct")
-        | Some (DTYPE_Packed_struct _) =>
+        | Some (DTYPE_Struct true _) =>
             vs <- map_monad eval_texp es ;;
-            ret (DVALUE_Packed_struct vs)
+            ret (DVALUE_Struct true vs)
         | _ => raise ("bad type for VALUE_Packed_struct")
         end
 
@@ -236,7 +251,7 @@ Section Denotation.
       ret (DVALUE_Array t vs)
 
     | EXP_Vector t es =>
-      vs <- map_monad eval_texp es ;;
+      vs <- map_monad eval_texp_base es ;;
       ret (DVALUE_Vector t vs)
 
     | OP_IBinop iop dt op1 op2 =>
@@ -281,7 +296,7 @@ Section Denotation.
 
     | OP_InsertElement (dt_vec, vecop) (dt_elt, eltop) (dt_idx, idx) =>
         vec <- denote_exp (Some dt_vec) vecop ;;
-        elt <- denote_exp (Some dt_elt) eltop ;;
+        elt <- denote_exp_base (Some dt_elt) eltop ;;
         idx <- denote_exp (Some dt_idx) idx ;;
         lift (insert_element vec elt idx)
 
@@ -309,13 +324,13 @@ Section Denotation.
     | EXP_Metadata md =>
         (* METADATA TODO - it isn't clear what the denotations should be *)
         match md with
-        | METADATA_Null => ret (DVALUE_Addr null)
-        | METADATA_Id _ => ret DVALUE_None
+        | METADATA_Null => ret (DVALUE_Base (DVALUE_Pointer null))
+        | METADATA_Id _ => ret NONE
         | METADATA_Const tv => eval_texp tv
-        | METADATA_Node _ => ret DVALUE_None
-        | METADATA_Pair _ _ => ret DVALUE_None
-        | METADATA_Debug _ _ => ret DVALUE_None
-        | METADATA_File_info _ => ret DVALUE_None
+        | METADATA_Node _ => ret NONE
+        | METADATA_Pair _ _ => ret NONE
+        | METADATA_Debug _ _ => ret NONE
+        | METADATA_File_info _ => ret NONE
         end
 
     | EXP_Asm _ _ _ _ template _ =>
@@ -326,7 +341,7 @@ Section Denotation.
         | None => raise ("denote_exp given untyped EXP_Splat")
         | Some (DTYPE_Vector sz t) =>
             (* use the type from the splat elt *)
-            v <- eval_texp elt ;;
+            v <- eval_texp_base elt ;;
             (* this could be very expensive if the vector is big *)
             ret (DVALUE_Vector t (List.repeat v (N.to_nat sz)))
         | Some _ => raise ("denote_exp given EXP_Splat with non-vector type")
@@ -365,19 +380,19 @@ Section Denotation.
       (* SAZ: not clear whether this comparison implies "samesign" or not *)
       dv <- lift (eval_icmp false Eq loaded_v cmp_v);;
       match dv with
-      | DVALUE_I 1 comparison_bit =>
+      | DVALUE_Base (DVALUE_I 1 comparison_bit) =>
           if equ comparison_bit one then
             (* They compared as equal: perform the write to memory *)
             store cmp_ty ptr_v new_v ;;
             (* return a struct with the loaded value and "true" *)
-            let ret_v := DVALUE_Struct [loaded_v; DVALUE_I 1 one] in
+            let ret_v := DVALUE_Struct false [loaded_v; DVALUE_Base (DVALUE_I 1 one)] in
             lwrite id ret_v
           else
             (* They compared as distinct: do not perform the write to memory *)
             (* return a struct with the loaded value and "false" *)
-            let ret_v := DVALUE_Struct [loaded_v; DVALUE_I 1 zero] in
+            let ret_v := DVALUE_Struct false [loaded_v; DVALUE_Base (DVALUE_I 1 zero)] in
             lwrite id ret_v
-      | DVALUE_Poison dt => raiseUB ("comparing poison in atomiccmpxchg.")
+      | DVALUE_Base (DVALUE_Poison dt) => raiseUB ("comparing poison in atomiccmpxchg.")
       | _ => raise ("Br got non-bool value")
       end
     else
@@ -465,7 +480,7 @@ Section Denotation.
   (* An instruction has only side-effects, it therefore returns [unit] *)
   Definition denote_instr
     (i: (instr_id * instr dtyp * list (metadata dtyp)))
-    (varargs : option addr) : CFGtop unit :=
+    (varargs : option ptr) : CFGtop unit :=
     
     let '(i, md) := i in
     (* The following two lines set up file location information. *)
@@ -508,7 +523,8 @@ Section Denotation.
             lwrite id v
         | Some (t, num_exp) =>
             n <- denote_exp' (Some t) num_exp;;
-            v <- alloca dt (Z.to_N (dvalue_int_unsigned n)) align;;
+            n' <- (lift (dvalue_to_dvalue_base n)) ;;
+            v <- alloca dt (Z.to_N (dvalue_base_int_unsigned n')) align;;
             lwrite id v
         end;;
         ret tt
@@ -564,11 +580,11 @@ Section Denotation.
     | (IVoid _, INSTR_Comment _) => ret tt
 
     | (pt, INSTR_VAArg (t, ptr_to_args_exp) argty) =>
-        ptr_to_args <- denote_exp' (Some DTYPE_Pointer) ptr_to_args_exp;;
+        ptr_to_args <- denote_exp' (Some (DTYPE_Base DTYPE_Pointer)) ptr_to_args_exp;;
         args <- load DTYPE_Pointer ptr_to_args;;
         retv <- load argty args;;
         ix <- lift (from_Z 1);;
-        args' <- lift (eval_gep argty args [DVALUE_Iptr ix]);;
+        args' <- lift (eval_gep argty args [DVALUE_Base (DVALUE_Iptr ix)]);;
         store DTYPE_Pointer ptr_to_args args';;
         match pt with
         | IVoid _ => ret tt

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -158,12 +158,9 @@ Section Denotation.
     | DVALUE_Struct p fields => 
         val <- map_monad freeze fields;;
         ret (DVALUE_Struct p val)
-    | DVALUE_Array τ elts => 
+    | DVALUE_Array v τ elts => 
         val <- map_monad freeze elts;;
-        ret (DVALUE_Array τ val)
-    | DVALUE_Vector τ elts =>
-        val <- map_monad freeze_base elts;;
-        ret (DVALUE_Vector τ val)
+        ret (DVALUE_Array v τ val)
     | _ => ret dv
     end.
 
@@ -215,7 +212,7 @@ Section Denotation.
 
     | EXP_Cstring es =>
       vs <- map_monad eval_texp es ;;
-      ret (DVALUE_Array (@DTYPE_I 8) vs)
+      ret (DVALUE_Array false (@DTYPE_I 8) vs)
 
     (* [undef] is treated semantically as [poison] on this branch. *)
     | EXP_Undef =>
@@ -248,11 +245,11 @@ Section Denotation.
 
     | EXP_Array t es =>
       vs <- map_monad eval_texp es ;;
-      ret (DVALUE_Array t vs)
+      ret (DVALUE_Array false t vs)
 
     | EXP_Vector t es =>
-      vs <- map_monad eval_texp_base es ;;
-      ret (DVALUE_Vector t vs)
+      vs <- map_monad eval_texp es ;;
+      ret (DVALUE_Array true t vs)
 
     | OP_IBinop iop dt op1 op2 =>
       v1 <- denote_exp (Some dt) op1 ;;
@@ -339,11 +336,11 @@ Section Denotation.
     | EXP_Splat elt =>
         match top with
         | None => raise ("denote_exp given untyped EXP_Splat")
-        | Some (DTYPE_Vector sz t) =>
+        | Some (DTYPE_Array true sz t) =>
             (* use the type from the splat elt *)
-            v <- eval_texp_base elt ;;
+            v <- eval_texp elt ;;
             (* this could be very expensive if the vector is big *)
-            ret (DVALUE_Vector t (List.repeat v (N.to_nat sz)))
+            ret (DVALUE_Array true t (List.repeat v (N.to_nat sz)))
         | Some _ => raise ("denote_exp given EXP_Splat with non-vector type")
         end
           

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -658,17 +658,17 @@ Section Denotation.
       ret (inr dv)
 
     | TERM_Ret_void =>
-        ret (inr DVALUE_None)
+        ret (inr NONE)
 
     | TERM_Br (dt,op) br1 br2 =>
       v <- denote_exp' (Some dt) op ;;
       match v with
-      | DVALUE_I 1 comparison_bit =>
+      | DVALUE_Base (DVALUE_I 1 comparison_bit) =>
         if equ comparison_bit one then
           ret (inl br1)
         else
           ret (inl br2)
-      | DVALUE_Poison dt => raiseUB (err_loc ++ ": Branching on poison.")
+      | DVALUE_Base (DVALUE_Poison dt) => raiseUB (err_loc ++ ": Branching on poison.")
       | _ => raise (err_loc ++ ": Br got non-bool value")
       end
 
@@ -682,7 +682,7 @@ Section Denotation.
         switches <- map_monad
                      (fun '((TInt_Literal sz x),id) =>
                         s <- lift (coerce_integer_to_int (Some sz) (denote_int_syntax x));;
-                        ret (s,id))
+                        ret (DVALUE_Base s,id))
                      dests;; 
         inl <$> lift (select_switch selector default_br switches)
 
@@ -717,7 +717,7 @@ Section Denotation.
     end.
 
   (* Denoting a list of instruction simply binds the trees together *)
-  Definition denote_code (c: code dtyp) (varargs : option addr) : CFGtop unit :=
+  Definition denote_code (c: code dtyp) (varargs : option ptr) : CFGtop unit :=
     map_monad_ (fun i => denote_instr i varargs) c.
 
   Definition denote_phi (bid_from : block_id) (id_p : local_id * phi dtyp * (list (metadata dtyp))) : CFGtop (local_id * dvalue) :=
@@ -741,7 +741,7 @@ Section Denotation.
 
   (* A block ends with a terminator, it either jumps to another block,
          or returns a dynamic value *)
-  Definition denote_block (b: block dtyp) (bid_from : block_id) (varargs : option addr) : CFGtop (block_id + dvalue) :=
+  Definition denote_block (b: block dtyp) (bid_from : block_id) (varargs : option ptr) : CFGtop (block_id + dvalue) :=
     denote_phis bid_from (blk_phis b);;
     denote_code (blk_code b) varargs;;
     denote_terminator (blk_term b).
@@ -760,7 +760,7 @@ Section Denotation.
      If it ever returns a dynamic value, we exit the loop by returning the [dvalue].
    *)
 
-  Definition denote_ocfg (bks: ocfg dtyp) (varargs : option addr)
+  Definition denote_ocfg (bks: ocfg dtyp) (varargs : option ptr)
     : (block_id * block_id) -> CFGtop ((block_id * block_id) + dvalue) :=
     ITree.iter
       (fun '((bid_from,bid_src) : block_id * block_id) =>
@@ -774,7 +774,7 @@ Section Denotation.
              end
          end).
 
-  Definition denote_cfg (f: cfg dtyp) (varargs : option addr) : CFGtop dvalue :=
+  Definition denote_cfg (f: cfg dtyp) (varargs : option ptr) : CFGtop dvalue :=
     r <- denote_ocfg (blks f) varargs (init f,init f) ;;
     match r with
     | inl bid => raise ("Can't find block in denote_cfg " ++ show (snd bid))
@@ -838,18 +838,18 @@ Section Denotation.
     mem_pop.
   
   (* Push call frame, return varargs address *)
-  Definition push_call_frame (df:definition dtyp (cfg dtyp)) (args : list dvalue) : CFGtop addr :=
+  Definition push_call_frame (df:definition dtyp (cfg dtyp)) (args : list dvalue) : CFGtop ptr :=
     (* We match the arguments variables to the inputs *)
     '(bs, vs) <- lift (combine_lists_varargs (df_args df) args) ;;
     dts <- lift (map_monad dtyp_of_dvalue vs);;
-    let dt := DTYPE_Packed_struct dts in
+    let dt := DTYPE_Struct true dts in
     (* generate the corresponding writes to the local stack frame *)
     mem_push ;;
     stack_push bs ;;
     varargs <- alloca dt 1 None;;
-    store dt varargs (DVALUE_Packed_struct vs);;
+    store dt varargs (DVALUE_Struct true vs);;
     match varargs with
-    | DVALUE_Addr varg =>
+    | DVALUE_Base (DVALUE_Pointer varg) =>
         ret varg
     | _ => raise "Non-address returned from alloca of varargs"
     end.
@@ -880,7 +880,7 @@ Section Denotation.
 
   Definition lookup_defn (dv : dvalue) (m : IntMap function_denotation) : option function_denotation
     := match dv with
-       | DVALUE_Addr addr =>
+       | DVALUE_Base (DVALUE_Pointer addr) =>
            lookup (ptr_to_int addr) m
        | _ => None
        end.

--- a/src/rocq/Semantics/DynamicValues.v
+++ b/src/rocq/Semantics/DynamicValues.v
@@ -108,12 +108,10 @@ Section DValue.
   Inductive dvalue : Set :=
   | DVALUE_Base (db : dvalue_base)      
   | DVALUE_Struct (packed:bool) (fields: list dvalue)
-
   (* REVISIT: DESIGN CHOICE:
      - Array and Vector values carry their "full" dtyp (which includes a length)
    *)                  
-  | DVALUE_Array (t:dtyp) (elts: list dvalue)
-  | DVALUE_Vector (t:dtyp) (elts: list dvalue_base)                 
+  | DVALUE_Array (vector:bool) (t:dtyp) (elts: list dvalue)
   .
   Set Elimination Schemes.
 
@@ -161,30 +159,16 @@ Section DValue.
     | DVALUE_Struct p fields =>
         dts <- map_monad dtyp_of_dvalue fields ;;
         ret (DTYPE_Struct p dts)
-    | DVALUE_Array (DTYPE_Array sz t) elts =>
+    | DVALUE_Array p (DTYPE_Array q sz t) elts =>
         if @NO_VOID_dec t
         then
           if forallb (fun e => match dtyp_of_dvalue e with
                             | raise_ret t' => dtyp_eqb t t'
                             | _ => false end) elts
              && N.eqb sz (N.of_nat (length elts))
-          then ret (DTYPE_Array (N.of_nat (length elts)) t)
+          then ret (DTYPE_Array p (N.of_nat (length elts)) t)
           else raise_error "dtyp_of_dvalue: mismatched element type in array"
         else raise_error "dtyp_of_dvalue: void in array type"
-    | DVALUE_Vector (DTYPE_Vector sz t) elts =>
-        if @NO_VOID_dec (DTYPE_Vector sz t)
-        then
-          if forallb (fun e => match dtyp_base_of_dvalue_base e with
-                            | Some t' => if dtyp_base_eq_dec t t' then true else false
-                            | None => false end) elts
-             && N.eqb sz (N.of_nat (length elts))
-          then
-            if @vector_dtyp_base_dec t
-            then ret (DTYPE_Vector (N.of_nat (length elts)) t)
-            else raise_error "dtyp_of_dvalue: invalid element type for vector"
-          else raise_error "dtyp_of_dvalue: mismatched element type in vector"
-        else raise_error "dtyp_of_dvalue: void in vector type"
-                         
     | _ => raise_error "dtyp_of_dvalue: missing case"
     end.
 
@@ -232,8 +216,8 @@ Section DValue.
         if p then
           "<{" ++ String.concat ", " (map show_dvalue fields) ++ "}>"
         else "{" ++ String.concat ", " (map show_dvalue fields) ++ "}"
-    | DVALUE_Array t elts => show_dtyp t ++ " [" ++ String.concat ", " (map show_dvalue elts) ++ "]"
-    | DVALUE_Vector t elts => show_dtyp t ++ " < " ++ String.concat ", " (map show_dvalue_base elts) ++ ">"
+    | DVALUE_Array false t elts => show_dtyp t ++ " [" ++ String.concat ", " (map show_dvalue elts) ++ "]"
+    | DVALUE_Array true t elts => show_dtyp t ++ " < " ++ String.concat ", " (map show_dvalue elts) ++ ">"
     end.
 
   #[global] Instance showDValue : Show dvalue
@@ -246,9 +230,7 @@ Section DValue.
     Variable P : dvalue -> Prop.
     Hypothesis IH_Base : forall dv, P (DVALUE_Base dv).
     Hypothesis IH_Struct        : forall p (fields: list dvalue), Forall P fields -> P (DVALUE_Struct p fields).
-    Hypothesis IH_Array         : forall t (elts: list dvalue), Forall P elts -> P (DVALUE_Array t elts).
-    Hypothesis IH_Vector        : forall t (elts: list dvalue_base), P (DVALUE_Vector t elts).
-
+    Hypothesis IH_Array         : forall v t (elts: list dvalue), Forall P elts -> P (DVALUE_Array v t elts).
     Lemma dvalue_ind : forall (dv:dvalue), P dv.
     Proof using All.
       fix IH 1.
@@ -303,27 +285,24 @@ Section DValue.
                 match v1, v2 with
                 | DVALUE_Base v1, DVALUE_Base v2 => _
                 | DVALUE_Struct p fields, DVALUE_Struct p' fields' => _
-                | DVALUE_Array t elts, DVALUE_Array t' elts' => _
-                | DVALUE_Vector t elts, DVALUE_Vector t' elts' => _                                                                | _, _ => _
+                | DVALUE_Array v t elts, DVALUE_Array v' t' elts' => _
+                | _, _ => _                                                                   
                 end); try (ltac:(dec_dtyp); fail).
       - destruct (dvalue_base_eq_dec v1 v2).
-        * left; subst; reflexivity.
-        * right; intros H; inversion H. contradiction.
-      - destruct (lsteq_dec fields fields').
-        * destruct (bool_dec p p').
-          -- left; subst; reflexivity.
-          -- right; intros H; inversion H. contradiction.
-        * right; intros H; inversion H. contradiction.
-      - destruct (lsteq_dec elts elts').
-        * destruct (dtyp_eq_dec t t').
-          --  left; subst; reflexivity.
-          -- right; intros H; inversion H. contradiction.
-        * right; intros H; inversion H. contradiction.
-      - destruct (list_eq_dec dvalue_base_eq_dec elts elts').
-        * destruct (dtyp_eq_dec t t').
-          --  left; subst; reflexivity.
-          -- right; intros H; inversion H. contradiction.
-        * right; intros H; inversion H. contradiction.
+        + left; subst; reflexivity.
+        + right; intros H; inversion H. contradiction.
+      - destruct (bool_dec p p').
+        + destruct (lsteq_dec fields fields').
+          * left; subst; reflexivity.
+          * right; intros H; inversion H. contradiction.
+        + right; intros H; inversion H. contradiction.
+      - destruct (bool_dec v v').
+        + destruct (dtyp_eq_dec t t').
+          * destruct (lsteq_dec elts elts').
+            --  left; subst; reflexivity.
+            -- right; intros H; inversion H. contradiction.
+          * right; intros H; inversion H. contradiction.
+        + right; intros H; inversion H. contradiction.            
     Defined.
 
     Definition dvalue_eqb (dv1 dv2 : dvalue) : bool :=
@@ -1294,16 +1273,19 @@ Section DValue.
   (* I split the definition between the vector and other evaluations because
      otherwise eval_iop should be recursive to allow for vector calculations,
      but rocq can't find a fixpoint. *)
-  Definition eval_iop iop v1 v2 : EOU dvalue :=
+  Fixpoint eval_iop iop v1 v2 : EOU dvalue :=
     match v1, v2 with
     | (DVALUE_Base v1), (DVALUE_Base v2) =>
         DVALUE_Base <$> (eval_iop_integer_base iop v1 v2)
                            
-    | (DVALUE_Vector t elts1), (DVALUE_Vector _ elts2) =>
+    | (DVALUE_Array true t elts1), (DVALUE_Array true _ elts2) =>
         let n := N.length elts1 in
         let m := N.length elts2 in
-        if n =? m  then 
-          (DVALUE_Vector t) <$> (vec_loop (eval_iop_integer_base iop) (List.combine elts1 elts2))
+        if n =? m  then
+          elts1' <- map_monad dvalue_to_dvalue_base elts1 ;;
+          elts2' <- map_monad dvalue_to_dvalue_base elts2 ;;
+          ans <- vec_loop (eval_iop_integer_base iop) (List.combine elts1' elts2') ;;
+          ret (DVALUE_Array true t (List.map DVALUE_Base ans))
         else
           raise_ub ("iop: " ++ (show iop) ++  " of different-length vectors")
 
@@ -1382,11 +1364,14 @@ Section DValue.
     | (DVALUE_Base dv1), (DVALUE_Base dv2) =>
         DVALUE_Base <$> (eval_fop_base fop dv1 dv2)
       
-    | (DVALUE_Vector t elts1), (DVALUE_Vector _ elts2) =>
+    | (DVALUE_Array true t elts1), (DVALUE_Array true _ elts2) =>
         let n := N.length elts1 in
         let m := N.length elts2 in
         if n =? m  then
-          (DVALUE_Vector t) <$> (vec_loop (eval_fop_base fop) (List.combine elts1 elts2))
+          elts1' <- map_monad dvalue_to_dvalue_base elts1 ;;
+          elts2' <- map_monad dvalue_to_dvalue_base elts2 ;;
+          ans <- vec_loop (eval_fop_base fop) (List.combine elts1' elts2') ;;
+          ret (DVALUE_Array true t (List.map DVALUE_Base ans))
         else
         raise_ub ("fop: " ++ (show fop) ++  " different-length vectors of type "
                     ++ (show t) ++ "v1 = " ++ (show v1) ++ "v2 = " ++ (show v2)
@@ -1407,8 +1392,10 @@ Section DValue.
     | DVALUE_Base db =>
         DVALUE_Base <$> (eval_fneg_base db)
                     
-    | DVALUE_Vector t elts =>
-        (DVALUE_Vector t) <$>  (map_monad (eval_fneg_base) elts)
+    | DVALUE_Array true t elts =>
+        elts' <- map_monad dvalue_to_dvalue_base elts ;;        
+        ans <- map_monad (eval_fneg_base) elts' ;;
+        ret (DVALUE_Array true t (List.map DVALUE_Base ans))
     | _ => raise_error "eval_fneg got illegal value"
     end.
   
@@ -1485,18 +1472,19 @@ Section DValue.
     | (DVALUE_Base dv1), (DVALUE_Base dv2) =>
         DVALUE_Base <$> (eval_fcmp_base fcmp dv1 dv2)
                     
-    | (DVALUE_Vector t elts1), (DVALUE_Vector _ elts2) =>
+    | (DVALUE_Array true t elts1), (DVALUE_Array true _ elts2) =>
         let n := N.length elts1 in
         let m := N.length elts2 in
-        if n =? m  then 
-          val <- vec_loop (eval_fcmp_base fcmp) (List.combine elts1 elts2) ;;
-          ret (DVALUE_Vector (DTYPE_Vector n (DTYPE_I 1)) val)
+        if n =? m  then
+          elts1' <- map_monad dvalue_to_dvalue_base elts1 ;;
+          elts2' <- map_monad dvalue_to_dvalue_base elts2 ;;
+          ans <- vec_loop (eval_fcmp_base fcmp) (List.combine elts1' elts2') ;;
+          ret (DVALUE_Array true (DTYPE_Array true n (DTYPE_I 1)) (List.map DVALUE_Base ans))
         else
           raise_ub "fcmp of different-length vectors"
     | _, _ => raise_error "eval_fcmp got illegal value"
     end.
 
-  
   End ARITHMETIC.
 
   (* monadically split a list into a prefix, an element, and a tail
@@ -1528,10 +1516,10 @@ Section DValue.
             modified_subfield <- insert_value sub elt tl ;;
             ret (DVALUE_Struct p (pre ++ [modified_subfield] ++ post)%list)
     
-        | DVALUE_Array t elts =>
+        | DVALUE_Array false t elts =>
             '(pre,sub,post) <- option_ub "insertvalue array index out of bounds" (split [] i elts) ;;
             modified_subfield <- insert_value sub elt tl ;;
-            ret (DVALUE_Array t (pre ++ [modified_subfield] ++ post))
+            ret (DVALUE_Array false t (pre ++ [modified_subfield] ++ post))
 
         | DVALUE_Base (DVALUE_Poison (DTYPE_Struct p ts)) =>
             '(pre_t, sub_t, post_t) <- option_ub "insertvalue poison index out of bounds" (split [] i ts) ;;
@@ -1553,7 +1541,7 @@ Section DValue.
             '(pre,sub,post) <- option_ub "extractvalue struct index out of bounds" (split [] i elts) ;;
             extract_value sub tl 
     
-        | DVALUE_Array t elts =>
+        | DVALUE_Array false t elts =>
             '(pre,sub,post) <- option_ub "extractvalue array index out of bounds" (split [] i elts) ;;
             extract_value sub tl 
 
@@ -1576,36 +1564,36 @@ Section DValue.
   (* LANGREF? : What is the behavior if [vex] is poison?  UB or return poision?  *)
   Definition extract_element (vec:dvalue) (idx:dvalue) : EOU dvalue :=
     match vec with
-    | DVALUE_Vector (DTYPE_Vector _ dt) elts =>
+    | DVALUE_Array true (DTYPE_Array true _ dt) elts =>
         match dvalue_to_Z idx with
         | Some i =>
             match split [] i elts with
-            | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Base dt)))
-            | Some (pre, elt, post) =>  ret (DVALUE_Base elt)
+            | None => ret (DVALUE_Base (DVALUE_Poison dt))
+            | Some (pre, elt, post) =>  ret elt
             end
         | None => raise_error "extractelemnt: non-integer index"
         end
     | _ => raise_error "extractelement: non-vector type"
     end.
 
-  Definition insert_element (vec : dvalue) (elt : dvalue_base) (idx : dvalue) : EOU dvalue :=
+  Definition insert_element (vec : dvalue) (elt : dvalue) (idx : dvalue) : EOU dvalue :=
     match vec with
-    | DVALUE_Vector (DTYPE_Vector sz dt) elts =>
+    | DVALUE_Array true (DTYPE_Array true sz dt) elts =>
         match dvalue_to_Z idx with
         | Some i =>
             match split [] i elts with
-            | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz dt)))
-            | Some (pre, _, post) =>  ret (DVALUE_Vector (DTYPE_Vector sz dt) (pre ++ [elt] ++ post))
+            | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz dt)))
+            | Some (pre, _, post) =>  ret (DVALUE_Array true (DTYPE_Array true sz dt) (pre ++ [elt] ++ post))
             end
         | None => raise_error "insertelement: non-integer index"
         end
-    | DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz dt)) =>
-        let elts : list dvalue_base := repeat (DVALUE_Poison (DTYPE_Base dt)) (N.to_nat sz) in
+    | DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz dt)) =>
+        let elts : list dvalue := repeat (DVALUE_Base (DVALUE_Poison dt)) (N.to_nat sz) in
         match dvalue_to_Z idx with
         | Some i =>
             match split [] i elts with
-            | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz dt)))
-            | Some (pre, _, post) =>  ret (DVALUE_Vector (DTYPE_Vector sz dt) (pre ++ [elt] ++ post))
+            | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz dt)))
+            | Some (pre, _, post) =>  ret (DVALUE_Array true (DTYPE_Array true sz dt) (pre ++ [elt] ++ post))
             end
         | None => raise_error "insertelement: non-integer index"
         end
@@ -1645,19 +1633,11 @@ Section DValue.
 
   (* Do we have to exclude mmx? "There are no arrays, vectors or constants of this type" *)
   | DVALUE_Array_typ :
-    forall xs sz dt,
+    forall v xs sz dt,
       NO_VOID dt ->
       Forall (fun x => dvalue_has_dtyp x dt) xs ->
       length xs = (N.to_nat sz) ->
-      dvalue_has_dtyp (DVALUE_Array (DTYPE_Array sz dt) xs) (DTYPE_Array sz dt) 
-
-  | DVALUE_Vector_typ :
-      forall xs sz dt,
-      NO_VOID_base dt ->
-      Forall (fun x => dvalue_base_has_dtyp_base x dt) xs ->
-      length xs = (N.to_nat sz) ->
-      vector_dtyp_base dt ->
-      dvalue_has_dtyp (DVALUE_Vector (DTYPE_Vector sz dt) xs) (DTYPE_Vector sz dt)
+      dvalue_has_dtyp (DVALUE_Array v (DTYPE_Array v sz dt) xs) (DTYPE_Array v sz dt) 
   .
   Set Elimination Schemes.
 
@@ -2260,12 +2240,9 @@ Section DValue.
     | DTYPE_Struct p fields =>
         v <- map_monad default_dvalue_of_dtyp fields;;
         ret (DVALUE_Struct p v)
-    | DTYPE_Array sz t =>
-        v <- default_dvalue_of_dtyp t ;;
-        ret (DVALUE_Array dt (repeat v (N.to_nat sz)))
-    | DTYPE_Vector sz t =>
-        v <- default_dvalue_base_of_dtyp_base t ;;
-        ret (DVALUE_Vector dt (repeat v (N.to_nat sz)))
+    | DTYPE_Array v sz t =>
+        dv <- default_dvalue_of_dtyp t ;;
+        ret (DVALUE_Array v dt (repeat dv (N.to_nat sz)))
     end.
 
   Lemma dvalue_default_base_NO_VOID :
@@ -2291,9 +2268,6 @@ Section DValue.
     - cbn in H.
       break_match_hyp_inv.
       eapply IHt. reflexivity.
-    - simpl in H.
-      destruct (default_dvalue_base_of_dtyp_base t) eqn:HEQ; inversion H.
-      eapply dvalue_default_base_NO_VOID. eapply HEQ.
   Qed.
 
   (*

--- a/src/rocq/Semantics/DynamicValues.v
+++ b/src/rocq/Semantics/DynamicValues.v
@@ -117,6 +117,16 @@ Section DValue.
   .
   Set Elimination Schemes.
 
+
+  Coercion DVALUE_Base : dvalue_base >-> dvalue.
+
+  (* Partial coercion in the other direction *)
+  Definition dvalue_to_dvalue_base (dv : dvalue) : EOU dvalue_base :=
+    match dv with
+    | DVALUE_Base d => ret d
+    | _ => raise_error "dvalue_to_dvalue_base: got non-base value"
+    end.
+  
   Definition dtyp_base_of_dvalue_base (v:dvalue_base) : option dtyp_base :=
     match v with
     | DVALUE_Pointer a => Some DTYPE_Pointer
@@ -135,14 +145,14 @@ Section DValue.
 
   Definition dtyp_of_dvalue_base (v:dvalue_base) : dtyp :=
     match v with
-    | DVALUE_Pointer a => DTYPE_Base DTYPE_Pointer
-    | DVALUE_I sz x => DTYPE_Base (DTYPE_I sz)
-    | DVALUE_Iptr x => DTYPE_Base (DTYPE_Iptr)
-    | DVALUE_Double x => DTYPE_Base (DTYPE_FP FP_double)
-    | DVALUE_Float x => DTYPE_Base (DTYPE_FP FP_float)
+    | DVALUE_Pointer a => DTYPE_Pointer
+    | DVALUE_I sz x => (DTYPE_I sz)
+    | DVALUE_Iptr x => (DTYPE_Iptr)
+    | DVALUE_Double x => (DTYPE_FP FP_double)
+    | DVALUE_Float x => (DTYPE_FP FP_float)
     | DVALUE_Poison t => t
-    | DVALUE_None => DTYPE_Base DTYPE_Void
-    | DVALUE_B sz bits => DTYPE_Base (DTYPE_B sz)
+    | DVALUE_None =>  DTYPE_Void
+    | DVALUE_B sz bits =>  (DTYPE_B sz)
     end.
   
   Fixpoint dtyp_of_dvalue (v:dvalue) : EOU dtyp :=
@@ -786,11 +796,6 @@ Section DValue.
             cbn in *; lia
       ].
 
-  Definition dvalue_is_poison (dv : dvalue) : bool :=
-    match dv with
-    | DVALUE_Poison dt => true
-    | _ => false
-    end.
 
   Section DecidableEquality.
 
@@ -950,6 +955,12 @@ Section DValue.
   
     Hint Unfold eqv_dvalue : core.
 
+    Definition dvalue_is_poison (dv : dvalue) : bool :=
+      match dv with
+      | DVALUE_Base (DVALUE_Poison dt) => true
+      | _ => false
+      end.
+    
     Lemma ibinop_eq_dec : forall (op1 op2:ibinop), {op1 = op2} + {op1 <> op2}.
       intros.
       repeat decide equality.

--- a/src/rocq/Semantics/DynamicValues.v
+++ b/src/rocq/Semantics/DynamicValues.v
@@ -326,11 +326,13 @@ Section DValue.
         * right; intros H; inversion H. contradiction.
     Defined.
 
+    Definition dvalue_eqb (dv1 dv2 : dvalue) : bool :=
+      if dvalue_eq_dec dv1 dv2 then true else false.
+    
     #[global] Instance eq_dec_dvalue : RelDec (@eq dvalue) := RelDec_from_dec (@eq dvalue) (@dvalue_eq_dec).
     #[global] Instance eqv_dvalue : Eqv dvalue := (@eq dvalue).
     Hint Unfold eqv_dvalue : core.
 
-    
   (*
   Inductive dvalue_direct_subterm : dvalue -> dvalue -> Prop :=
   | DVALUE_Struct_subterm : forall f fields, In f fields -> dvalue_direct_subterm f (DVALUE_Struct fields)

--- a/src/rocq/Semantics/DynamicValues.v
+++ b/src/rocq/Semantics/DynamicValues.v
@@ -3,7 +3,8 @@ From Stdlib Require Import
   Relations
   DecidableClass
   Program.Wf
-  Numbers.HexadecimalString.
+  Numbers.HexadecimalString
+  Lists.List. 
 
 Import BinInt.
 
@@ -41,6 +42,10 @@ Open Scope N_scope.
 
 (** * Dynamic values
     Definition of the dynamic values manipulated by VIR.
+
+  map_to {X} : (forall (n:N), fin n -> X)
+
+
  *)
 
 #[global] Instance Eqv_nat : Eqv nat := (@eq nat).
@@ -73,49 +78,79 @@ Definition ll_double := Floats.float.
 Section DValue.
   Context {Pa : Params}.
 
+  Variant memory_bit :=
+  | Bit_ptr (p:ptr) (idx : N)  (* idx'th bit of pointer p *)
+  | Bit_psn                    (* poison *)
+  | Bit_bit (b:@bit_int 1)     (* actual bit *)
+  .    
+  
+  Variant dvalue_base : Set :=
+  | DVALUE_Pointer (p:ptr)
+  | DVALUE_I (sz : positive) (x:@bit_int sz)
+  | DVALUE_Iptr (x:iptr)
+    (* TODO - this version | DVALUE_FP (fp:floating_point_variant) (x:@float_val fp) *)
+  | DVALUE_Double (x:ll_double)
+  | DVALUE_Float (x:ll_float)
+
+  (* DESIGN CHOICE:
+     - There is only one canonical representation of poison values.
+     - It is a dvalue_base because it has no substructure; even if the type t is structured
+   *)                   
+  | DVALUE_Poison (t:dtyp)
+  | DVALUE_None
+    (* Byte type carrier.  Invariant: length bits = sz *)
+  | DVALUE_B (sz : positive) (bits : list memory_bit)
+  .
+
+  
   (* The set of dynamic values manipulated by an LLVM program. *)
   Unset Elimination Schemes.
   Inductive dvalue : Set :=
-  | DVALUE_Addr (a:addr)
-  | DVALUE_I (sz : positive) (x:@bit_int sz)
-  | DVALUE_Iptr (x:iptr)
-(* TODO - this version | DVALUE_FP (fp:floating_point_variant) (x:@float_val fp) *)
-  | DVALUE_Double (x:ll_double)
-  | DVALUE_Float (x:ll_float)
-  | DVALUE_Poison (t:dtyp)
-  | DVALUE_None
-  | DVALUE_Struct        (fields: list dvalue)
-  | DVALUE_Packed_struct (fields: list dvalue)
-  | DVALUE_Array         (t:dtyp) (elts: list dvalue)
-  | DVALUE_Vector        (t:dtyp) (elts: list dvalue)
+  | DVALUE_Base (db : dvalue_base)      
+  | DVALUE_Struct (packed:bool) (fields: list dvalue)
+
+  (* REVISIT: DESIGN CHOICE:
+     - Array and Vector values carry their "full" dtyp (which includes a length)
+   *)                  
+  | DVALUE_Array (t:dtyp) (elts: list dvalue)
+  | DVALUE_Vector (t:dtyp) (elts: list dvalue_base)                 
   .
   Set Elimination Schemes.
 
-  Fixpoint dtyp_of_dvalue (v:dvalue) : EOU dtyp :=
-    let list_dtyps :=
-      fix go (uvs : list dvalue) : EOU (list dtyp) :=
-        match uvs with
-        | [] => ret []
-        | v::tl =>
-            dt <- dtyp_of_dvalue v;;
-            dts <- go tl;;
-            ret (dt :: dts)
-        end
-    in
+  Definition dtyp_base_of_dvalue_base (v:dvalue_base) : option dtyp_base :=
     match v with
-    | DVALUE_Addr a => ret DTYPE_Pointer
-    | DVALUE_I sz x => ret (DTYPE_I sz)
-    | DVALUE_Iptr x => ret DTYPE_Iptr
-    | DVALUE_Double x => ret (DTYPE_FP FP_double)
-    | DVALUE_Float x => ret (DTYPE_FP FP_float)
-    | DVALUE_Poison t => ret t
-    | DVALUE_None => ret DTYPE_Void
-    | DVALUE_Struct fields =>
-        dts <- list_dtyps fields;;
-        ret (DTYPE_Struct dts)
-    | DVALUE_Packed_struct fields =>
-        dts <- list_dtyps fields;;
-        ret (DTYPE_Packed_struct dts)
+    | DVALUE_Pointer a => Some DTYPE_Pointer
+    | DVALUE_I sz x => Some (DTYPE_I sz)
+    | DVALUE_Iptr x => Some (DTYPE_Iptr)
+    | DVALUE_Double x => Some (DTYPE_FP FP_double)
+    | DVALUE_Float x => Some (DTYPE_FP FP_float)
+    | DVALUE_Poison t =>
+        match t with
+        | DTYPE_Base dt => Some dt
+        | _ => None
+        end
+    | DVALUE_None => Some DTYPE_Void
+    | DVALUE_B sz bits => Some (DTYPE_B sz)
+    end.
+
+  Definition dtyp_of_dvalue_base (v:dvalue_base) : dtyp :=
+    match v with
+    | DVALUE_Pointer a => DTYPE_Base DTYPE_Pointer
+    | DVALUE_I sz x => DTYPE_Base (DTYPE_I sz)
+    | DVALUE_Iptr x => DTYPE_Base (DTYPE_Iptr)
+    | DVALUE_Double x => DTYPE_Base (DTYPE_FP FP_double)
+    | DVALUE_Float x => DTYPE_Base (DTYPE_FP FP_float)
+    | DVALUE_Poison t => t
+    | DVALUE_None => DTYPE_Base DTYPE_Void
+    | DVALUE_B sz bits => DTYPE_Base (DTYPE_B sz)
+    end.
+  
+  Fixpoint dtyp_of_dvalue (v:dvalue) : EOU dtyp :=
+    match v with
+    | DVALUE_Base vb => ret (dtyp_of_dvalue_base vb)
+    | DVALUE_Struct p fields =>
+        dts <- map_monad dtyp_of_dvalue fields ;;
+        ret (DTYPE_Struct p dts)
     | DVALUE_Array (DTYPE_Array sz t) elts =>
         if @NO_VOID_dec t
         then
@@ -127,14 +162,14 @@ Section DValue.
           else raise_error "dtyp_of_dvalue: mismatched element type in array"
         else raise_error "dtyp_of_dvalue: void in array type"
     | DVALUE_Vector (DTYPE_Vector sz t) elts =>
-        if @NO_VOID_dec t
+        if @NO_VOID_dec (DTYPE_Vector sz t)
         then
-          if forallb (fun e => match dtyp_of_dvalue e with
-                            | raise_ret t' => dtyp_eqb t t'
-                            | _ => false end) elts
+          if forallb (fun e => match dtyp_base_of_dvalue_base e with
+                            | Some t' => if dtyp_base_eq_dec t t' then true else false
+                            | None => false end) elts
              && N.eqb sz (N.of_nat (length elts))
           then
-            if @vector_dtyp_dec t
+            if @vector_dtyp_base_dec t
             then ret (DTYPE_Vector (N.of_nat (length elts)) t)
             else raise_error "dtyp_of_dvalue: invalid element type for vector"
           else raise_error "dtyp_of_dvalue: mismatched element type in vector"
@@ -154,25 +189,139 @@ Section DValue.
 
   #[global] Instance showFloat32 : Show float32
     := {| show := float_to_hex_string |}.
+
+  Definition show_memory_bit (mb : memory_bit) : string :=
+    match mb with
+    | Bit_ptr ptr n => show_ptr ptr ++ "[" ++ show n ++ "]"
+    | Bit_psn => "p"
+    | Bit_bit i => show (unsigned i)
+    end.
+
+  #[global] Instance showMemoryBit : Show memory_bit
+    := {| show := show_memory_bit |}.                                          
   
-  Fixpoint show_dvalue (dv : dvalue) : string :=
+  Definition show_dvalue_base (dv : dvalue_base) : string :=
     match dv with
-    | DVALUE_Addr a => "addr " ++ show_addr a
+    | DVALUE_Pointer a => "addr " ++ show_ptr a
     | DVALUE_I sz x => "i" ++ show (Zpos sz) ++ " " ++ show (unsigned x)
     | DVALUE_Iptr x => "intptr " ++ show (to_Z x)
     | DVALUE_Double x => "double " ++ show x
     | DVALUE_Float x => "float " ++ show x
     | DVALUE_Poison t => "poison[" ++ show_dtyp t ++ "]"
     | DVALUE_None => "none"
-    | DVALUE_Struct fields => "{" ++ String.concat ", " (map show_dvalue fields) ++ "}"
-    | DVALUE_Packed_struct fields => "<{" ++ String.concat ", " (map show_dvalue fields) ++ "}>"
+    | DVALUE_B sz x => "b" ++ show (Zpos sz) ++ "[" ++ show x ++ "]"
+    end.      
+
+  #[global] Instance showDvalueBase : Show dvalue_base
+    := {| show := show_dvalue_base |}.
+  
+  Fixpoint show_dvalue (dv : dvalue) : string :=
+    match dv with
+    | DVALUE_Base db => show db
+    | DVALUE_Struct p fields =>
+        if p then
+          "<{" ++ String.concat ", " (map show_dvalue fields) ++ "}>"
+        else "{" ++ String.concat ", " (map show_dvalue fields) ++ "}"
     | DVALUE_Array t elts => show_dtyp t ++ " [" ++ String.concat ", " (map show_dvalue elts) ++ "]"
-    | DVALUE_Vector t elts => show_dtyp t ++ " < " ++ String.concat ", " (map show_dvalue elts) ++ ">"
+    | DVALUE_Vector t elts => show_dtyp t ++ " < " ++ String.concat ", " (map show_dvalue_base elts) ++ ">"
     end.
 
   #[global] Instance showDValue : Show dvalue
    := {| show := show_dvalue |}.                                       
 
+
+  Section DvalueInd.
+  (* Induction principles ----------------------------------------------------- *)
+    
+    Variable P : dvalue -> Prop.
+    Hypothesis IH_Base : forall dv, P (DVALUE_Base dv).
+    Hypothesis IH_Struct        : forall p (fields: list dvalue), Forall P fields -> P (DVALUE_Struct p fields).
+    Hypothesis IH_Array         : forall t (elts: list dvalue), Forall P elts -> P (DVALUE_Array t elts).
+    Hypothesis IH_Vector        : forall t (elts: list dvalue_base), P (DVALUE_Vector t elts).
+
+    Lemma dvalue_ind : forall (dv:dvalue), P dv.
+    Proof using All.
+      fix IH 1.
+      remember P as P0 in IH.
+      destruct dv; auto; subst.
+      - apply IH_Struct.
+        induction fields; eauto.
+      - apply IH_Array.
+        induction elts; eauto.
+    Qed.
+  End DvalueInd.
+
+  Section DecidableEquality.
+
+    Lemma memory_bit_eq_dec : forall (b1 b2 : memory_bit), {b1 = b2} + {b1 <> b2}.
+    Proof.
+      intros b1 b2.
+      decide equality; subst.
+      - destruct (N.eq_dec idx idx0); subst; auto.
+      - destruct (eq_dec_ptr p p0); subst; auto.
+      - destruct (Integers.eq_dec b b0); subst; auto.
+    Defined.
+      
+    Lemma dvalue_base_eq_dec : forall (v1 v2 : dvalue_base), {v1 = v2} + {v1 <> v2}.
+    Proof.
+      intros.
+      destruct v1; destruct v2; try solve [right; intros H; inversion H].
+      - destruct (eq_dec_ptr p p0); subst; auto. right; intros H; inversion H; contradiction.
+      - destruct (Pos.eq_dec sz sz0); subst.
+         + destruct (Integers.eq_dec x x0); subst; auto.
+           right. intros H; inversion H. subst_existT. contradiction.
+         + right. intros H. inversion H. subst_existT. contradiction.
+      - destruct (eq_dec_iptr x x0); subst; auto.
+        right. intros H. inversion H. subst_existT. contradiction.
+      - destruct (Float.eq_dec x x0); subst; auto.
+        right. intros H. inversion H. subst_existT. contradiction.
+      - destruct (Float32.eq_dec x x0); subst; auto.
+        right. intros H. inversion H. subst_existT. contradiction.
+      - destruct (dtyp_eq_dec t t0); subst; auto.
+        right. intros H. inversion H. subst_existT. contradiction.
+      - left; auto.
+      -  destruct (Pos.eq_dec sz sz0); subst; auto.
+         destruct (list_eq_dec memory_bit_eq_dec bits bits0); subst; auto.
+         + right. intros H. inversion H. subst_existT. contradiction.
+         + right. intros H. inversion H. subst_existT. contradiction.
+    Defined.
+
+    Lemma dvalue_eq_dec : forall (dv1 dv2 : dvalue), {dv1 = dv2} + {dv1 <> dv2}.
+    Proof.
+      refine (fix f v1 v2 :=
+                let lsteq_dec := list_eq_dec f in
+                match v1, v2 with
+                | DVALUE_Base v1, DVALUE_Base v2 => _
+                | DVALUE_Struct p fields, DVALUE_Struct p' fields' => _
+                | DVALUE_Array t elts, DVALUE_Array t' elts' => _
+                | DVALUE_Vector t elts, DVALUE_Vector t' elts' => _                                                                | _, _ => _
+                end); try (ltac:(dec_dtyp); fail).
+      - destruct (dvalue_base_eq_dec v1 v2).
+        * left; subst; reflexivity.
+        * right; intros H; inversion H. contradiction.
+      - destruct (lsteq_dec fields fields').
+        * destruct (bool_dec p p').
+          -- left; subst; reflexivity.
+          -- right; intros H; inversion H. contradiction.
+        * right; intros H; inversion H. contradiction.
+      - destruct (lsteq_dec elts elts').
+        * destruct (dtyp_eq_dec t t').
+          --  left; subst; reflexivity.
+          -- right; intros H; inversion H. contradiction.
+        * right; intros H; inversion H. contradiction.
+      - destruct (list_eq_dec dvalue_base_eq_dec elts elts').
+        * destruct (dtyp_eq_dec t t').
+          --  left; subst; reflexivity.
+          -- right; intros H; inversion H. contradiction.
+        * right; intros H; inversion H. contradiction.
+    Defined.
+
+    #[global] Instance eq_dec_dvalue : RelDec (@eq dvalue) := RelDec_from_dec (@eq dvalue) (@dvalue_eq_dec).
+    #[global] Instance eqv_dvalue : Eqv dvalue := (@eq dvalue).
+    Hint Unfold eqv_dvalue : core.
+
+    
+  (*
   Inductive dvalue_direct_subterm : dvalue -> dvalue -> Prop :=
   | DVALUE_Struct_subterm : forall f fields, In f fields -> dvalue_direct_subterm f (DVALUE_Struct fields)
   | DVALUE_Packed_struct_subterm : forall f fields, In f fields -> dvalue_direct_subterm f (DVALUE_Packed_struct fields)
@@ -797,9 +946,8 @@ Section DValue.
         + right.
           intros CONTRA; inv CONTRA; contradiction.
     Qed.
-
-    #[global] Instance eq_dec_dvalue : RelDec (@eq dvalue) := RelDec_from_dec (@eq dvalue) (@dvalue_eq_dec).
-    #[global] Instance eqv_dvalue : Eqv dvalue := (@eq dvalue).
+   *)
+  
     Hint Unfold eqv_dvalue : core.
 
     Lemma ibinop_eq_dec : forall (op1 op2:ibinop), {op1 = op2} + {op1 <> op2}.
@@ -844,6 +992,8 @@ Section DValue.
 
   End DecidableEquality.
 
+  (* SAZ: Not sure why these are needed *)
+  (*
   Definition is_DVALUE_I1 (d:dvalue) : bool :=
     match d with
     | DVALUE_I 1 _ => true
@@ -874,80 +1024,36 @@ Section DValue.
     | _ => false
     end.
 
-  Definition is_DVALUE_IX (d:dvalue) : bool :=
+   *)
+
+  Definition is_DVALUE_IX (d:dvalue_base) : bool :=
     match d with
     | DVALUE_I _ _ => true
     | _ => false
     end.
-
-  Class ToDvalue I : Type :=
-    { to_dvalue : I -> dvalue;
+  
+  Class ToDvalueBase I : Type :=
+    { tdb : I -> dvalue_base;
     }.
 
-  #[global] Existing Instance VMemInt_iptr.
+  #[global] Existing Instance VMemInt_iptr. 
 
-  #[global] Instance ToDvalue_iptr : ToDvalue iptr :=
-    { to_dvalue := DVALUE_Iptr }.
+  #[global] Instance ToDvalue_iptr : ToDvalueBase iptr :=
+    { tdb := DVALUE_Iptr }.
 
-  #[global] Instance ToDvalue_Int `{sz : positive} : ToDvalue (@bit_int sz) :=
-    { to_dvalue := @DVALUE_I sz }.
+  #[global] Instance ToDvalue_Int `{sz : positive} : ToDvalueBase (@bit_int sz) :=
+    { tdb := @DVALUE_I sz }.
 
-  Definition dvalue_int_unsigned (dv : dvalue) : Z
+  Definition dvalue_base_int_unsigned (dv : dvalue_base) : Z
     := match dv with
        | DVALUE_I sz x => unsigned x
        | DVALUE_Iptr x => to_unsigned x
        | _ => 0
        end.
 
-  Section CONVERSIONS.
-
-    (** ** Typed conversion
-        Performs a dynamic conversion of a [dvalue] of type [t1] to one of type [t2].
-        For instance, convert an integer over 8 bits to one over 1 bit by truncation.
-
-        The conversion function is not pure, i.e. in particular cannot live in [DynamicValues.v]
-        as would be natural, due to the [Int2Ptr] and [Ptr2Int] cases. At those types, the conversion
-        needs to cast between integers and pointers, which depends on the memory model.
-     *)
-
-    (* Note: Inferring the subevent instance takes a small but non-trivial amount of time,
-       and has to be done here hundreds and hundreds of times due to the brutal pattern matching on
-       several values. Factoring the inference upfront is therefore necessary.
-     *)
-
-    (* A trick avoiding proofs that involve thousands of cases: we split the conversion into
-      the composition of a huge case analysis that builds a value of [conv_case], and a function
-      with only four cases to actually build the tree.
-     *)
-    Variant conv_case : Set :=
-    | Conv_Pure    (x : dvalue)
-    | Conv_ItoP    (x : dvalue)
-    | Conv_PtoI    (x : dvalue)
-    | Conv_Oom     (s : string)
-    | Conv_Illegal (s: string).
-     
-    Variant ptr_conv_cases : Set :=
-    | PtrConv_ItoP
-    | PtrConv_PtoI
-    | PtrConv_Neither.
-
-    Definition get_conv_case_ptr conv (t1 : dtyp) (t2 : dtyp) : ptr_conv_cases
-      := match conv with
-         | Inttoptr =>
-           match t1, t2 with
-           | DTYPE_I 64, DTYPE_Pointer => PtrConv_ItoP
-           | DTYPE_Iptr, DTYPE_Pointer => PtrConv_ItoP
-           | _, _ => PtrConv_Neither
-           end
-         | Ptrtoint =>
-           match t1, t2 with
-           | DTYPE_Pointer, DTYPE_I _ => PtrConv_PtoI
-           | DTYPE_Pointer, DTYPE_Iptr => PtrConv_PtoI
-           | _, _ => PtrConv_Neither
-           end
-         | _ => PtrConv_Neither
-         end.
-  End CONVERSIONS.
+  (* SAZ: Could consider adding a typeclass to construct poison values from dtyp or dtyp_base *)
+  Definition dvp (t : dtyp_base) : dvalue_base := DVALUE_Poison (DTYPE_Base t).
+  
 
   (* Arithmetic Operations ---------------------------------------------------- *)
   Section ARITHMETIC.
@@ -960,24 +1066,24 @@ Section DValue.
 
      *)
 
-    Definition eval_int_op {Int} `{VMemInt Int} `{ToDvalue Int} (iop:ibinop) (x y: Int) : EOU dvalue :=
+    Definition eval_int_op {Int} `{VMemInt Int} `{ToDvalueBase Int} (iop:ibinop) (x y: Int) : EOU dvalue_base :=
       match iop with
       | Add nuw nsw =>
           if orb (andb nuw (mequ (madd_carry x y mzero) mone))
                (andb nsw (mequ (madd_overflow x y mzero) mone))
-          then ret (DVALUE_Poison mdtyp_of_int)
-          else to_dvalue <$> madd x y
-
+          then ret (dvp mdtyp_of_int)
+          else tdb <$> madd x y
+                         
       | Sub nuw nsw =>
           if orb (andb nuw (mequ (msub_borrow x y mzero) mone))
                (andb nsw (mequ (msub_overflow x y mzero) mone))
-          then ret (DVALUE_Poison mdtyp_of_int)
-          else to_dvalue <$> (msub x y)
-
+          then ret (dvp mdtyp_of_int)
+          else tdb <$> (msub x y)
+                         
       | Mul nuw nsw => 
           (* I1 mul can't overflow, just based on the 4 possible multiplications. *)
           if (option_pred (fun bw => Pos.eqb bw 1) mbitwidth)
-          then to_dvalue <$> (mmul x y)
+          then tdb <$> (mmul x y)
           else
             res <- mmul x y;;
             
@@ -993,46 +1099,46 @@ Section DValue.
                                | Some x => x
                                end in
 
-            if dtyp_eqb mdtyp_of_int DTYPE_Iptr
+            if dtyp_base_eq_dec mdtyp_of_int DTYPE_Iptr
             then
               if (res_u' >? munsigned res)
               then raise_oom "Multiplication overflow on iptr."
-              else ret (to_dvalue res)
+              else ret (tdb res)
             else
               if orb (andb nuw (res_u' >? munsigned res))
                    (andb nsw (orb min_s_bound max_s_bound))
-              then ret (DVALUE_Poison mdtyp_of_int)
-              else ret (to_dvalue res)                               
-
+              then ret (dvp mdtyp_of_int)
+              else ret (tdb res)                               
+                       
       | Shl nuw nsw =>
           res <- mshl x y;;
           
           let res_u := munsigned res in
           let res_u' := Z.shiftl (munsigned x) (munsigned y) in
 
-          if dtyp_eqb (@mdtyp_of_int Int _) DTYPE_Iptr
+          if dtyp_base_eq_dec (@mdtyp_of_int Int _) DTYPE_Iptr
           then
             (* TODO: Do we need to check for the unsigned case? Return result anyway? *)
             if (res_u' >? res_u)
             then raise_oom "Shl unsigned overflow on iptr."
             else
-              ret (to_dvalue res)
+              ret (tdb res)
           else
             (* Unsigned shift x right by bitwidth - y. If shifted x != sign bit * (2^y - 1),
          then there is overflow. *)
             if option_pred (fun bw => munsigned y >=? Zpos bw) mbitwidth
-            then ret (DVALUE_Poison mdtyp_of_int)
+            then ret (dvp mdtyp_of_int)
             else
               
               if andb nuw (res_u' >? res_u)
-              then ret (DVALUE_Poison mdtyp_of_int)
+              then ret (dvp mdtyp_of_int)
               else
                 (* Need to separate this out because mnegative can OOM *)
                 if nsw
                 then
                   match mbitwidth with
                   | None =>
-                      ret (to_dvalue res)
+                      ret (tdb res)
                   | Some bw =>
                       (* TODO: should this OOM here? *)
                       nres <- mnegative res;;
@@ -1040,19 +1146,20 @@ Section DValue.
                                   (Zpos bw - munsigned y)
                                 =? (munsigned nres)
                                    * (Z.pow 2 (munsigned y) - 1))%Z)
-                      then ret (DVALUE_Poison mdtyp_of_int)
-                      else ret (to_dvalue res)
+                      then ret (dvp mdtyp_of_int)
+                      else ret (tdb res)
                   end
-                else ret (to_dvalue res)
+                else ret (tdb res)
+
       | UDiv ex => 
           if (munsigned y =? 0)%Z
           then raise_ub "Unsigned division by 0."
           else if andb ex (negb ((munsigned x) mod (munsigned y) =? 0))%Z
-               then ret (DVALUE_Poison mdtyp_of_int)
-               else ret (to_dvalue (mdivu x y))
+               then ret (dvp mdtyp_of_int)
+               else ret (tdb (mdivu x y))
 
       | SDiv ex =>
-          if dtyp_eqb mdtyp_of_int DTYPE_Iptr
+          if dtyp_base_eq_dec mdtyp_of_int DTYPE_Iptr
           then raise_error "Signed division for iptr."
           else
             (* What does signed i1 mean? *)
@@ -1062,43 +1169,43 @@ Section DValue.
               if (from_option false (fmap (fun min => min =? msigned x) mmin_signed) && (msigned y =? -1))%Z
               then raise_ub "Signed division overflow."
               else if andb ex (negb ((msigned x) mod (msigned y) =? 0))%Z
-                   then ret (DVALUE_Poison mdtyp_of_int)
-                   else to_dvalue <$> mdivs x y
-
+                   then ret (dvp mdtyp_of_int)
+                   else tdb <$> mdivs x y                      
+                                  
       | LShr ex =>
-          if option_pred (fun bw => (munsigned y) >=? Zpos bw) mbitwidth && negb (dtyp_eqb mdtyp_of_int DTYPE_Iptr)
-          then ret (DVALUE_Poison mdtyp_of_int)
+          if option_pred (fun bw => (munsigned y) >=? Zpos bw) mbitwidth && negb (dtyp_base_eqb mdtyp_of_int DTYPE_Iptr)
+          then ret (dvp mdtyp_of_int)
           else if andb ex (negb ((munsigned x)
                                    mod (Z.pow 2 (munsigned y)) =? 0))%Z
-               then ret (DVALUE_Poison mdtyp_of_int)
-               else ret (to_dvalue (mshru x y))
-
+               then ret (dvp mdtyp_of_int)
+               else ret (tdb (mshru x y))
+                        
       | AShr ex =>
-          if dtyp_eqb mdtyp_of_int DTYPE_Iptr
+          if dtyp_base_eq_dec mdtyp_of_int DTYPE_Iptr
           then raise_error "Arithmetic shift for iptr."
           else
             if option_pred (fun bw => (munsigned y) >=? Zpos bw) mbitwidth
-            then ret (DVALUE_Poison mdtyp_of_int)
+            then ret (dvp mdtyp_of_int)
             else if andb ex (negb ((munsigned x)
                                      mod (Z.pow 2 (munsigned y)) =? 0))%Z
-                 then ret (DVALUE_Poison mdtyp_of_int)
-                 else ret (to_dvalue (mshr x y))
-
+                 then ret (dvp mdtyp_of_int)
+                 else ret (tdb (mshr x y))
+                          
       | URem =>
           if (munsigned y =? 0)%Z
           then raise_ub "Unsigned mod 0."
-          else ret (to_dvalue (mmodu x y))
+          else ret (tdb (mmodu x y))
 
       | SRem =>
-          if dtyp_eqb mdtyp_of_int DTYPE_Iptr
+          if dtyp_base_eq_dec mdtyp_of_int DTYPE_Iptr
           then raise_error "Signed division for iptr."
           else
             if (msigned y =? 0)%Z
             then raise_ub "Signed mod 0."
-            else to_dvalue <$> mmods x y
+            else tdb <$> mmods x y
                            
       | And =>
-          ret (to_dvalue (mand x y))
+          ret (tdb (mand x y))
 
       | Or b =>
           if b then
@@ -1107,24 +1214,25 @@ Section DValue.
                seeing whether `or` and `xor` give the same result.  
              *)
             if mequ (mor x y) (mxor x y) then
-              ret (to_dvalue (mor x y))
-            else ret (DVALUE_Poison mdtyp_of_int) 
+              ret (tdb (mor x y))
+            else ret (dvp mdtyp_of_int)
           else 
-            ret (to_dvalue (mor x y))
+            ret (tdb (mor x y))
 
       | Xor =>
-          ret (to_dvalue (mxor x y))
+          ret (tdb (mxor x y))
       end.
     Arguments eval_int_op _ _ _ : simpl nomatch.
 
     (* Evaluate the given iop on the given arguments according to the bitsize *)
-    Definition integer_op (bits:positive) (iop:ibinop) (x y:@bit_int bits) : EOU dvalue :=
-      eval_int_op iop x y.
-    Arguments integer_op _ _ _ _ : simpl nomatch.
+    (* TODO: Needed? If not, delete *)
+    (* Definition integer_op (bits:positive) (iop:ibinop) (x y:@bit_int bits) : EOU dvalue := *)
+    (*   eval_int_op iop x y. *)
+    (* Arguments integer_op _ _ _ _ : simpl nomatch. *)
 
   (* Convert written integer constant to corresponding integer with bitsize bits.
      Takes the integer modulo 2^bits. *)
-  Definition coerce_integer_to_int (bits:option positive) (i:Z) : EOU dvalue :=
+  Definition coerce_integer_to_int (bits:option positive) (i:Z) : EOU dvalue_base :=
     match bits with
     | Some sz  => ret (@DVALUE_I sz (repr i))
     | None    =>
@@ -1136,7 +1244,7 @@ Section DValue.
   (* Integer iop evaluation, called from eval_iop.
      Here the values must be integers. Helper defined
      in order to prevent eval_iop from being recursive. *)
-  Definition eval_iop_integer_h (iop : ibinop) (v1 v2 : dvalue) : EOU dvalue.
+  Definition eval_iop_integer_base (iop : ibinop) (v1 v2 : dvalue_base) : EOU dvalue_base.
     refine
       (match v1, v2 with
        | DVALUE_I sz1 i1, DVALUE_I sz2 i2 =>
@@ -1175,19 +1283,22 @@ Section DValue.
      but rocq can't find a fixpoint. *)
   Definition eval_iop iop v1 v2 : EOU dvalue :=
     match v1, v2 with
+    | (DVALUE_Base v1), (DVALUE_Base v2) =>
+        DVALUE_Base <$> (eval_iop_integer_base iop v1 v2)
+                           
     | (DVALUE_Vector t elts1), (DVALUE_Vector _ elts2) =>
         let n := N.length elts1 in
         let m := N.length elts2 in
         if n =? m  then 
-          val <- vec_loop (eval_iop_integer_h iop) (List.combine elts1 elts2) ;;
-          ret (DVALUE_Vector t val)
+          (DVALUE_Vector t) <$> (vec_loop (eval_iop_integer_base iop) (List.combine elts1 elts2))
         else
           raise_ub ("iop: " ++ (show iop) ++  " of different-length vectors")
-    | _, _ => eval_iop_integer_h iop v1 v2
+
+    | _, _ => raise_error "eval_iop called on illegal dvalue"
     end.
   Arguments eval_iop _ _ _ : simpl nomatch.
 
-  Definition eval_int_icmp {Int} `{VMI : VMemInt Int} (samesign:bool) icmp (x y : Int) : EOU dvalue :=
+  Definition eval_int_icmp {Int} `{VMI : VMemInt Int} (samesign:bool) icmp (x y : Int) : EOU dvalue_base :=
     c <- match icmp with
         | Eq => ret (mcmpu Ceq x y)
         | Ne => ret (mcmpu Cne x y)
@@ -1196,31 +1307,31 @@ Section DValue.
         | Ult => ret (mcmpu Clt x y)
         | Ule => ret (mcmpu Cle x y)
         | Sgt =>
-            if dtyp_eqb (@mdtyp_of_int Int VMI) DTYPE_Iptr
+            if dtyp_base_eq_dec (@mdtyp_of_int Int VMI) DTYPE_Iptr
             then raise_error "Signed '>' comparison on iptr type."
             else ret (mcmp Cgt x y)
         | Sge =>
-            if dtyp_eqb (@mdtyp_of_int Int VMI) DTYPE_Iptr
+            if dtyp_base_eq_dec (@mdtyp_of_int Int VMI) DTYPE_Iptr
             then raise_error "Signed '>=' comparison on iptr type."
             else ret (mcmp Cge x y)
         | Slt =>
-            if dtyp_eqb (@mdtyp_of_int Int VMI) DTYPE_Iptr
+            if dtyp_base_eq_dec (@mdtyp_of_int Int VMI) DTYPE_Iptr
             then raise_error "Signed '<' comparison on iptr type."
             else ret (mcmp Clt x y)
         | Sle =>
-            if dtyp_eqb (@mdtyp_of_int Int VMI) DTYPE_Iptr
+            if dtyp_base_eq_dec (@mdtyp_of_int Int VMI) DTYPE_Iptr
             then raise_error "Signed '>' comparison on iptr type."
             else ret (mcmp Cle x y)
         end;;
     ret ((* Check for sign *)
         if samesign && negb (msamesign x y) then
-          @DVALUE_Poison (DTYPE_I 1)
+          (dvp  (DTYPE_I 1))
         else if c
              then @DVALUE_I 1 (Integers.one)
              else @DVALUE_I 1 (Integers.zero)).
   Arguments eval_int_icmp _ _ _ _ : simpl nomatch.
 
-  Definition double_op (fop:fbinop) (v1:ll_double) (v2:ll_double) : EOU dvalue :=
+  Definition double_op (fop:fbinop) (v1:ll_double) (v2:ll_double) : EOU dvalue_base :=
     match fop with
     | FAdd => ret (DVALUE_Double (b64_plus FT_Rounding v1 v2))
     | FSub => ret (DVALUE_Double (b64_minus FT_Rounding v1 v2))
@@ -1229,7 +1340,7 @@ Section DValue.
     | FRem => raise_error "unimplemented double operation"
     end.
 
-  Definition float_op (fop:fbinop) (v1:ll_float) (v2:ll_float) : EOU dvalue :=
+  Definition float_op (fop:fbinop) (v1:ll_float) (v2:ll_float) : EOU dvalue_base :=
     match fop with
     | FAdd => ret (DVALUE_Float (b32_plus FT_Rounding v1 v2))
     | FSub => ret (DVALUE_Float (b32_minus FT_Rounding v1 v2))
@@ -1238,7 +1349,7 @@ Section DValue.
     | FRem => raise_error "unimplemented float operation"
     end.
 
-  Definition eval_fop_h (fop:fbinop) (v1:dvalue) (v2:dvalue) : EOU dvalue :=
+  Definition eval_fop_base (fop:fbinop) (v1:dvalue_base) (v2:dvalue_base) : EOU dvalue_base :=
     match v1, v2 with
     | DVALUE_Float f1, DVALUE_Float f2   => float_op fop f1 f2
     | DVALUE_Double d1, DVALUE_Double d2 => double_op fop d1 d2
@@ -1255,33 +1366,37 @@ Section DValue.
 
   Definition eval_fop (fop:fbinop) (v1:dvalue) (v2:dvalue) : EOU dvalue :=
     match v1, v2 with
+    | (DVALUE_Base dv1), (DVALUE_Base dv2) =>
+        DVALUE_Base <$> (eval_fop_base fop dv1 dv2)
+      
     | (DVALUE_Vector t elts1), (DVALUE_Vector _ elts2) =>
         let n := N.length elts1 in
         let m := N.length elts2 in
         if n =? m  then
-          val <- vec_loop (eval_fop_h fop) (List.combine elts1 elts2) ;;
-          ret (DVALUE_Vector t val)
+          (DVALUE_Vector t) <$> (vec_loop (eval_fop_base fop) (List.combine elts1 elts2))
         else
         raise_ub ("fop: " ++ (show fop) ++  " different-length vectors of type "
                     ++ (show t) ++ "v1 = " ++ (show v1) ++ "v2 = " ++ (show v2)
           )
-    | _, _ => eval_fop_h fop v1 v2
+    | _, _ => raise_error "eval_fop got illegal value"
     end.
   
-  Definition eval_fneg_h (v:dvalue) : EOU dvalue :=
+  Definition eval_fneg_base (v:dvalue_base) : EOU dvalue_base :=
     match v with
     | DVALUE_Float f  => ret (DVALUE_Float (Float32.neg f))
     | DVALUE_Double f => ret (DVALUE_Double (Float.neg f))
     | DVALUE_Poison t => ret (DVALUE_Poison t)
-    | _ => raise_error ("ill_typed-fneg ")
+    | _ => raise_error "ill_typed-fneg "
     end.
 
   Definition eval_fneg (v:dvalue) : EOU dvalue :=
     match v with
+    | DVALUE_Base db =>
+        DVALUE_Base <$> (eval_fneg_base db)
+                    
     | DVALUE_Vector t elts =>
-      val <- map_monad (eval_fneg_h) elts;;
-      ret (DVALUE_Vector t val)
-    | _ => eval_fneg_h v
+        (DVALUE_Vector t) <$>  (map_monad (eval_fneg_base) elts)
+    | _ => raise_error "eval_fneg got illegal value"
     end.
   
   Definition not_nan32 (f:ll_float) : bool :=
@@ -1296,7 +1411,7 @@ Section DValue.
   Definition ordered64 (f1 f2:ll_double) : bool :=
     andb (not_nan64 f1) (not_nan64 f2).
 
-  Definition float_cmp (fcmp:fcmp) (x:ll_float) (y:ll_float) : dvalue :=
+  Definition float_cmp (fcmp:fcmp) (x:ll_float) (y:ll_float) : dvalue_base :=
     if match fcmp with
        | FFalse => false
        | FOeq => andb (ordered32 x y) (Float32.cmp Ceq x y)
@@ -1318,7 +1433,7 @@ Section DValue.
     then @DVALUE_I 1 Integers.one else @DVALUE_I 1 Integers.zero.
   Arguments float_cmp _ _ _ : simpl nomatch.
 
-  Definition double_cmp (fcmp:fcmp) (x:ll_double) (y:ll_double) : dvalue :=
+  Definition double_cmp (fcmp:fcmp) (x:ll_double) (y:ll_double) : dvalue_base :=
     if match fcmp with
        | FFalse => false
        | FOeq => andb (ordered64 x y) (Float.cmp Ceq x y)
@@ -1340,7 +1455,7 @@ Section DValue.
     then @DVALUE_I 1 Integers.one else @DVALUE_I 1 Integers.zero.
     Arguments double_cmp _ _ _ : simpl nomatch.
 
-  Definition eval_fcmp_h (fcmp:fcmp) (v1:dvalue) (v2:dvalue) : EOU dvalue :=
+  Definition eval_fcmp_base (fcmp:fcmp) (v1:dvalue_base) (v2:dvalue_base) : EOU dvalue_base :=
     match v1, v2 with
     | DVALUE_Float f1, DVALUE_Float f2 => ret (float_cmp fcmp f1 f2)
     | DVALUE_Double f1, DVALUE_Double f2 => ret (double_cmp fcmp f1 f2)
@@ -1354,15 +1469,18 @@ Section DValue.
 
   Definition eval_fcmp (fcmp:fcmp) (v1:dvalue) (v2:dvalue) : EOU dvalue :=
     match v1, v2 with
+    | (DVALUE_Base dv1), (DVALUE_Base dv2) =>
+        DVALUE_Base <$> (eval_fcmp_base fcmp dv1 dv2)
+                    
     | (DVALUE_Vector t elts1), (DVALUE_Vector _ elts2) =>
         let n := N.length elts1 in
         let m := N.length elts2 in
         if n =? m  then 
-          val <- vec_loop (eval_fcmp_h fcmp) (List.combine elts1 elts2) ;;
+          val <- vec_loop (eval_fcmp_base fcmp) (List.combine elts1 elts2) ;;
           ret (DVALUE_Vector (DTYPE_Vector n (DTYPE_I 1)) val)
         else
           raise_ub "fcmp of different-length vectors"
-    | _, _ => eval_fcmp_h fcmp v1 v2
+    | _, _ => raise_error "eval_fcmp got illegal value"
     end.
 
   
@@ -1392,27 +1510,22 @@ Section DValue.
     | [] => ret elt
     | i::tl => 
         match str with
-        | DVALUE_Struct elts =>
+        | DVALUE_Struct p elts =>
             '(pre,sub,post) <- option_ub "insertvalue struct index out of bounds" (split [] i elts) ;;
             modified_subfield <- insert_value sub elt tl ;;
-            ret (DVALUE_Struct (pre ++ [modified_subfield] ++ post)%list)
+            ret (DVALUE_Struct p (pre ++ [modified_subfield] ++ post)%list)
     
-        | DVALUE_Packed_struct elts =>
-            '(pre,sub,post) <- option_ub "insertvalue packed struct index out of bounds" (split [] i elts) ;;
-            modified_subfield <- insert_value sub elt tl ;;
-            ret (DVALUE_Packed_struct (pre ++ [modified_subfield] ++ post))
-
         | DVALUE_Array t elts =>
             '(pre,sub,post) <- option_ub "insertvalue array index out of bounds" (split [] i elts) ;;
             modified_subfield <- insert_value sub elt tl ;;
             ret (DVALUE_Array t (pre ++ [modified_subfield] ++ post))
 
-        | DVALUE_Poison (DTYPE_Struct ts) =>
+        | DVALUE_Base (DVALUE_Poison (DTYPE_Struct p ts)) =>
             '(pre_t, sub_t, post_t) <- option_ub "insertvalue poison index out of bounds" (split [] i ts) ;;
-            let pre_dv := List.map DVALUE_Poison pre_t in
-            let post_dv := List.map DVALUE_Poison post_t in
-            modified_subfield <- insert_value (DVALUE_Poison sub_t) elt tl ;;
-            ret (DVALUE_Struct (pre_dv ++ [modified_subfield] ++ post_dv))
+            let pre_dv := List.map (fun t => DVALUE_Base (DVALUE_Poison t)) pre_t in
+            let post_dv := List.map (fun t => DVALUE_Base (DVALUE_Poison t)) post_t in
+            modified_subfield <- insert_value (DVALUE_Base (DVALUE_Poison sub_t)) elt tl ;;
+            ret (DVALUE_Struct p (pre_dv ++ [modified_subfield] ++ post_dv))
                 
         | _ => raise_error "insertvalue: non-aggregate type"
         end
@@ -1423,21 +1536,17 @@ Section DValue.
     | [] => ret str
     | i::tl => 
         match str with
-        | DVALUE_Struct elts =>
+        | DVALUE_Struct p elts =>
             '(pre,sub,post) <- option_ub "extractvalue struct index out of bounds" (split [] i elts) ;;
             extract_value sub tl 
     
-        | DVALUE_Packed_struct elts =>
-            '(pre,sub,post) <- option_ub "extractvalue packed struct index out of bounds" (split [] i elts) ;;
-            extract_value sub tl
-
         | DVALUE_Array t elts =>
             '(pre,sub,post) <- option_ub "extractvalue array index out of bounds" (split [] i elts) ;;
             extract_value sub tl 
 
-        | DVALUE_Poison (DTYPE_Struct ts) =>
+        | DVALUE_Base (DVALUE_Poison (DTYPE_Struct p ts)) =>
             '(pre_t, sub_t, post_t) <- option_ub "extractvalue poison index out of bounds" (split [] i ts) ;;
-            extract_value (DVALUE_Poison sub_t) tl 
+            extract_value (DVALUE_Base (DVALUE_Poison sub_t)) tl 
                 
         | _ => raise_error "extractvalue: non-aggregate type"
         end
@@ -1446,7 +1555,7 @@ Section DValue.
   Definition dvalue_to_Z (dv : dvalue) : option Z :=
     match dv with
     (* TODO: should this be restricted to 32 / 64-bit integers? *)      
-    | @DVALUE_I sz i2 => Some (signed i2)
+    | DVALUE_Base (@DVALUE_I sz i2) => Some (signed i2)
     | _ => None
     end.
   
@@ -1458,31 +1567,31 @@ Section DValue.
         match dvalue_to_Z idx with
         | Some i =>
             match split [] i elts with
-            | None => ret (DVALUE_Poison dt)
-            | Some (pre, elt, post) =>  ret elt
+            | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Base dt)))
+            | Some (pre, elt, post) =>  ret (DVALUE_Base elt)
             end
         | None => raise_error "extractelemnt: non-integer index"
         end
     | _ => raise_error "extractelement: non-vector type"
     end.
 
-  Definition insert_element (vec : dvalue) (elt : dvalue) (idx : dvalue) : EOU dvalue :=
+  Definition insert_element (vec : dvalue) (elt : dvalue_base) (idx : dvalue) : EOU dvalue :=
     match vec with
     | DVALUE_Vector (DTYPE_Vector sz dt) elts =>
         match dvalue_to_Z idx with
         | Some i =>
             match split [] i elts with
-            | None => ret (DVALUE_Poison (DTYPE_Vector sz dt))
+            | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz dt)))
             | Some (pre, _, post) =>  ret (DVALUE_Vector (DTYPE_Vector sz dt) (pre ++ [elt] ++ post))
             end
         | None => raise_error "insertelement: non-integer index"
         end
-    | DVALUE_Poison (DTYPE_Vector sz dt) =>
-        let elts := repeat (DVALUE_Poison dt) (N.to_nat sz) in
+    | DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz dt)) =>
+        let elts : list dvalue_base := repeat (DVALUE_Poison (DTYPE_Base dt)) (N.to_nat sz) in
         match dvalue_to_Z idx with
         | Some i =>
             match split [] i elts with
-            | None => ret (DVALUE_Poison (DTYPE_Vector sz dt))
+            | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz dt)))
             | Some (pre, _, post) =>  ret (DVALUE_Vector (DTYPE_Vector sz dt) (pre ++ [elt] ++ post))
             end
         | None => raise_error "insertelement: non-integer index"
@@ -1492,26 +1601,34 @@ Section DValue.
 
 (*  ------------------------------------------------------------------------- *)
 
+
+  Variant dvalue_base_has_dtyp_base : dvalue_base -> dtyp_base -> Prop :=
+  | DVALUE_Pointer_typ   : forall a, dvalue_base_has_dtyp_base (DVALUE_Pointer a) DTYPE_Pointer
+  | DVALUE_I_typ      : forall sz x, dvalue_base_has_dtyp_base (@DVALUE_I sz x) (DTYPE_I sz)
+  | DVALUE_Iptr_typ   : forall x, dvalue_base_has_dtyp_base (@DVALUE_Iptr x) DTYPE_Iptr
+  | DVALUE_Double_typ : forall x, dvalue_base_has_dtyp_base (DVALUE_Double x) (DTYPE_FP FP_double)
+  | DVALUE_Float_typ  : forall x, dvalue_base_has_dtyp_base (DVALUE_Float x) (DTYPE_FP FP_float)
+  | DVALUE_None_typ   : dvalue_base_has_dtyp_base DVALUE_None DTYPE_Void
+  | DVALUE_Poison_typ : forall τ, NO_VOID_base τ -> dvalue_base_has_dtyp_base (DVALUE_Poison (DTYPE_Base τ)) τ
+  | DVALUE_B_typ      : forall sz bits, length bits = (Pos.to_nat sz) ->
+                                   dvalue_base_has_dtyp_base (@DVALUE_B sz bits) (DTYPE_B sz)
+  .
+  
   (* Poison not included because of concretize *)
   Unset Elimination Schemes.
   Inductive dvalue_has_dtyp : dvalue -> dtyp -> Prop :=
-  | DVALUE_Addr_typ   : forall a, dvalue_has_dtyp (DVALUE_Addr a) DTYPE_Pointer
-  | DVALUE_I_typ      : forall sz x, dvalue_has_dtyp (@DVALUE_I sz x) (DTYPE_I sz)
-  | DVALUE_Iptr_typ   : forall x, dvalue_has_dtyp (@DVALUE_Iptr x) DTYPE_Iptr
-  | DVALUE_Double_typ : forall x, dvalue_has_dtyp (DVALUE_Double x) (DTYPE_FP FP_double)
-  | DVALUE_Float_typ  : forall x, dvalue_has_dtyp (DVALUE_Float x) (DTYPE_FP FP_float)
-  | DVALUE_None_typ   : dvalue_has_dtyp DVALUE_None DTYPE_Void
-  | DVALUE_Poison_typ  : forall τ, NO_VOID τ -> dvalue_has_dtyp (DVALUE_Poison τ) τ
+  | DVALUE_Base_typ :
+    forall dv t,
+      dvalue_base_has_dtyp_base dv t -> dvalue_has_dtyp (DVALUE_Base dv) (DTYPE_Base t)
 
+  | DVALUE_Poison_typ_agg :
+    forall t,
+      dvalue_has_dtyp (DVALUE_Base (DVALUE_Poison t)) t
+                                                       
   | DVALUE_Struct_typ :
-    forall fields dts,
+    forall p fields dts,
       List.Forall2 dvalue_has_dtyp fields dts ->
-      dvalue_has_dtyp (DVALUE_Struct fields) (DTYPE_Struct dts)
-
-  | DVALUE_Packed_struct_typ :
-    forall fields dts,
-      List.Forall2 dvalue_has_dtyp fields dts ->
-      dvalue_has_dtyp (DVALUE_Packed_struct fields) (DTYPE_Packed_struct dts)
+      dvalue_has_dtyp (DVALUE_Struct p fields) (DTYPE_Struct p dts)
 
   (* Do we have to exclude mmx? "There are no arrays, vectors or constants of this type" *)
   | DVALUE_Array_typ :
@@ -1519,20 +1636,23 @@ Section DValue.
       NO_VOID dt ->
       Forall (fun x => dvalue_has_dtyp x dt) xs ->
       length xs = (N.to_nat sz) ->
-      dvalue_has_dtyp (DVALUE_Array (DTYPE_Array sz dt) xs) (DTYPE_Array sz dt)
+      dvalue_has_dtyp (DVALUE_Array (DTYPE_Array sz dt) xs) (DTYPE_Array sz dt) 
 
   | DVALUE_Vector_typ :
       forall xs sz dt,
-      NO_VOID dt ->
-      Forall (fun x => dvalue_has_dtyp x dt) xs ->
+      NO_VOID_base dt ->
+      Forall (fun x => dvalue_base_has_dtyp_base x dt) xs ->
       length xs = (N.to_nat sz) ->
-      vector_dtyp dt ->
+      vector_dtyp_base dt ->
       dvalue_has_dtyp (DVALUE_Vector (DTYPE_Vector sz dt) xs) (DTYPE_Vector sz dt)
   .
   Set Elimination Schemes.
 
   Hint Constructors dvalue_has_dtyp : dvalue.
 
+
+  (* SAZ: I'm not sure where we use this dynamic typing information. *)
+  (*
   Section dvalue_has_dtyp_ind.
     Variable P : dvalue -> dtyp -> Prop.
     Hypothesis IH_Addr           : forall a, P (DVALUE_Addr a) DTYPE_Pointer.
@@ -1873,15 +1993,6 @@ Section DValue.
     | _ => false
     end.
 
-  (* SAZ: TODO - add the other conversion operations *)
-  (* SAZ: TODO - handle nuw and nsf flags for Trun, nneg for Zext *)
-  Definition conversion_okb (conv : LLVMAst.conversion_type) (from_dt to_dt : dtyp)  : bool :=
-    match conv with
-    | Trunc nuw nsw => lift_conv_okb trunc_base_okb from_dt to_dt
-    | Sext => lift_conv_okb ext_base_okb from_dt to_dt
-    | Zext nneg => lift_conv_okb ext_base_okb from_dt to_dt
-    | _ => false
-    end.
 
   (* Assumes:
      [l] is a list of indices treated as a path into the nested structure.
@@ -2104,18 +2215,17 @@ Section DValue.
     Qed.
     
   End EvalIopLemmas.
+   *)
 
-  Definition default_dvalue_of_dtyp_i (sz : positive) : dvalue :=
+  
+  Definition default_dvalue_of_dtyp_i (sz : positive) : dvalue_base :=
     @DVALUE_I sz (repr 0).
 
-  (* Handler for PickE which concretizes everything to 0 *)
-  (* If this succeeds the dvalue returned should agree with
-     dvalue_has_dtyp for the sake of the dvalue_default lemma. *)
-  Fixpoint default_dvalue_of_dtyp (dt : dtyp) : EOU dvalue :=
+  Definition default_dvalue_base_of_dtyp_base (dt : dtyp_base) : EOU dvalue_base :=
     match dt with
     | DTYPE_I sz => ret (default_dvalue_of_dtyp_i sz)
     | DTYPE_Iptr => ret (@DVALUE_Iptr zero_iptr)
-    | DTYPE_Pointer => ret (DVALUE_Addr null)
+    | DTYPE_Pointer => ret (DVALUE_Pointer null)
     | DTYPE_Void => raise_error "DTYPE_Void is not a true LLVM value"
     | DTYPE_FP FP_float => ret (DVALUE_Float Float32.zero)
     | DTYPE_FP FP_double => ret (DVALUE_Double (Float32.to_double Float32.zero))
@@ -2125,84 +2235,55 @@ Section DValue.
     | DTYPE_Metadata => raise_error "Unimplemented default type: metadata"
     | DTYPE_X86_mmx => raise_error "Unimplemented default type: x86_mmx"
     | DTYPE_Opaque => raise_error "Unimplemented default type: opaque"
+    | DTYPE_B sz => ret (DVALUE_B sz (repeat (Bit_bit zero) (Pos.to_nat sz)))
+    end.
+  
+  (* Handler for PickE which concretizes everything to 0 *)
+  (* If this succeeds the dvalue returned should agree with
+     dvalue_has_dtyp for the sake of the dvalue_default lemma. *)
+  Fixpoint default_dvalue_of_dtyp (dt : dtyp) : EOU dvalue :=
+    match dt with
+    | DTYPE_Base dt => DVALUE_Base <$> (default_dvalue_base_of_dtyp_base dt)
+    | DTYPE_Struct p fields =>
+        v <- map_monad default_dvalue_of_dtyp fields;;
+        ret (DVALUE_Struct p v)
     | DTYPE_Array sz t =>
         v <- default_dvalue_of_dtyp t ;;
-        (ret (DVALUE_Array dt (repeat v (N.to_nat sz))))
-
-    (* Matching valid Vector types... *)
-    (* Currently commented out unsupported ones *)
-    (* | DTYPE_Vector sz (DTYPE_Half) => *)
-    (*   if (0 <=? sz) then *)
-    (*     (ret (DVALUE_Vector *)
-    (*             (repeat (DVALUE_Float Float32.zero) (N.to_nat sz)))) *)
-    (*   else *)
-    (*     raise_error ("Negative array length for generating default value" ++ *)
-    (*     "of DTYPE_Array or DTYPE_Vector") *)
-    | DTYPE_Vector sz (DTYPE_FP FP_float) =>
-        ret (DVALUE_Vector dt
-               (repeat (DVALUE_Float Float32.zero) (N.to_nat sz)))
-    | DTYPE_Vector sz (DTYPE_FP FP_double) =>
-        ret (DVALUE_Vector dt
-               (repeat (DVALUE_Double (Float32.to_double Float32.zero))
-                       (N.to_nat sz)))
-    (* | DTYPE_Vector sz (DTYPE_X86_fp80) => *)
-    (*   if (0 <=? sz) then *)
-    (*     (ret (DVALUE_Vector *)
-    (*             (repeat (DVALUE_Float Float32.zero) (N.to_nat sz)))) *)
-    (*   else *)
-    (*     raise_error ("Negative array length for generating default value" ++ *)
-    (*     "of DTYPE_Array or DTYPE_Vector") *)
-    (* | DTYPE_Vector sz (DTYPE_Fp128) => *)
-    (*   if (0 <=? sz) then *)
-    (*     (ret (DVALUE_Vector *)
-    (*             (repeat (DVALUE_Float Float32.zero) (N.to_nat sz)))) *)
-    (*   else *)
-    (*     raise_error ("Negative array length for generating default value" ++ *)
-    (*     "of DTYPE_Array or DTYPE_Vector") *)
-    | DTYPE_Vector sz (DTYPE_I n) =>
-        let v := default_dvalue_of_dtyp_i n in
+        ret (DVALUE_Array dt (repeat v (N.to_nat sz)))
+    | DTYPE_Vector sz t =>
+        v <- default_dvalue_base_of_dtyp_base t ;;
         ret (DVALUE_Vector dt (repeat v (N.to_nat sz)))
-
-    | DTYPE_Vector sz DTYPE_Pointer =>
-        ret (DVALUE_Vector dt (repeat (DVALUE_Addr null) (N.to_nat sz)))
-
-    | DTYPE_Vector sz DTYPE_Iptr =>
-        ret (DVALUE_Vector dt (repeat (@DVALUE_Iptr zero_iptr) (N.to_nat sz)))
-
-    | DTYPE_Vector _ _ => raise_error ("Non-valid or unsupported vector type when generating default vector")
-    | DTYPE_Struct fields =>
-        v <- map_monad default_dvalue_of_dtyp fields;;
-        ret (DVALUE_Struct v)
-    | DTYPE_Packed_struct fields =>
-        v <- map_monad default_dvalue_of_dtyp fields;;
-        ret (DVALUE_Packed_struct v)
     end.
-   
+
+  Lemma dvalue_default_base_NO_VOID :
+    forall t v, default_dvalue_base_of_dtyp_base t = raise_ret v -> NO_VOID_base t.
+  Proof.
+    destruct t; intros; cbn; auto.
+    simpl in H. inversion H.
+  Qed.    
+    
   Lemma dvalue_default_NO_VOID :
     forall t v, default_dvalue_of_dtyp t = raise_ret v -> NO_VOID t.
   Proof using.
     induction t; intros; cbn; auto.
-    - inversion H.
-
-    - cbn in H.
-      repeat break_match_hyp_inv; auto.
-      eapply IHt; eauto.
-    - cbn in *.
-      break_match_hyp_inv.
-      rewrite FORALL_forall.
-      rewrite Forall_forall.
-      intros.
-      edestruct map_monad_EOU_success; eauto.
-    - cbn in *.
+    -  simpl in H.
+       destruct (default_dvalue_base_of_dtyp_base t) eqn:HEQ; inversion H.
+       eapply dvalue_default_base_NO_VOID. eapply HEQ.
+    - cbn in H0.
       break_match_hyp_inv.
       rewrite FORALL_forall.
       rewrite Forall_forall.
       intros.
       edestruct map_monad_EOU_success; eauto.
     - cbn in H.
-      repeat break_match_hyp_inv; cbn; auto.
+      break_match_hyp_inv.
+      eapply IHt. reflexivity.
+    - simpl in H.
+      destruct (default_dvalue_base_of_dtyp_base t) eqn:HEQ; inversion H.
+      eapply dvalue_default_base_NO_VOID. eapply HEQ.
   Qed.
- 
+
+  (*
   Lemma dvalue_default : forall t v,
       default_dvalue_of_dtyp t = ret v ->
       dvalue_has_dtyp v t.
@@ -2256,7 +2337,7 @@ Section DValue.
       + unfold vector_dtyp.
         right. right. right. exists FP_double. auto.
   Qed.
-
+*)
 End DValue.
 
 Arguments DVALUE_I {Pa} sz.
@@ -2265,5 +2346,5 @@ Arguments DVALUE_I {Pa} sz.
 #[global] Hint Constructors dvalue_has_dtyp : DVALUE_HAS_DTYP.
 #[global] Hint Rewrite Nnat.Nat2N.id : DVALUE_HAS_DTYP.
 #[global] Hint Resolve List.repeat_length : DVALUE_HAS_DTYP.
-#[global] Hint Extern 1 (NO_VOID _) => solve_no_void : DVALUE_HAS_DTYP.
+(* #[global] Hint Extern 1 (NO_VOID _) => solve_no_void : DVALUE_HAS_DTYP. *)
 

--- a/src/rocq/Semantics/Implementations/Memory.v
+++ b/src/rocq/Semantics/Implementations/Memory.v
@@ -41,32 +41,32 @@ Import Logic.
 Section MemoryModel.
   Context {Pa : Params} {MMP : @MemoryModelPrimitives Pa}.
 
-  (* We would like a better representation than a list *)
-  Definition get_consecutive_ptrs (ptr : addr) (size : N) : EOU (list addr) :=
+  (* We would like a better representation than a list *) 
+  Definition get_consecutive_ptrs (p : ptr) (size : N) : EOU (list ptr) :=
     ixs <- intptr_seq 0 size;;
     map_monad
-      (fun ix => handle_gep_addr (DTYPE_I 8) ptr [DVALUE_Iptr ix])
+      (fun ix => handle_gep_ptr (DTYPE_I 8) p [DVALUE_Base (DVALUE_Iptr ix)])
       ixs.
 
   (** Reading dvalues *)
-  Definition read_bytes (ptr : addr) (size : N) : memM (list memory_byte) :=
-    ptrs <- lift (get_consecutive_ptrs ptr size);;
+  Definition read_bytes (p : ptr) (size : N) : memM (list memory_byte) :=
+    ptrs <- lift (get_consecutive_ptrs p size);;
     (* Actually perform reads *)
     map_monad read_byte ptrs.
   
-  Definition read_dvalue (dt : dtyp) (ptr : addr) : memM dvalue :=
-    bytes <- read_bytes ptr (sizeof_dtyp dt);;
+  Definition read_dvalue (dt : dtyp) (p : ptr) : memM dvalue :=
+    bytes <- read_bytes p (sizeof_dtyp dt);;
     lift (memory_bytes_to_dvalue bytes dt).
 
   (** Writing dvalues *)
-  Definition write_bytes (ptr : addr) (bytes : list memory_byte) : memM unit :=
-    ptrs <- lift (get_consecutive_ptrs ptr (N.length bytes));;
+  Definition write_bytes (p : ptr) (bytes : list memory_byte) : memM unit :=
+    ptrs <- lift (get_consecutive_ptrs p (N.length bytes));;
     let ptr_bytes := zip ptrs bytes in
     (* Actually perform writes *)
     map_monad_ (fun '(ptr, byte) => write_byte ptr byte) ptr_bytes.
 
-  Definition write_dvalue (dt : dtyp) (ptr : addr) (v : dvalue) : memM unit :=
-    write_bytes ptr (dvalue_to_memory_bytes v dt).
+  Definition write_dvalue (dt : dtyp) (p : ptr) (v : dvalue) : memM unit :=
+    write_bytes p (dvalue_to_memory_bytes v dt).
 
   Definition generate_num_poison_bytes_h
     (start_ix : N) (num : N) (dt : dtyp) : list memory_byte :=
@@ -84,11 +84,11 @@ Section MemoryModel.
     generate_num_poison_bytes (sizeof_dtyp dt) dt.
 
   (** Allocating dtyps *)
-  Definition allocate_bytes (init_bytes : list memory_byte) (align : N) : memM addr :=
+  Definition allocate_bytes (init_bytes : list memory_byte) (align : N) : memM ptr :=
     pr <- fresh_prov;;
     allocate_bytes_with_pr init_bytes align pr.
 
-  Definition allocate_dtyp (dt : dtyp) (num_elements : N) (align : N) : memM addr :=
+  Definition allocate_dtyp (dt : dtyp) (num_elements : N) (align : N) : memM ptr :=
     if dtyp_eqb dt DTYPE_Void
     then mub "allocating void type"
     else element_bytes <- repeatMN num_elements (ret (generate_poison_bytes dt));;
@@ -106,17 +106,17 @@ Section MemoryModel.
             | None => 8%N
             | Some align => align
             end in
-          addr <- allocate_dtyp t n align;;
-          ret (DVALUE_Addr addr)
+          ptr <- allocate_dtyp t n align;;
+          ret (DVALUE_Base (DVALUE_Pointer ptr))
       | Load t a =>
           match a with
-          | DVALUE_Addr a =>
+          | DVALUE_Base (DVALUE_Pointer a) =>
               read_dvalue t a
-          | _ => mub "Loading from something that isn't an address."
+          | _ => mub "Loading from something that isn't an ptress."
           end
       | Store t a v =>
           match a with
-          | DVALUE_Addr a =>
+          | DVALUE_Base (DVALUE_Pointer a) =>
               write_dvalue t a v
           | _ => mub "Writing something to somewhere that isn't an address."
           end
@@ -125,12 +125,12 @@ Section MemoryModel.
   (** ** Memory-sensitive intrinsics *)
   
   (** Malloc *)
-  Definition malloc_bytes (init_bytes : list memory_byte) (align : N) : memM addr :=
+  Definition malloc_bytes (init_bytes : list memory_byte) (align : N) : memM ptr :=
     pr <- fresh_prov;;
     malloc_bytes_with_pr init_bytes align pr.
 
   (** Handle memcpy *)
-  Definition memcpy (src dst : addr) (size : N) (volatile : bool) : memM unit :=
+  Definition memcpy (src dst : ptr) (size : N) (volatile : bool) : memM unit :=
     (* From LangRef: The ‘llvm.memcpy.*’ intrinsics copy a block of
            memory from the source location to the destination location, which
            must either be equal or non-overlapping. *)
@@ -146,7 +146,7 @@ Section MemoryModel.
 
   (** memset spec *)
   Definition memset
-    (dst : addr) (val : int8) (len : Z) (volatile : bool) : memM unit :=
+    (dst : ptr) (val : int8) (len : Z) (volatile : bool) : memM unit :=
     if Z.ltb len 0
     then
       mub "memset given negative length."
@@ -154,25 +154,25 @@ Section MemoryModel.
       let byte := MByte (DVALUE_I 8 val) (DTYPE_I 8) 0 in
       write_bytes dst (repeatN (Z.to_N len) byte).
   
-  Definition handle_memcpy (args : list dvalue) : memM unit :=
+  Definition handle_memcpy (args : list dvalue_base) : memM unit :=
     match args with
-    | DVALUE_Addr dst ::
-        DVALUE_Addr src ::
+    | DVALUE_Pointer dst ::
+        DVALUE_Pointer src ::
         DVALUE_I sz size ::
         DVALUE_I _ volatile :: [] (* volatile ignored *)  =>
         memcpy src dst (Z.to_N (unsigned size)) (equ volatile VellvmIntegers.one)
-    | DVALUE_Addr dst ::
-        DVALUE_Addr src ::
+    | DVALUE_Pointer dst ::
+        DVALUE_Pointer src ::
         DVALUE_Iptr size ::
         DVALUE_I _ volatile :: [] (* volatile ignored *)  =>
         memcpy src dst (Z.to_N (to_Z size)) (equ volatile VellvmIntegers.one)
     | _ => merr "Unsupported arguments to memcpy."
     end.
   
-  Definition handle_memset (args : list dvalue) : memM unit.
+  Definition handle_memset (args : list dvalue_base) : memM unit.
     refine
       (match args with
-       | DVALUE_Addr dst ::
+       | DVALUE_Pointer dst ::
            DVALUE_I sz_val val ::
            DVALUE_I sz_len len ::
            DVALUE_I sz_vol volatile :: [] (* volatile ignored *)  =>
@@ -186,7 +186,7 @@ Section MemoryModel.
     - exact (merr "Unsupported arguments to memset.").
   Defined. 
 
-  Definition handle_malloc (args : list dvalue) (align : N) : memM addr :=
+  Definition handle_malloc (args : list dvalue_base) (align : N) : memM ptr :=
     match args with
     | [DVALUE_I bitwidth sz] =>
         malloc_bytes (generate_num_poison_bytes (Z.to_N (unsigned sz)) (DTYPE_I 8)) align
@@ -195,30 +195,33 @@ Section MemoryModel.
     | _ => merr "Malloc: invalid arguments."
     end.
 
-  Definition handle_free (args : list dvalue) : memM unit :=
+  Definition handle_free (args : list dvalue_base) : memM unit :=
     match args with
-    | [DVALUE_Addr ptr] => free ptr
+    | [DVALUE_Pointer ptr] => free ptr
     | _ => merr "Free: invalid arguments."
     end.
 
+  Definition NONE := DVALUE_Base DVALUE_None.
+  
   Definition handle_intrinsicM : IntrinsicE ~> memM :=
     fun T e =>
       match e with
       | Intrinsic t name args _ =>
+          args' <- lift (map_monad dvalue_to_dvalue_base args) ;;
           (* Pick all arguments, they should all be unique. *)
           (* TODO: add more variants to memcpy *)
           (* FIXME: use reldec typeclass? *)
           if orb (Rocqlib.proj_sumbool (string_dec name "llvm.memcpy.p0i8.p0i8.i32"))
                (Rocqlib.proj_sumbool (string_dec name "llvm.memcpy.p0i8.p0i8.i64"))
           then
-            handle_memcpy args;;
-            ret (inr DVALUE_None)
+            handle_memcpy args' ;;
+            ret (inr NONE)
           else
             if orb (Rocqlib.proj_sumbool (string_dec name "llvm.memset.p0i8.i32"))
                  (Rocqlib.proj_sumbool (string_dec name "llvm.memset.p0i8.i64"))
             then
-              handle_memset args;;
-              ret (inr DVALUE_None)
+              handle_memset args' ;;
+              ret (inr NONE)
             else
               if (Rocqlib.proj_sumbool (string_dec name "malloc"))
               then
@@ -226,13 +229,13 @@ Section MemoryModel.
                    it should be implemented as the best alignment
                    given the size.
                  *)
-                addr <- handle_malloc args 8%N;;
-                ret (inr (DVALUE_Addr addr))
+                ptr <- handle_malloc args' 8%N;;
+                ret (inr (DVALUE_Base (DVALUE_Pointer ptr)))
               else
                 if (Rocqlib.proj_sumbool (string_dec name "free"))
                 then
-                  handle_free args;;
-                  ret (inr DVALUE_None)
+                  handle_free args' ;;
+                  ret (inr NONE)
                 else
                   merr ("Unknown intrinsic: " ++ name)
       end.
@@ -249,13 +252,13 @@ Section Implementation.
       i.e. when the function returns.
       A [frame_stack] is a list of such frames.
    *)
-  Definition Frame := list addr.
+  Definition Frame := list ptr.
   Inductive Framestack : Type :=
   | Singleton (f : Frame)
   | Snoc (s : Framestack) (f : Frame).
 
   (** ** Heaps *)
-  Definition block := list addr.
+  Definition block := list ptr.
   Definition Heap := IntMap block.
 
   (** ** Memory stack
@@ -302,18 +305,18 @@ Section Implementation.
     |}.
 
   (** Operations on memory *)
-  Definition read_byte_raw_mem (mem : memory) (phys_addr : Z) : option byte :=
-    IM.find phys_addr mem.
-  Definition set_byte_raw_mem  (mem : memory) (phys_addr : Z) (byte : byte) : memory :=
-    IM.add phys_addr byte mem.
+  Definition read_byte_raw_mem (mem : memory) (phys_ptr : Z) : option byte :=
+    IM.find phys_ptr mem.
+  Definition set_byte_raw_mem  (mem : memory) (phys_ptr : Z) (byte : byte) : memory :=
+    IM.add phys_ptr byte mem.
   
  (** Add block to memory with a given allocation id *)
   Definition memory_bytes_to_bytes
     (aid : allocationId) (bytes : list memory_byte) : list byte :=
     map (fun b => (b, aid)) bytes.
 
-  (* Register a concrete address in a frame *)
-  Definition add_to_frame (m : memory_stack) (k : addr) : memory_stack :=
+  (* Register a concrete ptress in a frame *)
+  Definition add_to_frame (m : memory_stack) (k : ptr) : memory_stack :=
     let '(mkMemoryStack m s h) := m in
     match s with
     | Singleton f => mkMemoryStack m (Singleton (k :: f)) h
@@ -321,20 +324,20 @@ Section Implementation.
     end.
 
   (* Register a list of concrete addresses in a frame *)
-  Definition add_all_to_frame (ks : list addr) (m : memory_stack) : memory_stack
+  Definition add_all_to_frame (ks : list ptr) (m : memory_stack) : memory_stack
     := fold_left (fun ms k => add_to_frame ms k) ks m.
 
   (* Register a ptr with the heap *)
-  Definition add_to_heap (m : memory_stack) (root : addr) (ptr : addr) : memory_stack :=
+  Definition add_to_heap (m : memory_stack) (root : ptr) (p : ptr) : memory_stack :=
     let '(mkMemoryStack m s h) := m in
-    let h' := add_with (ptr_to_int root) ptr ret cons h in
+    let h' := add_with (ptr_to_int root) p ret cons h in
     mkMemoryStack m s h'.
 
   (* Register a list of concrete addresses in the heap *)
-  Definition add_all_to_heap' (m : memory_stack) (root : addr) (ks : list addr) : memory_stack
+  Definition add_all_to_heap' (m : memory_stack) (root : ptr) (ks : list ptr) : memory_stack
     := fold_left (fun ms k => add_to_heap ms root k) ks m.
 
-  Definition add_all_to_heap (ks : list addr) (m : memory_stack) : memory_stack
+  Definition add_all_to_heap (ks : list ptr) (m : memory_stack) : memory_stack
     := match ks with
        | [] => m
        | (root :: _) =>
@@ -415,9 +418,9 @@ Section Implementation.
     | Snoc s f => ret s
     end.
 
-  Definition read_byte_raw (msg : string) (phys_addr : Z) : memM byte :=
+  Definition read_byte_raw (msg : string) (phys_ptr : Z) : memM byte :=
     s <- get ;;
-    match read_byte_raw_mem (Memory_stack_memory (state_get_memory s)) phys_addr with
+    match read_byte_raw_mem (Memory_stack_memory (state_get_memory s)) phys_ptr with
     | Some b => ret b
     | None => Mub msg
     end.
@@ -427,57 +430,57 @@ Section Implementation.
     upd_mem (set_byte_raw_mem m phys_addr byte).
 
   (** Add block to memory with a given allocation id *)
-  Definition add_block (aid : allocationId) (ptr : addr)
-    (ptrs : list addr) (init_bytes : list memory_byte) : memM unit :=
+  Definition add_block (aid : allocationId) (p : ptr)
+    (ptrs : list ptr) (init_bytes : list memory_byte) : memM unit :=
     let mem_bytes := memory_bytes_to_bytes aid init_bytes in
     m <- get_mem;;
-    upd_mem (add_all_index mem_bytes (ptr_to_int ptr) m).
+    upd_mem (add_all_index mem_bytes (ptr_to_int p) m).
 
   (** Add pointers to the stack frame *)
-  Definition add_ptrs_to_frame (ptrs : list addr) : memM unit :=
+  Definition add_ptrs_to_frame (ptrs : list ptr) : memM unit :=
     app_mem_stack (add_all_to_frame ptrs).
   
-  Definition add_ptrs_to_heap (ptrs : list addr) : memM unit :=
+  Definition add_ptrs_to_heap (ptrs : list ptr) : memM unit :=
     app_mem_stack (add_all_to_heap ptrs).
  
   (** Add a block of bytes to memory, and register it in the current stack frame. *)
-  Definition add_block_to_stack (aid : allocationId) (ptr : addr)
-    (ptrs : list addr) (init_bytes : list memory_byte) : memM unit :=
-    add_block aid ptr ptrs init_bytes;;
+  Definition add_block_to_stack (aid : allocationId) (p : ptr)
+    (ptrs : list ptr) (init_bytes : list memory_byte) : memM unit :=
+    add_block aid p ptrs init_bytes;;
     add_ptrs_to_frame ptrs.
 
   (** Add a block of bytes to memory, and register it in the heap. *)
   (* Should we make sure ptr (the root) is added even if ptrs is empty? *)
-  Definition add_block_to_heap (aid : allocationId) (ptr : addr)
-    (ptrs : list addr) (init_bytes : list memory_byte) : memM unit :=
-    add_block aid ptr ptrs init_bytes;;
+  Definition add_block_to_heap (aid : allocationId) (p : ptr)
+    (ptrs : list ptr) (init_bytes : list memory_byte) : memM unit :=
+    add_block aid p ptrs init_bytes;;
     add_ptrs_to_heap ptrs.
 
-  Definition Read_byte (ptr : addr) : memM memory_byte :=
-    let addr := ptr_to_int ptr in
-    let pr := address_provenance ptr in
+  Definition Read_byte (p : ptr) : memM memory_byte :=
+    let addr := ptr_to_int p in
+    let pr := ptr_provenance p in
     '(byte,aid) <- read_byte_raw "Reading from unallocated memory." addr;;
     if access_allowed pr aid
     then ret byte
     else mub ("Read from memory with invalid provenance").
 
   (** Writes *)
-  Definition Write_byte (ptr : addr) (byte : memory_byte) : memM unit :=
-    let addr := ptr_to_int ptr in
-    let pr := address_provenance ptr in
+  Definition Write_byte (p : ptr) (byte : memory_byte) : memM unit :=
+    let addr := ptr_to_int p in
+    let pr := ptr_provenance p in
     '(_,aid) <- read_byte_raw "Writing to unallocated memory" addr ;;
     if access_allowed pr aid
     then set_byte_raw addr (byte,aid)
     else mub "Trying to write to memory with invalid provenance".
 
-  Definition get_free_block (size : N) (align : N) (pr : provenance) : memM (addr * list addr) :=
+  Definition get_free_block (size : N) (align : N) (pr : provenance) : memM (ptr * list ptr) :=
     let aid := provenance_to_allocation_id pr in
     addr <- next_key size align ;;
     ptr <- lift (int_to_ptr addr (allocation_id_to_prov aid)) ;;
     ptrs <- lift (get_consecutive_ptrs ptr size);;
     ret (ptr,ptrs).
 
-  Definition Allocate_bytes_with_pr (init_bytes : list memory_byte) (align : N) (pr : provenance) : memM addr :=
+  Definition Allocate_bytes_with_pr (init_bytes : list memory_byte) (align : N) (pr : provenance) : memM ptr :=
     let size := N.length init_bytes in
     let aid := provenance_to_allocation_id pr in
     '(ptr, ptrs) <- get_free_block size align pr;;
@@ -485,7 +488,7 @@ Section Implementation.
     ret ptr.
 
   (** Heap allocation *)
-  Definition Malloc_bytes_with_pr (init_bytes : list memory_byte) (align : N) (pr : provenance) : memM addr :=
+  Definition Malloc_bytes_with_pr (init_bytes : list memory_byte) (align : N) (pr : provenance) : memM ptr :=
     let size := N.length init_bytes in
     let aid := provenance_to_allocation_id pr in
     '(ptr, ptrs) <- get_free_block size align pr;;
@@ -510,8 +513,8 @@ Section Implementation.
   Definition free_block_memory (b : block) (m : memory) : memory :=
     fold_left (fun m key => free_byte (ptr_to_int key) m) b m.
 
-  Definition Free (ptr : addr) : memM unit :=
-    let raw_addr := ptr_to_int ptr in
+  Definition Free (p : ptr) : memM unit :=
+    let raw_addr := ptr_to_int p in
     h <- get_heap ;;
     match lookup raw_addr h with
     | None => mub "Attempt to free non-heap allocated address."

--- a/src/rocq/Semantics/Implementations/ParamsV.v
+++ b/src/rocq/Semantics/Implementations/ParamsV.v
@@ -1,7 +1,7 @@
 From Vellvm Require Import
   Params
   Implementations.Provenance
-  Implementations.Address
+  Implementations.Pointer
   Implementations.Sizeof.
 
 Instance ParamsV {IP : IPtr} {IPT : @IPtrTheory IP}: Params.

--- a/src/rocq/Semantics/Implementations/Pointer.v
+++ b/src/rocq/Semantics/Implementations/Pointer.v
@@ -6,7 +6,7 @@ From Vellvm Require Import
   Rocqlib
   EOU
   Interfaces.IPtr
-  Interfaces.Address
+  Interfaces.Pointer
   Interfaces.Provenance
   Implementations.Provenance
   VellvmIntegers.
@@ -19,12 +19,12 @@ Section withIPtr.
   (* TODO: move this *)
   Instance showIptr {IP : IPtr} : Show iptr := {| show := show_iptr |}.
 
-  #[refine] Instance AddressV {IP : IPtr} : @Address ProvenanceV :=
+  #[refine] Instance PointerV {IP : IPtr} : @Pointer ProvenanceV :=
     {|
-      addr := (iptr * prov);
+      ptr := (iptr * prov);
       null := (zero_iptr, nil_prov)%Z;
-      address_provenance := snd;
-      show_addr a := show a;
+      ptr_provenance := snd;
+      show_ptr a := show a;
     |}.
   Proof.
     intros [a1 a2] [b1 b2].
@@ -35,14 +35,14 @@ Section withIPtr.
     - right. intros H. inversion H; subst. apply n. reflexivity.
   Defined.
 
-  Instance PIV : @PI ProvenanceV AddressV :=
+  Instance PIV : @PI ProvenanceV PointerV :=
     {|
       ptr_to_int p := to_Z (fst p);
       int_to_ptr i pr := a <- from_Z i ;; ret (a, pr) 
     |}
   .
 
-  Instance PITheoryV : @PITheory ProvenanceV AddressV PIV.
+  Instance PITheoryV : @PITheory ProvenanceV PointerV PIV.
   Proof.
     constructor.
     - cbn; intros * EQ.

--- a/src/rocq/Semantics/Implementations/Sizeof.v
+++ b/src/rocq/Semantics/Implementations/Sizeof.v
@@ -9,40 +9,52 @@ From Vellvm.Semantics Require Import
 (* TODO: make parameter? *)
 Definition ptr_size : nat := 8.
 
+Definition Dtyp_base_alignment (dt : dtyp_base) : alignment :=
+  match dt with  
+    | DTYPE_I sz =>
+        if Pos.leb sz 8
+        then Build_alignment 1 1
+        else if Pos.leb sz 16
+             then Build_alignment 2 2
+             else if Pos.leb sz 32
+                  then Build_alignment 4 4
+                  else Build_alignment 4 8
+    | DTYPE_Iptr => Build_alignment 8 8
+    | DTYPE_Pointer => Build_alignment 8 8
+    | DTYPE_Void => Build_alignment 1 1
+    | DTYPE_FP FP_half => Build_alignment 2 2
+    | DTYPE_FP FP_bfloat => Build_alignment 2 2  (* same as for half? *)
+    | DTYPE_FP FP_float => Build_alignment 4 4
+    | DTYPE_FP FP_double => Build_alignment 8 8
+    | DTYPE_FP FP_x86_fp80 => Build_alignment 16 16  (* Not sure if this is right *)
+    | DTYPE_FP FP_fp128 => Build_alignment 16 16
+    | DTYPE_FP FP_ppc_fp128 => Build_alignment 16 16
+    | DTYPE_Label => Build_alignment 8 8 (* treat labels as pointers? *)
+    | DTYPE_Token => Build_alignment 8 8 (* not sure what alignment for token values *)
+    | DTYPE_Metadata => Build_alignment 1 1
+    | DTYPE_X86_mmx => Build_alignment 8 8 (* I assume these are 64-bit, but I'm not sure *)
+    | DTYPE_Opaque => Build_alignment 1 1
+    | DTYPE_B sz =>
+        if Pos.leb sz 8
+        then Build_alignment 1 1
+        else if Pos.leb sz 16
+             then Build_alignment 2 2
+             else if Pos.leb sz 32
+                  then Build_alignment 4 4
+                  else Build_alignment 4 8
+  end.  
+
 (* Default alignment matching LLVMs defaults *)
-Definition Dtyp_alignment (dt : dtyp) : alignment
-  := match dt with
-     | DTYPE_I sz =>
-         if Pos.leb sz 8
-         then Build_alignment 1 1
-         else if Pos.leb sz 16
-              then Build_alignment 2 2
-              else if Pos.leb sz 32
-                   then Build_alignment 4 4
-                   else Build_alignment 4 8
-     | DTYPE_Iptr => Build_alignment 8 8
-     | DTYPE_Pointer => Build_alignment 8 8
-     | DTYPE_Void => Build_alignment 1 1
-     | DTYPE_FP FP_half => Build_alignment 2 2
-     | DTYPE_FP FP_bfloat => Build_alignment 2 2  (* same as for half? *)
-     | DTYPE_FP FP_float => Build_alignment 4 4
-     | DTYPE_FP FP_double => Build_alignment 8 8
-     | DTYPE_FP FP_x86_fp80 => Build_alignment 16 16  (* Not sure if this is right *)
-     | DTYPE_FP FP_fp128 => Build_alignment 16 16
-     | DTYPE_FP FP_ppc_fp128 => Build_alignment 16 16
-     | DTYPE_Label => Build_alignment 8 8 (* treat labels as pointers? *)
-     | DTYPE_Token => Build_alignment 8 8 (* not sure what alignment for token values *)
-     | DTYPE_Metadata => Build_alignment 1 1
-     | DTYPE_X86_mmx => Build_alignment 8 8 (* I assume these are 64-bit, but I'm not sure *)
-     | DTYPE_Array sz t => Build_alignment 8 8
-     | DTYPE_Struct fields => Build_alignment 8 8
-     | DTYPE_Packed_struct fields => Build_alignment 8 8
-     | DTYPE_Opaque => Build_alignment 1 1
-     | DTYPE_Vector sz t =>
-         (* Alignment depends on the size of the vector types *)
-         (* TODO: 64-bit+ vectors should be 128-bit aligned *)
-         Build_alignment 8 8
-     end.
+Definition Dtyp_alignment (dt : dtyp) : alignment :=
+  match dt with
+  | DTYPE_Base t => Dtyp_base_alignment t
+  | DTYPE_Array sz t => Build_alignment 8 8
+  | DTYPE_Struct p fields => Build_alignment 8 8
+  | DTYPE_Vector sz t =>
+      (* Alignment depends on the size of the vector types *)
+      (* TODO: 64-bit+ vectors should be 128-bit aligned *)
+      Build_alignment 8 8
+  end.
 
 Definition max_preferred_dtyp_alignment (dts : list dtyp) : N :=
   match maximumByOpt (fun dt1 dt2 => preferred_alignment (Dtyp_alignment dt1) <? preferred_alignment (Dtyp_alignment dt1))%N dts with
@@ -71,7 +83,7 @@ Definition byte_sizeof_floating_point_variant (fp : floating_point_variant) : N 
 Definition bit_sizeof_floating_point_variant (fp : floating_point_variant) : N :=
   8 * (byte_sizeof_floating_point_variant fp).
 
-Fixpoint Bit_sizeof_dtyp (ty : dtyp) : N :=
+Definition Bit_sizeof_dtyp_base (ty : dtyp_base) : N :=
   match ty with
   | DTYPE_I sz => Npos sz
   | DTYPE_Iptr => 64 (* TODO: probably kind of a lie... *)
@@ -82,40 +94,53 @@ Fixpoint Bit_sizeof_dtyp (ty : dtyp) : N :=
   | DTYPE_Token => 64 (* ??? *)
   | DTYPE_Metadata => 0
   | DTYPE_X86_mmx => 64
+  | DTYPE_Opaque => 0
+  | DTYPE_B sz => Npos sz
+  end.
+
+Fixpoint Bit_sizeof_dtyp (ty : dtyp) : N :=
+  match ty with
+  | DTYPE_Base t => Bit_sizeof_dtyp_base t
   | DTYPE_Array sz t => sz * (round_up_to_eight (Bit_sizeof_dtyp t))
-  | DTYPE_Struct fields =>
+  | DTYPE_Struct false fields =>
       let sz := fold_left (fun acc x => pad_to_align_bitwise (Dtyp_alignment x) acc + (Bit_sizeof_dtyp x)%N) fields 0%N in
       let max_align := 8 * (max_preferred_dtyp_alignment fields) in
       pad_to max_align sz
-  | DTYPE_Packed_struct fields =>
+  | DTYPE_Struct true fields =>
       fold_left (fun acc x => (acc + round_up_to_eight (Bit_sizeof_dtyp x))%N) fields 0%N
-  | DTYPE_Opaque => 0
-  | DTYPE_Vector sz t => sz * Bit_sizeof_dtyp t
+  | DTYPE_Vector sz t => sz * Bit_sizeof_dtyp_base t
   end.
 
-Fixpoint Sizeof_dtyp (ty:dtyp) : N :=
+Definition Sizeof_dtyp_base (ty:dtyp_base) : N :=
   match ty with
   | DTYPE_Void         => 0
   | DTYPE_I sz         => N.max 1 (N.div (Npos sz) 8)
   | DTYPE_Iptr         => N.of_nat ptr_size
   | DTYPE_Pointer      => N.of_nat ptr_size
-  | DTYPE_Packed_struct l =>
-      fold_left (fun acc x => (acc + Sizeof_dtyp x)%N) l 0%N
-  | DTYPE_Struct l =>
-      let sz := fold_left (fun acc x => pad_to_align (Dtyp_alignment x) acc + (Sizeof_dtyp x)%N) l 0%N in
-      let max_align := max_preferred_dtyp_alignment l in
-      pad_to max_align sz
-  | DTYPE_Vector sz ty'  (* TODO: Vector sizeof currently invalid for sub-bytesize / non-byte aligned elements. Changing this involves changing serialization. *)
-  | DTYPE_Array sz ty' =>
-      sz * (Sizeof_dtyp ty')
   | DTYPE_FP fp        => byte_sizeof_floating_point_variant fp
   | DTYPE_Label        => 8
   | DTYPE_Token        => 8
   | DTYPE_Metadata     => 0
   | DTYPE_X86_mmx      => 8 (* TODO: Unsupported *)
   | DTYPE_Opaque       => 0 (* TODO: Unsupported *)
+  | DTYPE_B sz         => N.max 1 (N.div (Npos sz) 8)
   end.
-
+                           
+Fixpoint Sizeof_dtyp (ty:dtyp) : N :=
+  match ty with
+  | DTYPE_Base t => Sizeof_dtyp_base t
+  | DTYPE_Struct true l =>
+      fold_left (fun acc x => (acc + Sizeof_dtyp x)%N) l 0%N
+  | DTYPE_Struct false l =>
+      let sz := fold_left (fun acc x => pad_to_align (Dtyp_alignment x) acc + (Sizeof_dtyp x)%N) l 0%N in
+      let max_align := max_preferred_dtyp_alignment l in
+      pad_to max_align sz
+  | DTYPE_Vector sz ty' =>
+  (* TODO: Vector sizeof currently invalid for sub-bytesize / non-byte aligned elements. Changing this involves changing serialization. *)
+      sz * (Sizeof_dtyp_base ty')
+  | DTYPE_Array sz ty' =>
+      sz * (Sizeof_dtyp ty')
+  end.
 
 Instance SizeofV : Sizeof :=
   {|

--- a/src/rocq/Semantics/Implementations/Sizeof.v
+++ b/src/rocq/Semantics/Implementations/Sizeof.v
@@ -48,12 +48,10 @@ Definition Dtyp_base_alignment (dt : dtyp_base) : alignment :=
 Definition Dtyp_alignment (dt : dtyp) : alignment :=
   match dt with
   | DTYPE_Base t => Dtyp_base_alignment t
-  | DTYPE_Array sz t => Build_alignment 8 8
-  | DTYPE_Struct p fields => Build_alignment 8 8
-  | DTYPE_Vector sz t =>
       (* Alignment depends on the size of the vector types *)
       (* TODO: 64-bit+ vectors should be 128-bit aligned *)
-      Build_alignment 8 8
+  | DTYPE_Struct p fields => Build_alignment 8 8
+  | DTYPE_Array v sz t => Build_alignment 8 8
   end.
 
 Definition max_preferred_dtyp_alignment (dts : list dtyp) : N :=
@@ -101,14 +99,14 @@ Definition Bit_sizeof_dtyp_base (ty : dtyp_base) : N :=
 Fixpoint Bit_sizeof_dtyp (ty : dtyp) : N :=
   match ty with
   | DTYPE_Base t => Bit_sizeof_dtyp_base t
-  | DTYPE_Array sz t => sz * (round_up_to_eight (Bit_sizeof_dtyp t))
   | DTYPE_Struct false fields =>
       let sz := fold_left (fun acc x => pad_to_align_bitwise (Dtyp_alignment x) acc + (Bit_sizeof_dtyp x)%N) fields 0%N in
       let max_align := 8 * (max_preferred_dtyp_alignment fields) in
       pad_to max_align sz
   | DTYPE_Struct true fields =>
       fold_left (fun acc x => (acc + round_up_to_eight (Bit_sizeof_dtyp x))%N) fields 0%N
-  | DTYPE_Vector sz t => sz * Bit_sizeof_dtyp_base t
+  | DTYPE_Array false sz t => sz * (round_up_to_eight (Bit_sizeof_dtyp t))
+  | DTYPE_Array true sz t => sz * Bit_sizeof_dtyp t
   end.
 
 Definition Sizeof_dtyp_base (ty:dtyp_base) : N :=
@@ -135,10 +133,10 @@ Fixpoint Sizeof_dtyp (ty:dtyp) : N :=
       let sz := fold_left (fun acc x => pad_to_align (Dtyp_alignment x) acc + (Sizeof_dtyp x)%N) l 0%N in
       let max_align := max_preferred_dtyp_alignment l in
       pad_to max_align sz
-  | DTYPE_Vector sz ty' =>
+  | DTYPE_Array false sz ty' =>
+      sz * (Sizeof_dtyp ty')
+  | DTYPE_Array true sz ty' =>
   (* TODO: Vector sizeof currently invalid for sub-bytesize / non-byte aligned elements. Changing this involves changing serialization. *)
-      sz * (Sizeof_dtyp_base ty')
-  | DTYPE_Array sz ty' =>
       sz * (Sizeof_dtyp ty')
   end.
 
@@ -153,5 +151,6 @@ Instance SizeofTheoryV : @SizeofTheory SizeofV.
 Proof.
   constructor; eauto.
   lia.
+  intros. destruct v; auto.
 Qed.
 

--- a/src/rocq/Semantics/Interfaces/Memory.v
+++ b/src/rocq/Semantics/Interfaces/Memory.v
@@ -123,7 +123,7 @@ Class MemoryModelState {Pa : Params} :=
 Section MemM.
   Context {Pa : Params} {MMS : @MemoryModelState Pa}.
 
-  Definition memM := memS state addr provenance.
+  Definition memM := memS state ptr provenance.
 
   (* Definition get_state  : memM state := fun s => ret (s,s). *)
   (* Definition get_memory : memM memory_stack := fun s => ret (s, state_get_memory s). *)
@@ -136,26 +136,26 @@ Class MemoryModelPrimitives {Pa : Params} :=
     mm_state :: @MemoryModelState Pa ;
 
     (** Reads *)
-    read_byte : addr -> memM memory_byte ;
+    read_byte : ptr -> memM memory_byte ;
 
     (** Writes *)
-    write_byte : addr -> memory_byte -> memM unit ;
+    write_byte : ptr -> memory_byte -> memM unit ;
 
     (** Stack allocations *)
     (* TODO: The list of bytes get huge in practice when allocating big chunk of memory.
        For performance reasons, it might be better to take a different representation here
        ([Fin n -> memory_byte] for [n] the length of the list?)
      *)
-    allocate_bytes_with_pr : list memory_byte -> N -> provenance -> memM addr ;
+    allocate_bytes_with_pr : list memory_byte -> N -> provenance -> memM ptr ;
 
     (** Heap operations *)
-    malloc_bytes_with_pr : list memory_byte -> N -> provenance -> memM addr ;
+    malloc_bytes_with_pr : list memory_byte -> N -> provenance -> memM ptr ;
 
     (* The free intrinsics is implementation specific to avoid exposing
        in the interface both the lookup from heap to blocs, and an iterator
        over them. TODO: rethink if we are happy with it.
      *)
-    free : addr -> memM unit ;
+    free : ptr -> memM unit ;
       
     (** Frame stacks *)
     mempush : memM unit ;

--- a/src/rocq/Semantics/Interfaces/Params.v
+++ b/src/rocq/Semantics/Interfaces/Params.v
@@ -9,19 +9,19 @@
 From Vellvm.Semantics.Interfaces Require Export
   IPtr
   Provenance
-  Address
+  Pointer
   Sizeof.
 
 Class Params := {
     IPTR :: IPtr;
     PROV :: Provenance;
     SIZE :: Sizeof;
-    ADDR :: @Address PROV;
-    P2I  :: @PI PROV ADDR;
+    PTR  :: @Pointer PROV;
+    P2I  :: @PI PROV PTR;
 
     IPTRT :: @IPtrTheory IPTR;
     PROVT :: @ProvenanceTheory PROV;
     SIZET :: @SizeofTheory SIZE;
-    P2IT  :: @PITheory PROV ADDR P2I;
+    P2IT  :: @PITheory PROV PTR P2I;
   }.
 

--- a/src/rocq/Semantics/Interfaces/Pointer.v
+++ b/src/rocq/Semantics/Interfaces/Pointer.v
@@ -11,80 +11,80 @@ From Vellvm Require Import
 (* end hide *)
 
 (** * Signature for addresses
-    The semantics is functorized by the notion of addresses manipulated by the
+    The semantics is functorized by the notion of pointers manipulated by the
     memory model. This allows us to easily plug different memory models.
     This module is concretely implemented currently in [Handlers/Memory.v].
  *)
-Class Address {P : Provenance} :=
+Class Pointer {P : Provenance} :=
   {
-    addr : Set;
-    null : addr;
+    ptr  : Set;
+    null : ptr;
 
     (* Rocq's logical equality on the pointer data type *)
-    eq_dec_addr : forall (a b : addr), {a = b} + {a <> b};
-    (* different_addrs : forall (a : addr), exists (b : addr), a <> b; *)
+    eq_dec_ptr : forall (a b : ptr), {a = b} + {a <> b};
+    (* different_ptrs : forall (a : ptr), exists (b : ptr), a <> b; *)
 
     (* Access the provenance for an address *)
-    address_provenance : addr -> prov;
+    ptr_provenance : ptr -> prov;
 
     (* Debug *)
-    show_addr : addr -> string;
+    show_ptr : ptr -> string;
   }.
 
 (* We pull this into a separate class to allow for a generic
-   implementation parametirized by any Address supporting PI.
-   Could be merged into Address if we don't care about that.
+   implementation parametirized by any Pointer supporting PI.
+   Could be merged into Pointer if we don't care about that.
  *)
-Class Overlaps {P : Provenance} {A : @Address P} :=
+Class Overlaps {P : Provenance} {A : @Pointer P} :=
   {
       (** Do two memory regions overlap each other?
         - *a1* and *a2* are addresses to the start of each region.
         - *sz1* and *sz2* are the sizes of the two regions. *)
-    overlaps : addr -> N -> addr -> N -> bool ;
+    overlaps : ptr -> N -> ptr -> N -> bool ;
 }.
 
-(* TODO: Merge in the Address class, or keep it separate? *)
+(* TODO: Merge in the Pointer class, or keep it separate? *)
 (* TODO: Is it not over-engineering to allow margin for [ptr_to_int]
    to be anything but the one from iptr?
  *)
-Class PI {P : Provenance} {A : @Address P} :=
+Class PI {P : Provenance} {A : @Pointer P} :=
   {
-    ptr_to_int : addr -> Z;
+    ptr_to_int : ptr -> Z;
 
-    int_to_ptr : Z -> prov -> EOU addr;
+    int_to_ptr : Z -> prov -> EOU ptr;
   }.
 
-Class PITheory {P : Provenance} {A : @Address P} {P2I : @PI P A} :=
+Class PITheory {P : Provenance} {A : @Pointer P} {P2I : @PI P A} :=
   {
     int_to_ptr_provenance :
-    forall (x : Z) (p : prov) (a : addr),
+    forall (x : Z) (p : prov) (a : ptr),
       int_to_ptr x p = ret a ->
-      address_provenance a = p;
+      ptr_provenance a = p;
 
     int_to_ptr_ptr_to_int :
-    forall (a : addr) (p : prov),
-      address_provenance a = p ->
+    forall (a : ptr) (p : prov),
+      ptr_provenance a = p ->
       int_to_ptr (ptr_to_int a) p = ret a;
 
     int_to_ptr_ptr_to_int_exists :
-    forall (a : addr) (p : prov),
+    forall (a : ptr) (p : prov),
     exists a',
       int_to_ptr (ptr_to_int a) p = ret a' /\
         ptr_to_int a' = ptr_to_int a /\
-        address_provenance a' = p;
+        ptr_provenance a' = p;
 
     ptr_to_int_int_to_ptr :
-    forall (x : Z) (p : prov) (a : addr),
+    forall (x : Z) (p : prov) (a : ptr),
       int_to_ptr x p = ret a ->
       ptr_to_int a = x;
   }.
 
 Open Scope Z.
 
-Instance overlaps_ptoi {P : Provenance} {Ad : @Address P} {PI : @PI P Ad} :
-  @Overlaps P Ad :=
+Instance overlaps_ptoi {P : Provenance} {A : @Pointer P} {PI : @PI P A} :
+  @Overlaps P A :=
   {|
-    overlaps (a1 : addr) (sz1 : N) (a2 : addr) (sz2 : N) :=
+    overlaps (a1 : ptr) (sz1 : N) (a2 : ptr) (sz2 : N) :=
       let a1_start := ptr_to_int a1 in
       let a1_end   := ptr_to_int a1 + (Z.of_N sz1) in
       let a2_start := ptr_to_int a2 in
@@ -98,23 +98,23 @@ Instance overlaps_ptoi {P : Provenance} {Ad : @Address P} {PI : @PI P Ad} :
    Move in the Params file?
  *)
 Section Overlap.
-  Context {P : Provenance} {Ad : @Address P} {Si : Sizeof} {O : @Overlaps P Ad}.
+  Context {P : Provenance} {A : @Pointer P} {Si : Sizeof} {O : @Overlaps P A}.
 
   (** Checks if two regions of memory overlap each other. The types
    *τ1* and *τ2* are used to determine the size of the two memory
         regions.
    *)
-  Definition overlaps_dtyp (a1 : addr) (τ1 : dtyp) (a2 : addr) (τ2 : dtyp)
+  Definition overlaps_dtyp (a1 : ptr) (τ1 : dtyp) (a2 : ptr) (τ2 : dtyp)
     : bool :=
     overlaps a1 (sizeof_dtyp τ1) a2 (sizeof_dtyp τ2).
 
   (** Make sure that two regions of memory do not overlap *)
-  Definition no_overlap (a1 : addr) (sz1 : N) (a2 : addr) (sz2 : N) : bool
+  Definition no_overlap (a1 : ptr) (sz1 : N) (a2 : ptr) (sz2 : N) : bool
     := negb (overlaps a1 sz1 a2 sz2).
 
   (** Same as *no_overlap*, but using *dtyp*s *τ1* and *τ2* to
         determine the size of the regions. *)
-  Definition no_overlap_dtyp (a1 : addr) (τ1 : dtyp) (a2 : addr) (τ2 : dtyp)
+  Definition no_overlap_dtyp (a1 : ptr) (τ1 : dtyp) (a2 : ptr) (τ2 : dtyp)
     : bool := negb (overlaps_dtyp a1 τ1 a2 τ2).
 
 End Overlap.

--- a/src/rocq/Semantics/Interfaces/Sizeof.v
+++ b/src/rocq/Semantics/Interfaces/Sizeof.v
@@ -57,12 +57,8 @@ Class SizeofTheory {S : Sizeof} : Prop :=
       sizeof_dtyp (DTYPE_Struct true dts) = List.fold_left (fun acc dt => N.add acc (sizeof_dtyp dt)) dts 0%N;
 
     sizeof_dtyp_array :
-    forall sz t,
-      sizeof_dtyp (DTYPE_Array sz t) = (sz * sizeof_dtyp t)%N;
-
-    sizeof_dtyp_vector :
-    forall sz t,
-      sizeof_dtyp (DTYPE_Vector sz t) = (sz * sizeof_dtyp (DTYPE_Base t))%N;
+    forall v sz t,
+      sizeof_dtyp (DTYPE_Array v sz t) = (sz * sizeof_dtyp t)%N;
 
     (* SAZ - why is this not [sizeof_dtyp_i (DTYPE_Base (DTYPE_I sz)) = sz]  ?*)
     sizeof_dtyp_i8 :

--- a/src/rocq/Semantics/Interfaces/Sizeof.v
+++ b/src/rocq/Semantics/Interfaces/Sizeof.v
@@ -40,21 +40,21 @@ Definition max_preferred_dtyp_alignment {S : Sizeof} (dts : list dtyp) : N :=
   | None => 1
   end.
 
-Definition ptr_size `{Sizeof} : N := sizeof_dtyp DTYPE_Pointer.
+Definition ptr_size `{Sizeof} : N := sizeof_dtyp (DTYPE_Base DTYPE_Pointer).
 
 Class SizeofTheory {S : Sizeof} : Prop :=
   {
-    sizeof_dtyp_void : sizeof_dtyp DTYPE_Void = 0%N;
+    sizeof_dtyp_void : sizeof_dtyp (DTYPE_Base DTYPE_Void) = 0%N;
     sizeof_dtyp_pos :
     forall dt, (0 <= sizeof_dtyp dt)%N;
 
     sizeof_dtyp_Struct :
     forall dts,
-      sizeof_dtyp (DTYPE_Struct dts) = pad_to (max_preferred_dtyp_alignment dts) (List.fold_left (fun acc dt => N.add (pad_to_align (dtyp_alignment dt) acc) (sizeof_dtyp dt)) dts 0%N);
+      sizeof_dtyp (DTYPE_Struct false dts) = pad_to (max_preferred_dtyp_alignment dts) (List.fold_left (fun acc dt => N.add (pad_to_align (dtyp_alignment dt) acc) (sizeof_dtyp dt)) dts 0%N);
 
     sizeof_dtyp_Packed_struct :
     forall dts,
-      sizeof_dtyp (DTYPE_Packed_struct dts) = List.fold_left (fun acc dt => N.add acc (sizeof_dtyp dt)) dts 0%N;
+      sizeof_dtyp (DTYPE_Struct true dts) = List.fold_left (fun acc dt => N.add acc (sizeof_dtyp dt)) dts 0%N;
 
     sizeof_dtyp_array :
     forall sz t,
@@ -62,10 +62,11 @@ Class SizeofTheory {S : Sizeof} : Prop :=
 
     sizeof_dtyp_vector :
     forall sz t,
-      sizeof_dtyp (DTYPE_Vector sz t) = (sz * sizeof_dtyp t)%N;
+      sizeof_dtyp (DTYPE_Vector sz t) = (sz * sizeof_dtyp (DTYPE_Base t))%N;
 
+    (* SAZ - why is this not [sizeof_dtyp_i (DTYPE_Base (DTYPE_I sz)) = sz]  ?*)
     sizeof_dtyp_i8 :
-    sizeof_dtyp (DTYPE_I 8) = 1%N;
+    sizeof_dtyp (DTYPE_Base (DTYPE_I 8)) = 1%N;
   }.
 
 

--- a/src/rocq/Semantics/IntrinsicsDefinitions.v
+++ b/src/rocq/Semantics/IntrinsicsDefinitions.v
@@ -375,8 +375,9 @@ Section Intrinsics.
 
    - The right-hand [dvalue] of the [+] result is used to throw an exception.
    *)
-  Definition pure_function     := list dvalue -> EOU (dvalue + dvalue).
-  Definition semantic_function := list dvalue -> option ptr -> itree E (dvalue + dvalue).
+  Definition pure_base_function := list dvalue_base -> EOU (dvalue_base + dvalue_base).
+  Definition pure_function      := list dvalue -> EOU (dvalue + dvalue).
+  Definition semantic_function  := list dvalue -> option ptr -> itree E (dvalue + dvalue).
 
   (* An association list mapping intrinsic names to their semantic definitions *)
   Definition intrinsic_definitions := list (declaration typ * semantic_function).
@@ -386,7 +387,7 @@ Section Intrinsics.
 
   #[local] Notation retr x := (ret (inr x)).
   (* Absolute value for Float. *)
-  Definition llvm_fabs_f32 : pure_function :=
+  Definition llvm_fabs_f32 : pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_Float d] => retr (DVALUE_Float (b32_abs d))
@@ -394,7 +395,7 @@ Section Intrinsics.
       end.
 
   (* Abosulute value for Doubles. *)
-  Definition llvm_fabs_f64 : pure_function :=
+  Definition llvm_fabs_f64 : pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_Double d] => retr (DVALUE_Double (b64_abs d))
@@ -415,14 +416,14 @@ Section Intrinsics.
       if Float32.cmp Clt a b then b else a
     end.
 
-  Definition llvm_maxnum_f64 : pure_function :=
+  Definition llvm_maxnum_f64 : pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_Double a; DVALUE_Double b] => retr (DVALUE_Double (Float_maxnum a b))
       | _ => raise_error "llvm_maxnum_f64 got incorrect / ill-typed inputs"
       end.
 
-  Definition llvm_maxnum_f32 : pure_function :=
+  Definition llvm_maxnum_f32 : pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_Float a; DVALUE_Float b] => retr (DVALUE_Float (Float32_maxnum a b))
@@ -443,14 +444,14 @@ Section Intrinsics.
       if Float32.cmp Clt a b then a else b
     end.
 
-  Definition llvm_minimum_f64 : pure_function :=
+  Definition llvm_minimum_f64 : pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_Double a; DVALUE_Double b] => retr (DVALUE_Double (Float_minimum a b))
       | _ => raise_error "llvm_minimum_f64 got incorrect / ill-typed inputs"
       end.
 
-  Definition llvm_minimum_f32 : pure_function :=
+  Definition llvm_minimum_f32 : pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_Float a; DVALUE_Float b] => retr (DVALUE_Float (Float32_minimum a b))
@@ -458,7 +459,7 @@ Section Intrinsics.
       end.
 
   (* Saturated arithmetic: https://llvm.org/docs/LangRef.html#saturation-arithmetic-intrinsics *)
-  Definition ushl_sat {I : Type} `{TDI : ToDvalue I} `{VMI : VMemInt I} (x y : I) : EOU dvalue :=
+  Definition ushl_sat {I : Type} `{TDI : ToDvalueBase I} `{VMI : VMemInt I} (x y : I) : EOU dvalue_base :=
     res <- mshl x y;;
     let res_u := munsigned res in
     let res_u' := Z.shiftl (munsigned x) (munsigned y) in
@@ -475,47 +476,47 @@ Section Intrinsics.
             | raise_oom _ =>
                 raise_error "ushl_sat: cannot represent maximum value in type... Should not happen."
             (* Note: we have enlarged the monad, so that statically we don't rule out new absurd cases such as failure or ub *)
-            | m => to_dvalue <$> m
+            | m => tdb <$> m
             end
         end
-      else ret (to_dvalue res).
+      else ret (tdb res).
 
-  Definition llvm_ushl_sat_1: pure_function :=
+  Definition llvm_ushl_sat_1: pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_I 1 a; DVALUE_I 1 b] => inr <$> ushl_sat a b
       | _ => raise_error "llvm_ushl_sat_1 got incorrect / ill-typed inputs"
       end.
 
-  Definition llvm_ushl_sat_8: pure_function :=
+  Definition llvm_ushl_sat_8: pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_I 8 a; DVALUE_I 8 b] => inr <$> ushl_sat a b
       | _ => raise_error "llvm_ushl_sat_8 got incorrect / ill-typed inputs"
       end.
 
-  Definition llvm_ushl_sat_16: pure_function :=
+  Definition llvm_ushl_sat_16: pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_I 16 a; DVALUE_I 16 b] => inr <$> ushl_sat a b
       | _ => raise_error "llvm_ushl_sat_16 got incorrect / ill-typed inputs"
       end.
 
-  Definition llvm_ushl_sat_32: pure_function :=
+  Definition llvm_ushl_sat_32: pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_I 32 a; DVALUE_I 32 b] => inr <$> ushl_sat a b
       | _ => raise_error "llvm_ushl_sat_32 got incorrect / ill-typed inputs"
       end.
 
-  Definition llvm_ushl_sat_64: pure_function :=
+  Definition llvm_ushl_sat_64: pure_base_function :=
     fun args =>
       match args with
       | [DVALUE_I 64 a; DVALUE_I 64 b] => inr <$> ushl_sat a b
       | _ => raise_error "llvm_ushl_sat_64 got incorrect / ill-typed inputs"
       end.
 
-  Definition llvm_vellvm_internal_throw : pure_function :=
+  Definition llvm_vellvm_internal_throw : pure_base_function :=
     fun args =>
       match args with
       (* Raise: the [inl] branch of the intrinsic's [exc + dvalue] result is
@@ -530,9 +531,9 @@ Section Intrinsics.
       match args, varargs with
     | [ a ], Some varargs =>
         match a with
-        | DVALUE_Poison dt => raiseUB ("Store to poisoned address in va_start.")
-        | _ => store DTYPE_Pointer a (DVALUE_Addr varargs);;
-              retr DVALUE_None
+        | DVALUE_Base (DVALUE_Poison dt) => raiseUB ("Store to poisoned address in va_start.")
+        | _ => store DTYPE_Pointer a (DVALUE_Pointer varargs);;
+              retr (DVALUE_Base DVALUE_None)
         end
     | _, _ => raise "va_start: invalid arguments."
     end.
@@ -543,32 +544,44 @@ Section Intrinsics.
       | [dest; src] =>
           vargs <- load DTYPE_Pointer src;;
           store DTYPE_Pointer dest vargs;;
-          retr DVALUE_None
+          retr (DVALUE_Base DVALUE_None)
       | _ => raise ": va_copy invalid arguments"
       end.
 
   Definition llvm_va_end  : semantic_function :=
     fun args varargs =>
-      retr DVALUE_None.
+      retr (DVALUE_Base DVALUE_None).
 
+  Definition pure_base_to_pure : pure_base_function -> pure_function :=
+    fun f args =>
+      args' <- map_monad dvalue_to_dvalue_base args ;;
+      ans <- f args' ;;
+      match ans with
+      | inr x => retr (DVALUE_Base x)
+      | inl x => ret (inl (DVALUE_Base x))
+      end.
+  
   Definition pure_to_semantic : pure_function -> semantic_function :=
     fun f args _ => EOU_to_itree (f args).
 
+  Definition pure_base_to_semantic : pure_base_function -> semantic_function :=
+    fun f => pure_to_semantic (pure_base_to_pure f).
+  
   (* Clients of Vellvm can register the names of their own intrinsics
      definitions here. *)
   Definition defined_intrinsics : intrinsic_definitions :=
-    [ (fabs_32_decl, pure_to_semantic llvm_fabs_f32) ;
-      (fabs_64_decl, pure_to_semantic llvm_fabs_f64) ;
-      (maxnum_32_decl , pure_to_semantic llvm_maxnum_f32) ;
-      (maxnum_64_decl , pure_to_semantic llvm_maxnum_f64);
-      (minimum_32_decl, pure_to_semantic llvm_minimum_f32);
-      (minimum_64_decl, pure_to_semantic llvm_minimum_f64);
-      (ushl_sat_1_decl, pure_to_semantic llvm_ushl_sat_1);
-      (ushl_sat_8_decl, pure_to_semantic llvm_ushl_sat_8);
-      (ushl_sat_16_decl, pure_to_semantic llvm_ushl_sat_16);
-      (ushl_sat_32_decl, pure_to_semantic llvm_ushl_sat_32);
-      (ushl_sat_64_decl, pure_to_semantic llvm_ushl_sat_64);
-      (vellvm_internal_throw_decl, pure_to_semantic llvm_vellvm_internal_throw);
+    [ (fabs_32_decl, pure_base_to_semantic llvm_fabs_f32) ;
+      (fabs_64_decl, pure_base_to_semantic llvm_fabs_f64) ;
+      (maxnum_32_decl , pure_base_to_semantic llvm_maxnum_f32) ;
+      (maxnum_64_decl , pure_base_to_semantic llvm_maxnum_f64);
+      (minimum_32_decl, pure_base_to_semantic llvm_minimum_f32);
+      (minimum_64_decl, pure_base_to_semantic llvm_minimum_f64);
+      (ushl_sat_1_decl, pure_base_to_semantic llvm_ushl_sat_1);
+      (ushl_sat_8_decl, pure_base_to_semantic llvm_ushl_sat_8);
+      (ushl_sat_16_decl, pure_base_to_semantic llvm_ushl_sat_16);
+      (ushl_sat_32_decl, pure_base_to_semantic llvm_ushl_sat_32);
+      (ushl_sat_64_decl, pure_base_to_semantic llvm_ushl_sat_64);
+      (vellvm_internal_throw_decl, pure_base_to_semantic llvm_vellvm_internal_throw);
       (va_start_decl, llvm_va_start);
       (va_end_decl, llvm_va_end);
       (va_copy_decl, llvm_va_copy)

--- a/src/rocq/Semantics/IntrinsicsDefinitions.v
+++ b/src/rocq/Semantics/IntrinsicsDefinitions.v
@@ -376,7 +376,7 @@ Section Intrinsics.
    - The right-hand [dvalue] of the [+] result is used to throw an exception.
    *)
   Definition pure_function     := list dvalue -> EOU (dvalue + dvalue).
-  Definition semantic_function := list dvalue -> option addr -> itree E (dvalue + dvalue).
+  Definition semantic_function := list dvalue -> option ptr -> itree E (dvalue + dvalue).
 
   (* An association list mapping intrinsic names to their semantic definitions *)
   Definition intrinsic_definitions := list (declaration typ * semantic_function).

--- a/src/rocq/Semantics/LLVMEvents.v
+++ b/src/rocq/Semantics/LLVMEvents.v
@@ -138,7 +138,7 @@ Section withParams.
   (* Call to an intrinsic whose implementation do not rely on the implementation of the memory model *)
   (* Intrinsics may raise an exception by returning inl *)
   Variant IntrinsicE : Type -> Type :=
-    | Intrinsic (t : dtyp) (f : string) (args : list dvalue) (vararg : option addr) :
+    | Intrinsic (t : dtyp) (f : string) (args : list dvalue) (vararg : option ptr) :
       IntrinsicE (exc + dvalue).
   Definition intrinsic {E} `{IntrinsicE -< E} t f args vararg : itree E _ := trigger (Intrinsic t f args vararg).
   

--- a/src/rocq/Semantics/Libraries.v
+++ b/src/rocq/Semantics/Libraries.v
@@ -42,12 +42,12 @@ Section withParams.
       Propagates all memory failures and raises a Vellvm "Failure" if the
       value read does not concretize to a DVALUE_I8.
    *)
-  Definition i8_str_index (strptr : addr) (index : Z) : CFGtop (@Integers.bit_int 8) :=
+  Definition i8_str_index (strptr : ptr) (index : Z) : CFGtop (@Integers.bit_int 8) :=
     iptr <- EOU_to_itree (from_Z index) ;;
-    addr <- EOU_to_itree (handle_gep_addr (DTYPE_I 8) strptr [DVALUE_Iptr iptr]) ;;
-    d_byte <- load (DTYPE_I 8) (DVALUE_Addr addr) ;;
+    addr <- EOU_to_itree (handle_gep_ptr (DTYPE_I 8) strptr [DVALUE_Base (DVALUE_Iptr iptr)]) ;;
+    d_byte <- load (DTYPE_I 8) (DVALUE_Pointer addr) ;;
     match d_byte with
-    | DVALUE_I 8 b => ret b
+    | DVALUE_Base (DVALUE_I 8 b) => ret b
     | bad => raise ("i8_str_index failed with non-DVALUE_I8 " ++ show_dvalue bad)
     end.
 
@@ -60,10 +60,10 @@ Section withParams.
     refine
       (let putchar_body (u_char:dvalue) : CFGtop dvalue :=
          match u_char with
-         | DVALUE_I sz x32 =>
+         | DVALUE_Base (DVALUE_I sz x32)  =>
              if Pos.eq_dec 32 sz
              then
-               match get_conv_case (Trunc false false) (DTYPE_I 32) u_char (DTYPE_I 8) with
+               match get_conv_case (Trunc false false) (DTYPE_I 32) (DVALUE_I sz x32) (DTYPE_I 8) with
                | Conv_Pure (DVALUE_I sz x8) =>
                    if Pos.eq_dec 8 sz
                    then _
@@ -93,7 +93,7 @@ Section withParams.
   Definition puts_denotation : function_denotation :=
     let puts_body (u_strptr : dvalue) : CFGtop dvalue :=
       match u_strptr with
-      | DVALUE_Addr strptr =>
+      | DVALUE_Base (DVALUE_Pointer strptr) =>
           char <- i8_str_index strptr 0%Z ;;
           bytes <-
             ITree.iter
@@ -107,7 +107,7 @@ Section withParams.
               )
               (char, [], 1%Z) ;;
           v <- io_stdout (DList.rev_tail_rec bytes) ;;
-          ret (DVALUE_I 8 (@Integers.zero 8))
+          ret (DVALUE_Base (DVALUE_I 8 (@Integers.zero 8)))
       | bad => raiseUB ("puts got non-address argument " ++ show_dvalue bad)
       end
     in

--- a/src/rocq/Semantics/MemoryBytes.v
+++ b/src/rocq/Semantics/MemoryBytes.v
@@ -85,10 +85,31 @@ Section MemoryByte.
                                    | NoPois a => k a
                                    end)
     |}.
-  
+
+
+  Definition dvalue_base_extract_byte (dv : dvalue_base) (idx : Z) : EOUP Z :=
+    match dv with
+    | DVALUE_I sz x =>
+        ret (extract_byte_vint x idx)
+    | DVALUE_Iptr x =>
+        ret (extract_byte_Z (to_Z x) idx)
+    | DVALUE_Pointer ptr =>
+        (* Note: this throws away provenance *)
+        ret (extract_byte_Z (ptr_to_int ptr) idx)
+    | DVALUE_Float f =>
+        ret (extract_byte_Z (unsigned (Float32.to_bits f)) idx)
+    | DVALUE_Double d =>
+        ret (extract_byte_Z (unsigned (Float.to_bits d)) idx)
+    | DVALUE_Poison dt => ret Pois
+    | DVALUE_None =>
+        (* TODO: Not sure if this should be an error, poison, or what. *)
+        raise_error "dvalue_extract_byte on DVALUE_None"
+    | DVALUE_B sz bits =>
+        raise_error "Byte Type TODO"
+    end.
+               
   (* offset is the number of bytes indexed past so far *)
-  Fixpoint dvalue_extract_byte
-    (dv : dvalue) (dt : dtyp) (idx : Z) {struct dv} : EOUP Z  :=
+  Fixpoint dvalue_extract_byte (dv : dvalue) (dt : dtyp) (idx : Z) {struct dv} : EOUP Z  :=
     let dvalue_extract_struct_bytes (pad : option N) : list dvalue -> list dtyp -> N -> Z -> EOUP Z :=
       fix loop fields types (offset : N) (idx : Z) {struct fields} : EOUP Z :=
         match fields, types with
@@ -139,7 +160,7 @@ Section MemoryByte.
     in
 
     let dvalue_extract_array_bytes :=
-      fix loop elts dt (idx : Z) {struct elts}  :=
+      fix loop (elts : list dvalue) dt (idx : Z) {struct elts}  :=
         match elts with
         | [] => raise_error "No fields left for byte-indexing..."
         | e::es =>
@@ -150,54 +171,52 @@ Section MemoryByte.
             else loop es dt (idx - zsz)%Z
         end
     in
-    
+
+    let dvalue_extract_vector_bytes :=
+      fix loop (elts : list dvalue_base) dt (idx : Z) {struct elts}  :=
+        match elts with
+        | [] => raise_error "No fields left for byte-indexing..."
+        | e::es =>
+            let sz := sizeof_dtyp dt in
+            let zsz := Z.of_N sz in
+            if Z.ltb idx zsz
+            then dvalue_base_extract_byte e idx
+            else loop es dt (idx - zsz)%Z
+        end
+    in
+
     match dv with
-       | DVALUE_I sz x =>
-           ret (extract_byte_vint x idx)
-       | DVALUE_Iptr x =>
-           ret (extract_byte_Z (to_Z x) idx)
-       | DVALUE_Addr addr =>
-           (* Note: this throws away provenance *)
-           ret (extract_byte_Z (ptr_to_int addr) idx)
-       | DVALUE_Float f =>
-           ret (extract_byte_Z (unsigned (Float32.to_bits f)) idx)
-       | DVALUE_Double d =>
-           ret (extract_byte_Z (unsigned (Float.to_bits d)) idx)
-       | DVALUE_Poison dt => ret Pois
-       | DVALUE_None =>
-           (* TODO: Not sure if this should be an error, poison, or what. *)
-           raise_error "dvalue_extract_byte on DVALUE_None"
+    | DVALUE_Base dv => dvalue_base_extract_byte dv idx
+    | DVALUE_Struct false fields =>
+        match dt with
+        | DTYPE_Struct false dts =>
+            dvalue_extract_struct_bytes (Some (max_preferred_dtyp_alignment dts)) fields dts 0 idx
+        | _ => raise_error "dvalue_extract_byte: type mismatch on DVALUE_Struct."
+        end
 
-       | DVALUE_Struct fields =>
-           match dt with
-           | DTYPE_Struct dts =>
-               dvalue_extract_struct_bytes (Some (max_preferred_dtyp_alignment dts)) fields dts 0 idx
-           | _ => raise_error "dvalue_extract_byte: type mismatch on DVALUE_Struct."
-           end
+    | DVALUE_Struct true fields =>
+        match dt with
+        | DTYPE_Struct true dts =>
+            dvalue_extract_struct_bytes None fields dts 0 idx
+        | _ => raise_error "dvalue_extract_byte: type mismatch on DVALUE_Packed_struct."
+        end
 
-       | DVALUE_Packed_struct fields =>
-           match dt with
-           | DTYPE_Packed_struct dts =>
-               dvalue_extract_struct_bytes None fields dts 0 idx
-           | _ => raise_error "dvalue_extract_byte: type mismatch on DVALUE_Packed_struct."
-           end
+    | DVALUE_Array _ elts =>
+        match dt with
+        | DTYPE_Array sz dt =>
+            dvalue_extract_array_bytes elts dt idx
+        | _ =>
+            raise_error "dvalue_extract_byte: type mismatch on DVALUE_Array."
+        end
 
-       | DVALUE_Array _ elts =>
-           match dt with
-           | DTYPE_Array sz dt =>
-               dvalue_extract_array_bytes elts dt idx
-           | _ =>
-               raise_error "dvalue_extract_byte: type mismatch on DVALUE_Array."
-           end
-
-       | DVALUE_Vector _ elts =>
-           match dt with
-           | DTYPE_Vector sz dt =>
-               dvalue_extract_array_bytes elts dt idx
-           | _ =>
-               raise_error "dvalue_extract_byte: type mismatch on DVALUE_Vector."
-           end
-       end.
+    | DVALUE_Vector _ elts =>
+        match dt with
+        | DTYPE_Vector sz dt =>
+            dvalue_extract_vector_bytes elts (DTYPE_Base dt) idx
+        | _ =>
+            raise_error "dvalue_extract_byte: type mismatch on DVALUE_Vector."
+        end
+    end.
 
   Inductive memory_byte : Type :=
   | MByte (dv : dvalue) (dt : dtyp) (idx : N) : memory_byte
@@ -216,12 +235,64 @@ Section MemoryByte.
 
   #[local] Obligation Tactic := try Tactics.program_simpl; try solve [cbn; try lia].
 
-  Definition absorb_pois {A} dt (c : EOUP A) (k : A -> EOU dvalue) : EOU dvalue :=
+  Definition absorb_pois {A} dt (c : EOUP A) (k : A -> EOU dvalue_base) : EOU dvalue_base :=
     x <- (c : EOU _) ;;
     match x with
     | Pois => ret (DVALUE_Poison dt)
     | NoPois v => k v
     end.
+
+  Definition memory_bytes_to_dvalue_base (dbs : list memory_byte) (dt : dtyp_base) : EOU dvalue_base :=
+    match dt with
+    | DTYPE_I sz => 
+        absorb_pois (DTYPE_Base dt)
+          (map_monad (m := EOUP) (memory_byte_value) dbs)
+          (fun v => ret (DVALUE_I sz (concat_bytes_Z_vint v)))
+
+    | DTYPE_Iptr =>
+        absorb_pois (DTYPE_Base dt)
+          (map_monad memory_byte_value dbs)
+          (fun zs => DVALUE_Iptr <$> from_Z (concat_bytes_Z zs))
+
+    (* TODO: not sure if this should be wildcard provenance.
+           TODO: not sure if this should truncate iptr value... *)
+    (* TODO: not sure if this should be lazy OOM or not *)
+    | DTYPE_Pointer =>
+        absorb_pois (DTYPE_Base dt) (map_monad memory_byte_value dbs) 
+          (fun zs => DVALUE_Pointer <$> int_to_ptr (concat_bytes_Z zs) wildcard_prov)
+    | DTYPE_Void =>
+        raise_error "memory_bytes_to_dvalue on void type."
+    | DTYPE_FP FP_half =>
+        raise_error "memory_bytes_to_dvalue: unsupported half."
+    | DTYPE_FP FP_bfloat =>
+        raise_error "memory_bytes_to_dvalue: unsupported bfloat"
+    | DTYPE_FP FP_float =>
+        absorb_pois (DTYPE_Base dt) (map_monad memory_byte_value dbs)
+          (fun zs => ret (DVALUE_Float (Float32.of_bits (concat_bytes_Z_vint zs))))
+    | DTYPE_FP FP_double => 
+        absorb_pois (DTYPE_Base dt) (map_monad memory_byte_value dbs)
+          (fun zs => ret (DVALUE_Double (Float.of_bits (concat_bytes_Z_vint zs))))
+    | DTYPE_FP FP_x86_fp80 =>
+        raise_error "memory_bytes_to_dvalue: unsupported X86_fp80."
+    | DTYPE_FP FP_fp128 =>
+        raise_error "memory_bytes_to_dvalue: unsupported fp128."
+    | DTYPE_FP FP_ppc_fp128 =>
+        raise_error "memory_bytes_to_dvalue: unsupported ppc_fp128."
+    | DTYPE_Label =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Label."
+    | DTYPE_Token =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Token."
+    | DTYPE_Metadata =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Metadata."
+    | DTYPE_X86_mmx =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_X86_mmx."
+    | DTYPE_Opaque =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Opaque."
+
+    | DTYPE_B sz =>
+        raise_error "memory_bytes_to_dvalue_base: TODO: byte type"
+    end.
+
   
   Fixpoint memory_bytes_to_dvalue (dbs : list memory_byte) (dt : dtyp) : EOU dvalue :=
     let list_memory_bytes_to_dvalue (pad : option N) :=
@@ -249,50 +320,8 @@ Section MemoryByte.
             ret (f :: rest)
         end
     in
-
     match dt with
-    | DTYPE_I sz => 
-        absorb_pois dt
-          (map_monad (m := EOUP) (memory_byte_value) dbs)
-          (fun v => ret (DVALUE_I sz (concat_bytes_Z_vint v)))
-
-    | DTYPE_Iptr =>
-        absorb_pois dt
-          (map_monad memory_byte_value dbs)
-          (fun zs => DVALUE_Iptr <$> from_Z (concat_bytes_Z zs))
-
-    (* TODO: not sure if this should be wildcard provenance.
-           TODO: not sure if this should truncate iptr value... *)
-    (* TODO: not sure if this should be lazy OOM or not *)
-    | DTYPE_Pointer =>
-        absorb_pois dt (map_monad memory_byte_value dbs) 
-          (fun zs => DVALUE_Addr <$> int_to_ptr (concat_bytes_Z zs) wildcard_prov)
-    | DTYPE_Void =>
-        raise_error "memory_bytes_to_dvalue on void type."
-    | DTYPE_FP FP_half =>
-        raise_error "memory_bytes_to_dvalue: unsupported half."
-    | DTYPE_FP FP_bfloat =>
-        raise_error "memory_bytes_to_dvalue: unsupported bfloat"
-    | DTYPE_FP FP_float =>
-        absorb_pois dt (map_monad memory_byte_value dbs)
-          (fun zs => ret (DVALUE_Float (Float32.of_bits (concat_bytes_Z_vint zs))))
-    | DTYPE_FP FP_double => 
-        absorb_pois dt (map_monad memory_byte_value dbs)
-          (fun zs => ret (DVALUE_Double (Float.of_bits (concat_bytes_Z_vint zs))))
-    | DTYPE_FP FP_x86_fp80 =>
-        raise_error "memory_bytes_to_dvalue: unsupported X86_fp80."
-    | DTYPE_FP FP_fp128 =>
-        raise_error "memory_bytes_to_dvalue: unsupported fp128."
-    | DTYPE_FP FP_ppc_fp128 =>
-        raise_error "memory_bytes_to_dvalue: unsupported ppc_fp128."
-    | DTYPE_Label =>
-        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Label."
-    | DTYPE_Token =>
-        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Token."
-    | DTYPE_Metadata =>
-        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Metadata."
-    | DTYPE_X86_mmx =>
-        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_X86_mmx."
+    | DTYPE_Base dt => DVALUE_Base <$> (memory_bytes_to_dvalue_base dbs dt)
 
     (* NOTE: arrays and vectors are decorated with their whole type, which contains
          necessary size information.
@@ -308,22 +337,19 @@ Section MemoryByte.
         ret (DVALUE_Array (DTYPE_Array sz t) elts)
 
     | DTYPE_Vector sz t =>
-        let sz' := sizeof_dtyp t in
+        let sz' := sizeof_dtyp (DTYPE_Base t) in
         let elt_bytes :=
           if N.eqb sz' 0
           then repeatN sz []
           else split_every_nil sz' dbs
         in
-        elts <- map_monad (fun es => memory_bytes_to_dvalue es t) elt_bytes;;
+        elts <- map_monad (fun es => memory_bytes_to_dvalue_base es t) elt_bytes;;
         ret (DVALUE_Vector (DTYPE_Vector sz t) elts)
-    | DTYPE_Struct fields =>
-        Functor.fmap DVALUE_Struct (list_memory_bytes_to_dvalue (Some (max_preferred_dtyp_alignment fields)) 0 fields dbs)
+    | DTYPE_Struct false fields =>
+        (DVALUE_Struct false) <$> (list_memory_bytes_to_dvalue (Some (max_preferred_dtyp_alignment fields)) 0 fields dbs)
                      
-    | DTYPE_Packed_struct fields =>
-        Functor.fmap DVALUE_Packed_struct (list_memory_bytes_to_dvalue None 0 fields dbs)
-    | DTYPE_Opaque =>
-        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Opaque."
-                    
+    | DTYPE_Struct true fields =>
+        (DVALUE_Struct true) <$> (list_memory_bytes_to_dvalue None 0 fields dbs)
     end.
   
 End MemoryByte.

--- a/src/rocq/Semantics/MemoryBytes.v
+++ b/src/rocq/Semantics/MemoryBytes.v
@@ -171,20 +171,6 @@ Section MemoryByte.
             else loop es dt (idx - zsz)%Z
         end
     in
-
-    let dvalue_extract_vector_bytes :=
-      fix loop (elts : list dvalue_base) dt (idx : Z) {struct elts}  :=
-        match elts with
-        | [] => raise_error "No fields left for byte-indexing..."
-        | e::es =>
-            let sz := sizeof_dtyp dt in
-            let zsz := Z.of_N sz in
-            if Z.ltb idx zsz
-            then dvalue_base_extract_byte e idx
-            else loop es dt (idx - zsz)%Z
-        end
-    in
-
     match dv with
     | DVALUE_Base dv => dvalue_base_extract_byte dv idx
     | DVALUE_Struct false fields =>
@@ -201,20 +187,12 @@ Section MemoryByte.
         | _ => raise_error "dvalue_extract_byte: type mismatch on DVALUE_Packed_struct."
         end
 
-    | DVALUE_Array _ elts =>
+    | DVALUE_Array v _ elts =>
         match dt with
-        | DTYPE_Array sz dt =>
+        | DTYPE_Array _ sz dt =>
             dvalue_extract_array_bytes elts dt idx
         | _ =>
             raise_error "dvalue_extract_byte: type mismatch on DVALUE_Array."
-        end
-
-    | DVALUE_Vector _ elts =>
-        match dt with
-        | DTYPE_Vector sz dt =>
-            dvalue_extract_vector_bytes elts (DTYPE_Base dt) idx
-        | _ =>
-            raise_error "dvalue_extract_byte: type mismatch on DVALUE_Vector."
         end
     end.
 
@@ -326,7 +304,7 @@ Section MemoryByte.
     (* NOTE: arrays and vectors are decorated with their whole type, which contains
          necessary size information.
      *)
-    | DTYPE_Array sz t =>
+    | DTYPE_Array v sz t =>
         let sz' := sizeof_dtyp t in
         let elt_bytes :=
           if N.eqb sz' 0
@@ -334,17 +312,8 @@ Section MemoryByte.
           else split_every_nil sz' dbs
         in
         elts <- map_monad (fun es => memory_bytes_to_dvalue es t) elt_bytes;;
-        ret (DVALUE_Array (DTYPE_Array sz t) elts)
+        ret (DVALUE_Array v (DTYPE_Array v sz t) elts)
 
-    | DTYPE_Vector sz t =>
-        let sz' := sizeof_dtyp (DTYPE_Base t) in
-        let elt_bytes :=
-          if N.eqb sz' 0
-          then repeatN sz []
-          else split_every_nil sz' dbs
-        in
-        elts <- map_monad (fun es => memory_bytes_to_dvalue_base es t) elt_bytes;;
-        ret (DVALUE_Vector (DTYPE_Vector sz t) elts)
     | DTYPE_Struct false fields =>
         (DVALUE_Struct false) <$> (list_memory_bytes_to_dvalue (Some (max_preferred_dtyp_alignment fields)) 0 fields dbs)
                      

--- a/src/rocq/Semantics/MemoryBytes.v
+++ b/src/rocq/Semantics/MemoryBytes.v
@@ -216,8 +216,6 @@ Section MemoryByte.
 
   #[local] Obligation Tactic := try Tactics.program_simpl; try solve [cbn; try lia].
 
-  Definition dtyp_is_void (dt : dtyp) : bool := match dt with | DTYPE_Void => true | _ => false end.
-
   Definition absorb_pois {A} dt (c : EOUP A) (k : A -> EOU dvalue) : EOU dvalue :=
     x <- (c : EOU _) ;;
     match x with
@@ -226,110 +224,107 @@ Section MemoryByte.
     end.
   
   Fixpoint memory_bytes_to_dvalue (dbs : list memory_byte) (dt : dtyp) : EOU dvalue :=
-    if dtyp_is_void dt
-    then raise_error "deserialize_sbytes: Attempt to deserialize void."%string
-    else
-      let list_memory_bytes_to_dvalue (pad : option N) :=
-        fix go (offset : N) dts dbs :=
-          match dts with
-          | [] =>
-              (* TODO: should we check that we have the appropriate number of extra padding bytes here? *)
-              (* Long term we'll have to include padding bytes in the dvalue *)
-              ret []
-          | (dt::dts) =>
-              let padding :=
-                if pad
-                then pad_amount (preferred_alignment (dtyp_alignment dt)) offset
-                else 0%N
-              in
-              let zpadding := Z.of_N padding in
-              let sz := sizeof_dtyp dt in
-              (* Skip any padding bytes *)
-              let dbs' := drop padding dbs in
-              let init_bytes := take sz dbs' in
-              let rest_bytes := drop sz dbs' in
-              let offset' := offset + padding in
-              f <- memory_bytes_to_dvalue init_bytes dt ;;
-              rest <- go (offset' + sz) dts rest_bytes ;;
-              ret (f :: rest)
-          end
-      in
+    let list_memory_bytes_to_dvalue (pad : option N) :=
+      fix go (offset : N) dts dbs :=
+        match dts with
+        | [] =>
+            (* TODO: should we check that we have the appropriate number of extra padding bytes here? *)
+            (* Long term we'll have to include padding bytes in the dvalue *)
+            ret []
+        | (dt::dts) =>
+            let padding :=
+              if pad
+              then pad_amount (preferred_alignment (dtyp_alignment dt)) offset
+              else 0%N
+            in
+            let zpadding := Z.of_N padding in
+            let sz := sizeof_dtyp dt in
+            (* Skip any padding bytes *)
+            let dbs' := drop padding dbs in
+            let init_bytes := take sz dbs' in
+            let rest_bytes := drop sz dbs' in
+            let offset' := offset + padding in
+            f <- memory_bytes_to_dvalue init_bytes dt ;;
+            rest <- go (offset' + sz) dts rest_bytes ;;
+            ret (f :: rest)
+        end
+    in
 
-      match dt with
-      | DTYPE_I sz => 
-          absorb_pois dt
-            (map_monad (m := EOUP) (memory_byte_value) dbs)
-            (fun v => ret (DVALUE_I sz (concat_bytes_Z_vint v)))
+    match dt with
+    | DTYPE_I sz => 
+        absorb_pois dt
+          (map_monad (m := EOUP) (memory_byte_value) dbs)
+          (fun v => ret (DVALUE_I sz (concat_bytes_Z_vint v)))
 
-      | DTYPE_Iptr =>
-          absorb_pois dt
-            (map_monad memory_byte_value dbs)
-            (fun zs => DVALUE_Iptr <$> from_Z (concat_bytes_Z zs))
+    | DTYPE_Iptr =>
+        absorb_pois dt
+          (map_monad memory_byte_value dbs)
+          (fun zs => DVALUE_Iptr <$> from_Z (concat_bytes_Z zs))
 
-      (* TODO: not sure if this should be wildcard provenance.
+    (* TODO: not sure if this should be wildcard provenance.
            TODO: not sure if this should truncate iptr value... *)
-      (* TODO: not sure if this should be lazy OOM or not *)
-      | DTYPE_Pointer =>
-          absorb_pois dt (map_monad memory_byte_value dbs) 
-            (fun zs => DVALUE_Addr <$> int_to_ptr (concat_bytes_Z zs) wildcard_prov)
-      | DTYPE_Void =>
-          raise_error "memory_bytes_to_dvalue on void type."
-      | DTYPE_FP FP_half =>
-          raise_error "memory_bytes_to_dvalue: unsupported half."
-      | DTYPE_FP FP_bfloat =>
-          raise_error "memory_bytes_to_dvalue: unsupported bfloat"
-      | DTYPE_FP FP_float =>
-          absorb_pois dt (map_monad memory_byte_value dbs)
-            (fun zs => ret (DVALUE_Float (Float32.of_bits (concat_bytes_Z_vint zs))))
-      | DTYPE_FP FP_double => 
-          absorb_pois dt (map_monad memory_byte_value dbs)
-            (fun zs => ret (DVALUE_Double (Float.of_bits (concat_bytes_Z_vint zs))))
-      | DTYPE_FP FP_x86_fp80 =>
-          raise_error "memory_bytes_to_dvalue: unsupported X86_fp80."
-      | DTYPE_FP FP_fp128 =>
-          raise_error "memory_bytes_to_dvalue: unsupported fp128."
-      | DTYPE_FP FP_ppc_fp128 =>
-          raise_error "memory_bytes_to_dvalue: unsupported ppc_fp128."
-      | DTYPE_Label =>
-          raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Label."
-      | DTYPE_Token =>
-          raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Token."
-      | DTYPE_Metadata =>
-          raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Metadata."
-      | DTYPE_X86_mmx =>
-          raise_error "memory_bytes_to_dvalue: unsupported DTYPE_X86_mmx."
+    (* TODO: not sure if this should be lazy OOM or not *)
+    | DTYPE_Pointer =>
+        absorb_pois dt (map_monad memory_byte_value dbs) 
+          (fun zs => DVALUE_Addr <$> int_to_ptr (concat_bytes_Z zs) wildcard_prov)
+    | DTYPE_Void =>
+        raise_error "memory_bytes_to_dvalue on void type."
+    | DTYPE_FP FP_half =>
+        raise_error "memory_bytes_to_dvalue: unsupported half."
+    | DTYPE_FP FP_bfloat =>
+        raise_error "memory_bytes_to_dvalue: unsupported bfloat"
+    | DTYPE_FP FP_float =>
+        absorb_pois dt (map_monad memory_byte_value dbs)
+          (fun zs => ret (DVALUE_Float (Float32.of_bits (concat_bytes_Z_vint zs))))
+    | DTYPE_FP FP_double => 
+        absorb_pois dt (map_monad memory_byte_value dbs)
+          (fun zs => ret (DVALUE_Double (Float.of_bits (concat_bytes_Z_vint zs))))
+    | DTYPE_FP FP_x86_fp80 =>
+        raise_error "memory_bytes_to_dvalue: unsupported X86_fp80."
+    | DTYPE_FP FP_fp128 =>
+        raise_error "memory_bytes_to_dvalue: unsupported fp128."
+    | DTYPE_FP FP_ppc_fp128 =>
+        raise_error "memory_bytes_to_dvalue: unsupported ppc_fp128."
+    | DTYPE_Label =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Label."
+    | DTYPE_Token =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Token."
+    | DTYPE_Metadata =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Metadata."
+    | DTYPE_X86_mmx =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_X86_mmx."
 
-      (* NOTE: arrays and vectors are decorated with their whole type, which contains
+    (* NOTE: arrays and vectors are decorated with their whole type, which contains
          necessary size information.
-       *)
-      | DTYPE_Array sz t =>
-          let sz' := sizeof_dtyp t in
-          let elt_bytes :=
-            if N.eqb sz' 0
-            then repeatN sz []
-            else split_every_nil sz' dbs
-          in
-          elts <- map_monad (fun es => memory_bytes_to_dvalue es t) elt_bytes;;
-          ret (DVALUE_Array (DTYPE_Array sz t) elts)
+     *)
+    | DTYPE_Array sz t =>
+        let sz' := sizeof_dtyp t in
+        let elt_bytes :=
+          if N.eqb sz' 0
+          then repeatN sz []
+          else split_every_nil sz' dbs
+        in
+        elts <- map_monad (fun es => memory_bytes_to_dvalue es t) elt_bytes;;
+        ret (DVALUE_Array (DTYPE_Array sz t) elts)
 
-      | DTYPE_Vector sz t =>
-          let sz' := sizeof_dtyp t in
-          let elt_bytes :=
-            if N.eqb sz' 0
-            then repeatN sz []
-            else split_every_nil sz' dbs
-          in
-          elts <- map_monad (fun es => memory_bytes_to_dvalue es t) elt_bytes;;
-          ret (DVALUE_Vector (DTYPE_Vector sz t) elts)
-      | DTYPE_Struct fields =>
-          Functor.fmap DVALUE_Struct (list_memory_bytes_to_dvalue (Some (max_preferred_dtyp_alignment fields)) 0 fields dbs)
-                       
-      | DTYPE_Packed_struct fields =>
-          Functor.fmap DVALUE_Packed_struct (list_memory_bytes_to_dvalue None 0 fields dbs)
-      | DTYPE_Opaque =>
-          raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Opaque."
-                      
-      end.
+    | DTYPE_Vector sz t =>
+        let sz' := sizeof_dtyp t in
+        let elt_bytes :=
+          if N.eqb sz' 0
+          then repeatN sz []
+          else split_every_nil sz' dbs
+        in
+        elts <- map_monad (fun es => memory_bytes_to_dvalue es t) elt_bytes;;
+        ret (DVALUE_Vector (DTYPE_Vector sz t) elts)
+    | DTYPE_Struct fields =>
+        Functor.fmap DVALUE_Struct (list_memory_bytes_to_dvalue (Some (max_preferred_dtyp_alignment fields)) 0 fields dbs)
+                     
+    | DTYPE_Packed_struct fields =>
+        Functor.fmap DVALUE_Packed_struct (list_memory_bytes_to_dvalue None 0 fields dbs)
+    | DTYPE_Opaque =>
+        raise_error "memory_bytes_to_dvalue: unsupported DTYPE_Opaque."
+                    
+    end.
   
 End MemoryByte.
 

--- a/src/rocq/Semantics/Operations/Compare.v
+++ b/src/rocq/Semantics/Operations/Compare.v
@@ -8,7 +8,7 @@ From Vellvm Require Import
 Section Compare.
   Context {Pa : Params}.
 
-  Definition eval_icmp_h (samesign:bool) (icmp : icmp) (v1 v2 : dvalue) : EOU dvalue.
+  Definition eval_icmp_base (samesign:bool) (icmp : icmp) (v1 v2 : dvalue_base) : EOU dvalue_base.
     refine
       (match v1, v2 with
        | DVALUE_I sz1 i1, DVALUE_I sz2 i2 =>
@@ -17,17 +17,17 @@ Section Compare.
        | DVALUE_Poison t1, DVALUE_Poison t2 => ret (DVALUE_Poison t1)
        | DVALUE_Poison t, _ => if is_DVALUE_IX v2 then ret (DVALUE_Poison t) else raise_error "ill_typed-iop"
        | _, DVALUE_Poison t => if is_DVALUE_IX v1 then ret (DVALUE_Poison t) else raise_error "ill_typed-iop"
-       | DVALUE_Addr a1, DVALUE_Addr a2 =>
+       | DVALUE_Pointer a1, DVALUE_Pointer a2 =>
            let i1 := ptr_to_int a1 in
            let i2 := ptr_to_int a2 in
            eval_int_icmp false icmp i1 i2
-       | _, _ => raise_error ("ill_typed-icmp: " ++ show_dvalue v1 ++ ", " ++ show_dvalue v2)
+       | _, _ => raise_error ("eval_icmp_base: ill_typed-icmp: " ++ show v1 ++ ", " ++ show v2)
        end).
     destruct (Pos.eq_dec sz1 sz2); subst.
     - exact (eval_int_icmp samesign icmp i1 i2).
-    - exact (raise_error ("ill_typed-icmp: " ++ show_dvalue v1 ++ ", " ++ show_dvalue v2)).
+    - exact (raise_error ("eval_icmp_base: ill_typed-icmp: " ++ show v1 ++ ", " ++ show v2)).
   Defined.
-  Arguments eval_icmp_h _ _ _ _ : simpl nomatch.
+  Arguments eval_icmp_base _ _ _ _ : simpl nomatch.
 
   Definition eval_icmp (samesign:bool) (icmp : icmp) (v1 v2 : dvalue) : EOU dvalue :=
     match v1, v2 with
@@ -35,11 +35,12 @@ Section Compare.
         let n := N.length elts1 in
         let m := N.length elts2 in
         if (n =? m)%N  then 
-          val <- vec_loop (eval_icmp_h samesign icmp) (List.combine elts1 elts2) ;;
+          val <- vec_loop (eval_icmp_base samesign icmp) (List.combine elts1 elts2) ;;
           ret (DVALUE_Vector (DTYPE_Vector n (DTYPE_I 1)) val)
         else
           raise_ub "icmp of different-length vectors"
-    | _, _ => eval_icmp_h samesign icmp v1 v2
+    | DVALUE_Base v1, DVALUE_Base v2 => DVALUE_Base <$> (eval_icmp_base samesign icmp v1 v2)
+    | _, _ => raise_error "eval_icmp_base: ill-typed icmp"
     end.
 
   Arguments eval_icmp _ _ _ _ : simpl nomatch.

--- a/src/rocq/Semantics/Operations/Compare.v
+++ b/src/rocq/Semantics/Operations/Compare.v
@@ -31,12 +31,14 @@ Section Compare.
 
   Definition eval_icmp (samesign:bool) (icmp : icmp) (v1 v2 : dvalue) : EOU dvalue :=
     match v1, v2 with
-    | (DVALUE_Vector t elts1), (DVALUE_Vector _ elts2) =>
+    | (DVALUE_Array true t elts1), (DVALUE_Array true _ elts2) =>
         let n := N.length elts1 in
         let m := N.length elts2 in
-        if (n =? m)%N  then 
-          val <- vec_loop (eval_icmp_base samesign icmp) (List.combine elts1 elts2) ;;
-          ret (DVALUE_Vector (DTYPE_Vector n (DTYPE_I 1)) val)
+        if (n =? m)%N  then
+          elts1' <- map_monad dvalue_to_dvalue_base elts1 ;;
+          elts2' <- map_monad dvalue_to_dvalue_base elts2 ;;
+          val <- vec_loop (eval_icmp_base samesign icmp) (List.combine elts1' elts2') ;;
+          ret (DVALUE_Array true (DTYPE_Array true n (DTYPE_I 1)) (List.map DVALUE_Base val))
         else
           raise_ub "icmp of different-length vectors"
     | DVALUE_Base v1, DVALUE_Base v2 => DVALUE_Base <$> (eval_icmp_base samesign icmp v1 v2)

--- a/src/rocq/Semantics/Operations/Conversion.v
+++ b/src/rocq/Semantics/Operations/Conversion.v
@@ -7,9 +7,62 @@ From Vellvm Require Import
      DynamicValues
      MemoryBytes.
 
+
 Section Convert.
   Context {Pa : Params}.
 
+
+  Section CONVERSIONS.
+
+    (** ** Typed conversion
+        Performs a dynamic conversion of a [dvalue] of type [t1] to one of type [t2].
+        For instance, convert an integer over 8 bits to one over 1 bit by truncation.
+
+        The conversion function is not pure, i.e. in particular cannot live in [DynamicValues.v]
+        as would be natural, due to the [Int2Ptr] and [Ptr2Int] cases. At those types, the conversion
+        needs to cast between integers and pointers, which depends on the memory model.
+     *)
+
+    (* Note: Inferring the subevent instance takes a small but non-trivial amount of time,
+       and has to be done here hundreds and hundreds of times due to the brutal pattern matching on
+       several values. Factoring the inference upfront is therefore necessary.
+     *)
+
+    (* A trick avoiding proofs that involve thousands of cases: we split the conversion into
+      the composition of a huge case analysis that builds a value of [conv_case], and a function
+      with only four cases to actually build the tree.
+     *)
+    Variant conv_case : Set :=
+    | Conv_Pure    (x : dvalue_base)
+    | Conv_ItoP    (x : dvalue_base)
+    | Conv_PtoI    (x : dvalue_base)
+    | Conv_Oom     (s : string)
+    | Conv_Illegal (s: string).
+     
+    Variant ptr_conv_cases : Set :=
+    | PtrConv_ItoP
+    | PtrConv_PtoI
+    | PtrConv_Neither.
+
+    Definition get_conv_case_ptr conv (t1 : dtyp_base) (t2 : dtyp_base) : ptr_conv_cases
+      := match conv with
+         | Inttoptr =>
+           match t1, t2 with
+           | DTYPE_I 64, DTYPE_Pointer => PtrConv_ItoP
+           | DTYPE_Iptr, DTYPE_Pointer => PtrConv_ItoP
+           | _, _ => PtrConv_Neither
+           end
+         | Ptrtoint =>
+           match t1, t2 with
+           | DTYPE_Pointer, DTYPE_I _ => PtrConv_PtoI
+           | DTYPE_Pointer, DTYPE_Iptr => PtrConv_PtoI
+           | _, _ => PtrConv_Neither
+           end
+         | _ => PtrConv_Neither
+         end.
+  End CONVERSIONS.
+
+  
   (* Floating point extension *)
   (* SAZ: I'm not sure that this implementation does the right thing
      with respect to the rounding mode (maybe not a problem for extension)
@@ -37,7 +90,7 @@ Section Convert.
         as would be natural, due to the [Int2Ptr] and [Ptr2Int] cases. At those types, the conversion
         needs to cast between integers and pointers, which depends on the memory model.
    *)
-  Definition get_conv_case (conv : conversion_type) (t1:dtyp) (x:dvalue) (t2:dtyp) : conv_case :=
+  Definition get_conv_case (conv : conversion_type) (t1:dtyp_base) (x:dvalue_base) (t2:dtyp_base) : conv_case :=
     match conv with
     | Trunc nuw nsb => (* TODO: handle the nuw and nsb flags *)
         match t1, x, t2 with
@@ -47,7 +100,7 @@ Section Convert.
             else Conv_Illegal "i-to-i ill-typed Trunc"
 
         | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
-            Conv_Pure (DVALUE_Poison t2)
+            Conv_Pure (dvp t2)
 
         | _, _, _ => Conv_Illegal "ill-typed Trunc"
         end
@@ -60,7 +113,7 @@ Section Convert.
             else Conv_Illegal "i-to-i ill-typed Zext"
 
         | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
-            Conv_Pure (DVALUE_Poison t2)
+            Conv_Pure (dvp t2)
 
         | _, _, _ => Conv_Illegal "ill-typed Zext"
         end
@@ -73,18 +126,18 @@ Section Convert.
             else Conv_Illegal "i-to-i ill-typed Sext"
 
         | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_I sz_to =>
-            Conv_Pure (DVALUE_Poison t2)
+            Conv_Pure (dvp t2)
 
         | _, _, _ => Conv_Illegal "ill-typed Sext"
         end
 
     | Bitcast =>
-        if dtyp_eqb t1 t2
+        if dtyp_base_eqb t1 t2
         then Conv_Pure x
-        else if bit_sizeof_dtyp t1 =? bit_sizeof_dtyp t2
+        else if bit_sizeof_dtyp (DTYPE_Base t1) =? bit_sizeof_dtyp (DTYPE_Base t2)
              then
-               let bytes := dvalue_to_memory_bytes x t1 in
-               let dv_conv := memory_bytes_to_dvalue bytes t2 in
+               let bytes := dvalue_to_memory_bytes (DVALUE_Base x) (DTYPE_Base t1) in
+               let dv_conv := memory_bytes_to_dvalue_base bytes t2 in
                match dv_conv with
                | raise_error err => Conv_Illegal ("Bitcast failure: " ++ err)
                | raise_oom oom => Conv_Oom ("Bitcast OOM: " ++ oom)
@@ -106,7 +159,7 @@ Section Convert.
             else Conv_Illegal "i-to-double ill-typed Uitofp"
 
         | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_FP _ =>
-            Conv_Pure (DVALUE_Poison t2)
+            Conv_Pure (dvp t2)
 
         | _, _, _ => Conv_Illegal "ill-typed Uitofp"
         end
@@ -124,7 +177,7 @@ Section Convert.
             else Conv_Illegal "i-to-double ill-typed Sitofp"
 
         | DTYPE_I sz_t, DVALUE_Poison t, DTYPE_FP _ =>
-            Conv_Pure (DVALUE_Poison t2)
+            Conv_Pure (dvp t2)
 
         | _, _, _ => Conv_Illegal "ill-typed Sitofp"
         end
@@ -149,18 +202,18 @@ Section Convert.
           value cannot fit in ty2, the result is a poison value. *)
         | DTYPE_FP FP_float, DVALUE_Float f, DTYPE_I sz_t =>
             match ZofB_range _ _ f (0%Z) (@max_unsigned sz_t) with
-            | None => Conv_Pure (DVALUE_Poison t2)
+            | None => Conv_Pure (dvp t2)
             | Some z => Conv_Pure (DVALUE_I sz_t (repr z))
             end
               
         | DTYPE_FP FP_double, DVALUE_Double f, DTYPE_I sz_t  =>
             match ZofB_range _ _ f (0%Z) (@max_unsigned sz_t) with
-            | None => Conv_Pure (DVALUE_Poison t2)
+            | None => Conv_Pure (dvp t2)
             | Some z => Conv_Pure (DVALUE_I sz_t (repr z))
             end
               
         | DTYPE_FP _, DVALUE_Poison t, DTYPE_I _ =>
-            Conv_Pure (DVALUE_Poison t2)
+            Conv_Pure (dvp t2)
 
         | _, _, _ => Conv_Illegal "ill-typed Fptoui"
         end
@@ -172,18 +225,18 @@ Section Convert.
           value cannot fit in ty2, the result is a poison value. *)
         | DTYPE_FP FP_float, DVALUE_Float f, DTYPE_I sz_t =>
             match ZofB_range _ _ f (@min_signed sz_t) (@max_signed sz_t) with
-            | None => Conv_Pure (DVALUE_Poison t2)
+            | None => Conv_Pure (dvp t2)
             | Some z => Conv_Pure (DVALUE_I sz_t (repr z))
             end
               
         | DTYPE_FP FP_double, DVALUE_Double f, DTYPE_I sz_t  =>
             match ZofB_range _ _ f (@min_signed sz_t) (@max_signed sz_t) with
-            | None => Conv_Pure (DVALUE_Poison t2)
+            | None => Conv_Pure (dvp t2)
             | Some z => Conv_Pure (DVALUE_I sz_t (repr z))
             end
               
         | DTYPE_FP _, DVALUE_Poison t, DTYPE_I _ =>
-            Conv_Pure (DVALUE_Poison t2)
+            Conv_Pure (dvp t2)
 
         | _, _, _ => Conv_Illegal "ill-typed Fptosi"
         end
@@ -205,28 +258,33 @@ Section Convert.
   
   Arguments get_conv_case _ _ _ _ : simpl nomatch.
 
-  Definition convert_h (conv : conversion_type) (t_from : dtyp) (dv : dvalue) (t_to : dtyp) : EOU dvalue :=
+  Definition convert_base (conv : conversion_type) (t_from : dtyp_base) (dv : dvalue_base) (t_to : dtyp_base) : EOU dvalue_base :=
     match get_conv_case conv t_from dv t_to with
     | Conv_PtoI x =>
         match x, t_to with
-        | DVALUE_Addr addr, DTYPE_I sz => coerce_integer_to_int (Some sz) (ptr_to_int addr)
-        | DVALUE_Addr addr, DTYPE_Iptr => coerce_integer_to_int None (ptr_to_int addr)
+        | DVALUE_Pointer ptr, DTYPE_I sz => coerce_integer_to_int (Some sz) (ptr_to_int ptr)
+        | DVALUE_Pointer ptr, DTYPE_Iptr => coerce_integer_to_int None (ptr_to_int ptr)
         | _, _ => raise_error "Invalid PTOI conversion"
         end
     | Conv_ItoP x =>
-        DVALUE_Addr <$> int_to_ptr (dvalue_int_unsigned x) wildcard_prov
+        DVALUE_Pointer <$> int_to_ptr (dvalue_base_int_unsigned x) wildcard_prov
     | Conv_Pure x => ret x
     | Conv_Oom s => raise_oom s
     | Conv_Illegal s => raise_error s
     end.
 
-  Definition get_vec_conversion_type (t_from t_to : dtyp) : option (dtyp * dtyp) :=
+  Definition get_conversion_type (t_from t_to : dtyp) : option (dtyp_base * dtyp_base) :=
     match t_from, t_to with
+    | DTYPE_Base t_from', DTYPE_Base t_to' =>
+        Some (t_from', t_to')
+
     | DTYPE_Vector n t_from', DTYPE_Vector m t_to' =>
-        if N.eqb n m then Some (t_from', t_to') else None
+        if N.eqb n m
+        then Some (t_from', t_to')
+        else None
+
     | _, _ => None
     end.
-
 
   (* SAZ: TODO - clean up this logic? Is there a cleaner way, and do we really need
      the conversion cases stuff?
@@ -239,21 +297,28 @@ Section Convert.
         else if bit_sizeof_dtyp t_from =? bit_sizeof_dtyp t_to
              then
                let bytes := dvalue_to_memory_bytes dv t_from in
-                memory_bytes_to_dvalue bytes t_to 
+               memory_bytes_to_dvalue bytes t_to 
              else raise_error "unequal bitsize in cast"
     | _ => 
         match dv with
-        | (DVALUE_Vector (DTYPE_Vector sz t) elts1) =>
-            match get_vec_conversion_type t_from t_to with
+        | (DVALUE_Base dv) =>
+            match get_conversion_type t_from t_to with
             | Some (t_from', t_to') =>
-                val <- map_monad (fun v => convert_h conv t_from' v t_to') elts1 ;;
+                DVALUE_Base <$> (convert_base conv t_from' dv t_to')
+                            
+            | None =>
+                raise_error "vector conversion at incompatible types or vector lengths"
+            end
+          
+        | (DVALUE_Vector (DTYPE_Vector sz t) elts1) =>
+            match get_conversion_type t_from t_to with
+            | Some (t_from', t_to') =>
+                val <- map_monad (fun v => convert_base conv t_from' v t_to') elts1 ;;
                 ret (DVALUE_Vector (DTYPE_Vector sz t_to') val)
             | None =>
                 raise_error "vector conversion at incompatible types or vector lengths"
             end
-        | (DVALUE_Vector _ _) =>
-            raise_error "convert: vector type annotation violates invariant"
-        | _ => convert_h conv t_from dv t_to
+        | _ => raise_error "convert: invalid input dvalue"
         end
     end.
 

--- a/src/rocq/Semantics/Operations/Conversion.v
+++ b/src/rocq/Semantics/Operations/Conversion.v
@@ -278,7 +278,7 @@ Section Convert.
     | DTYPE_Base t_from', DTYPE_Base t_to' =>
         Some (t_from', t_to')
 
-    | DTYPE_Vector n t_from', DTYPE_Vector m t_to' =>
+    | DTYPE_Array true n (DTYPE_Base t_from'), DTYPE_Array true m (DTYPE_Base t_to') =>
         if N.eqb n m
         then Some (t_from', t_to')
         else None
@@ -310,11 +310,12 @@ Section Convert.
                 raise_error "vector conversion at incompatible types or vector lengths"
             end
           
-        | (DVALUE_Vector (DTYPE_Vector sz t) elts1) =>
+        | (DVALUE_Array true (DTYPE_Array true sz t) elts1) =>
             match get_conversion_type t_from t_to with
             | Some (t_from', t_to') =>
-                val <- map_monad (fun v => convert_base conv t_from' v t_to') elts1 ;;
-                ret (DVALUE_Vector (DTYPE_Vector sz t_to') val)
+                elts1' <- map_monad dvalue_to_dvalue_base elts1 ;;
+                val <- map_monad (fun v => convert_base conv t_from' v t_to') elts1' ;;
+                ret (DVALUE_Array true (DTYPE_Array true sz t_to') (List.map DVALUE_Base val))
             | None =>
                 raise_error "vector conversion at incompatible types or vector lengths"
             end

--- a/src/rocq/Semantics/Operations/Gep.v
+++ b/src/rocq/Semantics/Operations/Gep.v
@@ -26,10 +26,8 @@ Section GEP.
         | DVALUE_Base (DVALUE_I 8 i) =>
             let k := signed i in
             match t with
-            | DTYPE_Array _ ta =>
+            | DTYPE_Array v _ ta =>
                 handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'                
-            | DTYPE_Vector _ ta =>
-                handle_gep_h (DTYPE_Base ta) (off + k * (Z.of_N (sizeof_dtyp (DTYPE_Base ta)))) vs'
             | _ => raise_error ("non-i8-indexable type")
             end
         | DVALUE_Base (DVALUE_I 32 i) =>
@@ -37,10 +35,8 @@ Section GEP.
             let ks := signed i in
             let n := BinIntDef.Z.to_nat k in
             match t with
-            | DTYPE_Array _ ta =>
+            | DTYPE_Array v _ ta =>
                 handle_gep_h ta (off + ks * (Z.of_N (sizeof_dtyp ta))) vs'                          
-            | DTYPE_Vector _ ta =>
-                handle_gep_h (DTYPE_Base ta) (off + ks * (Z.of_N (sizeof_dtyp (DTYPE_Base ta)))) vs'
             | DTYPE_Struct false ts =>
                 let offset := fold_left (fun acc t => pad_to_align (dtyp_alignment t) acc + sizeof_dtyp t)%N (firstn n ts) 0%N in
                 match nth_error ts n with
@@ -63,19 +59,17 @@ Section GEP.
         | DVALUE_Base (DVALUE_I 64 i) =>
             let k := signed i in
             match t with
-            | DTYPE_Array _ ta =>
+            | DTYPE_Array false _ ta =>
                 handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'
-            | DTYPE_Vector _ ta =>
-                handle_gep_h (DTYPE_Base ta) (off + k * (Z.of_N (sizeof_dtyp (DTYPE_Base ta)))) vs'
+            | DTYPE_Array true _ ta =>
+                handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'
             | _ => raise_error ("non-i64-indexable type")
             end
         | DVALUE_Base (DVALUE_Iptr i) =>
             let k := to_Z i in
             match t with
-            | DTYPE_Array _ ta =>
+            | DTYPE_Array v  _ ta =>
                 handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'                
-            | DTYPE_Vector _ ta =>
-                handle_gep_h (DTYPE_Base ta) (off + k * (Z.of_N (sizeof_dtyp (DTYPE_Base ta)))) vs'
             | _ => raise_error ("non-iptr-indexable type")
             end
               

--- a/src/rocq/Semantics/Operations/Gep.v
+++ b/src/rocq/Semantics/Operations/Gep.v
@@ -23,30 +23,32 @@ Section GEP.
     match vs with
     | v :: vs' =>
         match v with
-        | DVALUE_I 8 i =>
+        | DVALUE_Base (DVALUE_I 8 i) =>
             let k := signed i in
             match t with
-            | DTYPE_Array _ ta
+            | DTYPE_Array _ ta =>
+                handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'                
             | DTYPE_Vector _ ta =>
-                handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'
+                handle_gep_h (DTYPE_Base ta) (off + k * (Z.of_N (sizeof_dtyp (DTYPE_Base ta)))) vs'
             | _ => raise_error ("non-i8-indexable type")
             end
-        | DVALUE_I 32 i =>
+        | DVALUE_Base (DVALUE_I 32 i) =>
             let k := unsigned i in
             let ks := signed i in
             let n := BinIntDef.Z.to_nat k in
             match t with
-            | DTYPE_Array _ ta
+            | DTYPE_Array _ ta =>
+                handle_gep_h ta (off + ks * (Z.of_N (sizeof_dtyp ta))) vs'                          
             | DTYPE_Vector _ ta =>
-                handle_gep_h ta (off + ks * (Z.of_N (sizeof_dtyp ta))) vs'
-            | DTYPE_Struct ts =>
+                handle_gep_h (DTYPE_Base ta) (off + ks * (Z.of_N (sizeof_dtyp (DTYPE_Base ta)))) vs'
+            | DTYPE_Struct false ts =>
                 let offset := fold_left (fun acc t => pad_to_align (dtyp_alignment t) acc + sizeof_dtyp t)%N (firstn n ts) 0%N in
                 match nth_error ts n with
                 | None => raise_error "overflow"
                 | Some t' =>
                     handle_gep_h t' (off + Z.of_N offset) vs'
                 end
-            | DTYPE_Packed_struct ts =>
+            | DTYPE_Struct true ts =>
                 let offset := fold_left (fun acc t => acc + sizeof_dtyp t)%N
                                 (firstn n ts) 0%N in
                 match nth_error ts n with
@@ -58,20 +60,22 @@ Section GEP.
             | _ => raise_error ("non-i32-indexable type")
             end
               
-        | DVALUE_I 64 i =>
+        | DVALUE_Base (DVALUE_I 64 i) =>
             let k := signed i in
             match t with
-            | DTYPE_Array _ ta
-            | DTYPE_Vector _ ta =>
+            | DTYPE_Array _ ta =>
                 handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'
+            | DTYPE_Vector _ ta =>
+                handle_gep_h (DTYPE_Base ta) (off + k * (Z.of_N (sizeof_dtyp (DTYPE_Base ta)))) vs'
             | _ => raise_error ("non-i64-indexable type")
             end
-        | DVALUE_Iptr i =>
+        | DVALUE_Base (DVALUE_Iptr i) =>
             let k := to_Z i in
             match t with
-            | DTYPE_Array _ ta
+            | DTYPE_Array _ ta =>
+                handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'                
             | DTYPE_Vector _ ta =>
-                handle_gep_h ta (off + k * (Z.of_N (sizeof_dtyp ta))) vs'
+                handle_gep_h (DTYPE_Base ta) (off + k * (Z.of_N (sizeof_dtyp (DTYPE_Base ta)))) vs'
             | _ => raise_error ("non-iptr-indexable type")
             end
               
@@ -84,29 +88,29 @@ Section GEP.
      The pointer set the block into which we look, and the initial offset. The first index value add to the initial offset passed to [handle_gep_h] for the actual access to structured data.
    *)
   (* TODO: This should take into account padding too... May break get_consecutive_ptrs and friends. *)
-  Definition handle_gep_addr (t:dtyp) (a:addr) (vs:list dvalue) : EOU addr :=
+  Definition handle_gep_ptr (t:dtyp) (a:ptr) (vs:list dvalue) : EOU ptr :=
     let ptr := ptr_to_int a in
-    let prov := address_provenance a in
+    let prov := ptr_provenance a in
     match vs with
-    | DVALUE_I 8 i :: vs' =>
+    | DVALUE_Base (DVALUE_I 8 i) :: vs' =>
         ptr' <- handle_gep_h t (ptr + Z.of_N (sizeof_dtyp t) * (signed i)) vs' ;;
         int_to_ptr ptr' prov
-    | DVALUE_I 32 i :: vs' =>
+    | DVALUE_Base (DVALUE_I 32 i) :: vs' =>
         ptr' <- handle_gep_h t (ptr + Z.of_N (sizeof_dtyp t) * (signed i)) vs' ;;
         int_to_ptr ptr' prov
-    | DVALUE_I 64 i :: vs' =>
+    | DVALUE_Base (DVALUE_I 64 i) :: vs' =>
         ptr' <- handle_gep_h t (ptr + Z.of_N (sizeof_dtyp t) * (signed i)) vs' ;;
         int_to_ptr ptr' prov
-    | DVALUE_Iptr i :: vs' =>
+    | DVALUE_Base (DVALUE_Iptr i) :: vs' =>
         ptr' <- handle_gep_h t (ptr + Z.of_N (sizeof_dtyp t) * (to_Z i)) vs' ;;
         int_to_ptr ptr' prov
-    | [] => raise_error "handle_gep_addr: no indices"
-    | _ => raise_error "handle_gep_addr: unsupported index type"
+    | [] => raise_error "handle_gep_ptr: no indices"
+    | _ => raise_error "handle_gep_ptr: unsupported index type"
     end.
 
-  Lemma handle_gep_addr_0 :
-    forall (dt : dtyp) (p : addr),
-      handle_gep_addr dt p [DVALUE_Iptr zero_iptr] = ret p.
+  Lemma handle_gep_ptr_0 :
+    forall (dt : dtyp) (p : ptr),
+      handle_gep_ptr dt p [DVALUE_Base (DVALUE_Iptr zero_iptr)] = ret p.
   Proof.
     intros dt p.
     cbn.
@@ -115,17 +119,17 @@ Section GEP.
     rewrite int_to_ptr_ptr_to_int; auto.
   Qed.
 
-  Lemma handle_gep_addr_nil :
-    forall (dt : dtyp) (p : addr),
-      handle_gep_addr dt p [] = raise_error "handle_gep_addr: no indices"%string.
+  Lemma handle_gep_ptr_nil :
+    forall (dt : dtyp) (p : ptr),
+      handle_gep_ptr dt p [] = raise_error "handle_gep_ptr: no indices"%string.
   Proof.
     intros dt p.
     cbn; auto.
   Qed.
 
-  Lemma handle_gep_addr_ix :
-    forall (dt : dtyp) (p p' : addr) ix,
-      handle_gep_addr dt p [DVALUE_Iptr ix] = ret p' ->
+  Lemma handle_gep_ptr_ix :
+    forall (dt : dtyp) (p p' : ptr) ix,
+      handle_gep_ptr dt p [DVALUE_Base (DVALUE_Iptr ix)] = ret p' ->
       ptr_to_int p' = (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z.
   Proof.
     intros dt p p' ix GEP.
@@ -134,11 +138,11 @@ Section GEP.
     erewrite ptr_to_int_int_to_ptr; eauto.
   Qed.
 
-  Lemma handle_gep_addr_ix_OOM :
-    forall (dt : dtyp) (p p' : addr) ix msg,
-      handle_gep_addr dt p [DVALUE_Iptr ix] = raise_oom msg ->
+  Lemma handle_gep_ptr_ix_OOM :
+    forall (dt : dtyp) (p p' : ptr) ix msg,
+      handle_gep_ptr dt p [DVALUE_Base (DVALUE_Iptr ix)] = raise_oom msg ->
       exists msg',
-        int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (address_provenance p) = raise_oom msg'.
+        int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (ptr_provenance p) = raise_oom msg'.
   Proof.
     intros dt p p' ix msg GEP.
     cbn in *.
@@ -147,10 +151,10 @@ Section GEP.
     auto.
   Qed.
 
-  Lemma handle_gep_addr_ix' :
-    forall (dt : dtyp) (p p' : addr) ix,
-      ret p' = int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (address_provenance p) ->
-      handle_gep_addr dt p [DVALUE_Iptr ix] = ret p'.
+  Lemma handle_gep_ptr_ix' :
+    forall (dt : dtyp) (p p' : ptr) ix,
+      ret p' = int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (ptr_provenance p) ->
+      handle_gep_ptr dt p [DVALUE_Base (DVALUE_Iptr ix)] = ret p'.
   Proof.
     intros dt p p' ix IX.
     cbn in *.
@@ -158,10 +162,10 @@ Section GEP.
     reflexivity.
   Qed.
 
-  Lemma handle_gep_addr_ix'_OOM :
-    forall (dt : dtyp) (p p' : addr) ix msg,
-      int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (address_provenance p) = raise_oom msg ->
-      exists msg', handle_gep_addr dt p [DVALUE_Iptr ix] = raise_oom msg'.
+  Lemma handle_gep_ptr_ix'_OOM :
+    forall (dt : dtyp) (p p' : ptr) ix msg,
+      int_to_ptr (ptr_to_int p + Z.of_N (sizeof_dtyp dt) * to_Z ix)%Z (ptr_provenance p) = raise_oom msg ->
+      exists msg', handle_gep_ptr dt p [DVALUE_Base (DVALUE_Iptr ix)] = raise_oom msg'.
   Proof.
     intros dt p p' ix msg IX.
     cbn in *.
@@ -170,10 +174,10 @@ Section GEP.
     auto.
   Qed.
 
-  Lemma handle_gep_addr_preserves_provenance :
-    forall (dt : dtyp) ixs (p p' : addr),
-      handle_gep_addr dt p ixs = ret p' ->
-      address_provenance p = address_provenance p'.
+  Lemma handle_gep_ptr_preserves_provenance :
+    forall (dt : dtyp) ixs (p p' : ptr),
+      handle_gep_ptr dt p ixs = ret p' ->
+      ptr_provenance p = ptr_provenance p'.
   Proof.
     intros dt ixs.
     induction ixs;
@@ -189,7 +193,7 @@ Section GEP.
 
   Definition eval_gep (t:dtyp) (dv:dvalue) (vs:list dvalue) : EOU dvalue :=
     match dv with
-    | DVALUE_Addr a => DVALUE_Addr <$> handle_gep_addr t a vs
-    | _ => raise_error "non-address"%string
+    | DVALUE_Base (DVALUE_Pointer a) => (fun x => DVALUE_Base (DVALUE_Pointer x)) <$> handle_gep_ptr t a vs
+    | _ => raise_error "non-ptr"%string
     end.
 End GEP.

--- a/src/rocq/Semantics/Operations/Select.v
+++ b/src/rocq/Semantics/Operations/Select.v
@@ -8,48 +8,55 @@ From Vellvm Require Import
 Section Select.
   Context {Pa : Params}.
 
-  Definition eval_select
-    (cnd : dvalue) (v1 v2 : dvalue) : EOU dvalue
-    := match cnd with
-       | DVALUE_Poison t =>
-           (* TODO: Should be the type of the result of the select... *)
-           ret (DVALUE_Poison t)
-       | DVALUE_I 1 i =>
-           if (@Integers.unsigned 1 i =? 1)%Z
-           then ret v1
-           else ret v2
-       | DVALUE_Vector _ conds =>
-           let fix loop conds xs ys : EOU (list dvalue) :=
-             match conds, xs, ys with
-             | [], [], [] => ret []
-             | (c::conds), (x::xs), (y::ys) =>
-                 selected <- match c with
-                            | DVALUE_Poison t =>
-                                (* TODO: Should be the type of the result of the select... *)
-                                ret (DVALUE_Poison t)
-                            | DVALUE_I 1 i =>
-                                if (@Integers.unsigned 1 i =? 1)%Z
-                                then ret x
-                                else ret y
-                            | _ => raise_error "eval_select: ill-typed select, condition in vector was not poison or i1."
-                            end;;
-                 rest <- loop conds xs ys;;
-                 ret (selected :: rest)
-             | _, _, _ => raise_error "eval_select: ill-typed vector select, length mismatch."
-             end in
-           match v1, v2 with
-           | DVALUE_Poison t, _ =>
-               (* TODO: Should we make sure t is a vector type...? *)
-               ret (DVALUE_Poison t)
-           | DVALUE_Vector _ _, DVALUE_Poison t =>
-               (* TODO: Should we make sure t is a vector type...? *)
-               ret (DVALUE_Poison t)
-           | DVALUE_Vector t xs, DVALUE_Vector _ ys =>
-               selected <- loop conds xs ys;;
-               ret (DVALUE_Vector t selected)
-           | _, _ => raise_error "eval_select: ill-typed vector select, non-vector arguments"
-           end
-       | _ => raise_error "eval_select: ill-typed select."
-       end.
+  Definition eval_select_base (cnd : dvalue_base) (v1 v2 : dvalue_base) : EOU dvalue_base :=
+    match cnd with
+    | DVALUE_Poison (DTYPE_Base (DTYPE_I 1)) =>
+        (* picks the "type" of v1 *)
+        ret (DVALUE_Poison (dtyp_of_dvalue_base v1))
+    | DVALUE_I 1 i =>
+        if (@Integers.unsigned 1 i =? 1)%Z
+        then ret v1
+        else ret v2
+    | _ => raise_error "eval_select_base: ill-typed select."
+    end.
+    
+  Definition eval_select_base_dvalue (cnd : dvalue_base) (v1 v2 : dvalue) : EOU dvalue :=
+    match cnd with
+    | DVALUE_Poison (DTYPE_Base (DTYPE_I 1)) =>
+        (* picks the "type" of v1 *)
+        (fun x => DVALUE_Base (DVALUE_Poison x)) <$> (dtyp_of_dvalue v1)
+    | DVALUE_I 1 i =>
+        if (@Integers.unsigned 1 i =? 1)%Z
+        then ret v1
+        else ret v2
+    | _ => raise_error "eval_select_base_dvalue: ill-typed select."
+    end.
+
+
+
+  Definition eval_select (cnd : dvalue) (v1 v2 : dvalue) : EOU dvalue :=
+    match cnd with
+    | DVALUE_Base cnd' => eval_select_base_dvalue cnd' v1 v2
+    | DVALUE_Vector _ conds =>
+        match v1, v2 with
+        | DVALUE_Vector t elts1, DVALUE_Vector _ elts2 =>
+            (DVALUE_Vector t) <$>
+              (vec_loop (fun c => fun '(v1, v2) => eval_select_base c v1 v2)
+                 (List.combine conds (List.combine elts1 elts2)))
+        | DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz t)), DVALUE_Vector _ ys =>
+            (DVALUE_Vector (DTYPE_Vector sz t)) <$>
+              (vec_loop (fun c => fun '(v1, v2) => eval_select_base c v1 v2)
+                 (List.combine conds (List.combine (repeat (DVALUE_Poison (DTYPE_Base t)) (N.to_nat sz)) ys)))
+        | DVALUE_Vector _ xs, DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz t)) =>
+            (DVALUE_Vector (DTYPE_Vector sz t)) <$>
+              (vec_loop (fun c => fun '(v1, v2) => eval_select_base c v1 v2)
+                 (List.combine conds (List.combine xs (repeat (DVALUE_Poison (DTYPE_Base t)) (N.to_nat sz)))))
+        | DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz t)), DVALUE_Base (DVALUE_Poison (DTYPE_Vector _ _)) =>
+        (* TODO: could check the sizes to see if this is UB *)
+            ret (DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz t)))
+        | _, _ => raise_error "eval_select: ill-typed vector select, non-vector arguments"
+        end
+    | _ => raise_error "eval_select: ill-typed select."
+    end.
 
 End Select.

--- a/src/rocq/Semantics/Operations/Select.v
+++ b/src/rocq/Semantics/Operations/Select.v
@@ -37,23 +37,24 @@ Section Select.
   Definition eval_select (cnd : dvalue) (v1 v2 : dvalue) : EOU dvalue :=
     match cnd with
     | DVALUE_Base cnd' => eval_select_base_dvalue cnd' v1 v2
-    | DVALUE_Vector _ conds =>
+    | DVALUE_Array true _ conds =>
+        conds' <- map_monad dvalue_to_dvalue_base conds ;;
         match v1, v2 with
-        | DVALUE_Vector t elts1, DVALUE_Vector _ elts2 =>
-            (DVALUE_Vector t) <$>
-              (vec_loop (fun c => fun '(v1, v2) => eval_select_base c v1 v2)
-                 (List.combine conds (List.combine elts1 elts2)))
-        | DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz t)), DVALUE_Vector _ ys =>
-            (DVALUE_Vector (DTYPE_Vector sz t)) <$>
-              (vec_loop (fun c => fun '(v1, v2) => eval_select_base c v1 v2)
-                 (List.combine conds (List.combine (repeat (DVALUE_Poison (DTYPE_Base t)) (N.to_nat sz)) ys)))
-        | DVALUE_Vector _ xs, DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz t)) =>
-            (DVALUE_Vector (DTYPE_Vector sz t)) <$>
-              (vec_loop (fun c => fun '(v1, v2) => eval_select_base c v1 v2)
-                 (List.combine conds (List.combine xs (repeat (DVALUE_Poison (DTYPE_Base t)) (N.to_nat sz)))))
-        | DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz t)), DVALUE_Base (DVALUE_Poison (DTYPE_Vector _ _)) =>
+        | DVALUE_Array true t elts1, DVALUE_Array true _ elts2 =>
+            (DVALUE_Array true t) <$>
+              (vec_loop (fun c => fun '(v1, v2) => eval_select_base_dvalue c v1 v2)
+                 (List.combine conds' (List.combine elts1 elts2)))
+        | DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz t)), DVALUE_Array true _ ys =>
+            (DVALUE_Array true (DTYPE_Array true sz t)) <$>
+              (vec_loop (fun c => fun '(v1, v2) => eval_select_base_dvalue c v1 v2)
+                 (List.combine conds' (List.combine (repeat (DVALUE_Base (DVALUE_Poison t)) (N.to_nat sz)) ys)))
+        | DVALUE_Array true _ xs, DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz t)) =>
+            (DVALUE_Array true (DTYPE_Array true sz t)) <$>
+              (vec_loop (fun c => fun '(v1, v2) => eval_select_base_dvalue c v1 v2)
+                 (List.combine conds' (List.combine xs (repeat (DVALUE_Base (DVALUE_Poison t)) (N.to_nat sz)))))
+        | DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz t)), DVALUE_Base (DVALUE_Poison (DTYPE_Array true _ _)) =>
         (* TODO: could check the sizes to see if this is UB *)
-            ret (DVALUE_Base (DVALUE_Poison (DTYPE_Vector sz t)))
+            ret (DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz t)))
         | _, _ => raise_error "eval_select: ill-typed vector select, non-vector arguments"
         end
     | _ => raise_error "eval_select: ill-typed select."

--- a/src/rocq/Semantics/TopLevel.v
+++ b/src/rocq/Semantics/TopLevel.v
@@ -136,8 +136,8 @@ Section withParams.
 
   Definition i8_array_of_string (s : string) : dvalue :=
     let len := N.of_nat (String.length s) + 1%N in
-      DVALUE_Array
-          (DTYPE_Array len i8)
+      DVALUE_Array false
+          (DTYPE_Array false len i8)
           (List.app
             (map (DVALUE_Base ∘ (DVALUE_I 8%positive) ∘
             @Integers.repr 8%positive ∘
@@ -149,15 +149,15 @@ Section withParams.
     let len := N.of_nat (String.length arg) + 1%N in
     (* tl;dr allocating the string in a C-like manner; + 1 for null terminator *)
     v <- alloca i8 len None;;
-    store (DTYPE_Array len i8) v (i8_array_of_string arg);;
+    store (DTYPE_Array false len i8) v (i8_array_of_string arg);;
     ret v.
 
   Definition allocate_args (args : list string) : MCFGtop dvalue :=
     let len := N.of_nat (Datatypes.length args) in
       v <- alloca DTYPE_Pointer len None;;
       arg_addrs <- map_monad allocate_arg args;;
-      store (DTYPE_Array len DTYPE_Pointer) v
-            (DVALUE_Array (DTYPE_Array len DTYPE_Pointer) arg_addrs);;
+      store (DTYPE_Array false len DTYPE_Pointer) v
+            (DVALUE_Array false (DTYPE_Array false len DTYPE_Pointer) arg_addrs);;
       ret v.
 
   Definition build_main_args (args : list string) : MCFGtop (list dvalue) :=

--- a/src/rocq/Semantics/TopLevel.v
+++ b/src/rocq/Semantics/TopLevel.v
@@ -139,11 +139,11 @@ Section withParams.
       DVALUE_Array
           (DTYPE_Array len i8)
           (List.app
-            (map ((DVALUE_I 8%positive) ∘
+            (map (DVALUE_Base ∘ (DVALUE_I 8%positive) ∘
             @Integers.repr 8%positive ∘
             Z.of_N ∘
             Stdlib.Strings.Ascii.N_of_ascii ) (Stdlib.Strings.String.list_ascii_of_string s))
-            [DVALUE_I 8%positive (@Integers.zero 8%positive)]).
+            [DVALUE_Base (DVALUE_I 8%positive (@Integers.zero 8%positive))]).
 
   Definition allocate_arg (arg : string) : MCFGtop dvalue :=
     let len := N.of_nat (String.length arg) + 1%N in
@@ -163,7 +163,7 @@ Section withParams.
   Definition build_main_args (args : list string) : MCFGtop (list dvalue) :=
     v <- allocate_args args;;
     let main_args :=
-      [DVALUE_I 32 ((@Integers.repr 32%positive ∘ Z.of_nat) (List.length args)); v]
+      [DVALUE_Base (DVALUE_I 32 ((@Integers.repr 32%positive ∘ Z.of_nat) (List.length args))); v]
     in
     ret main_args.
 
@@ -195,8 +195,8 @@ Section withParams.
       (* aliases simply populate the global ID map *)
       match (g_exp g) with
       | Some (EXP_Ident (ID_Global g_source)) =>
-          addr <- gread g_source;;
-          gwrite (g_ident g) addr
+          p <- gread g_source;;
+          gwrite (g_ident g) p
       | Some _ => raiseUB ("alias " ++ (show_raw_id (g_ident g)) ++ " has bad initializer expression")
       | None => raiseUB ("alias " ++ (show_raw_id (g_ident g)) ++ " not initialized")
       end
@@ -205,7 +205,7 @@ Section withParams.
     let dt := (g_typ g) in
     a <- gread (g_ident g);;
     uv <- match (g_exp g) with
-         | None => ret (DVALUE_Poison dt)
+         | None => ret (DVALUE_Base (DVALUE_Poison dt))
          | Some e => denote_exp (Some dt) e
          end ;;
     store dt a uv.
@@ -227,8 +227,8 @@ Section withParams.
     let fid := (dc_name (df_prototype df)) in
     fv <- gread fid ;;
     match fv with
-    | DVALUE_Addr addr =>
-        ret (ptr_to_int addr, denote_function df)
+    | DVALUE_Base (DVALUE_Pointer p) =>
+        ret (ptr_to_int p, denote_function df)
     | _ => raise "address_one_function: invalid address, should not happen."
     end.
 
@@ -240,8 +240,8 @@ Section withParams.
     let (fid, den) := libfun in
     fv <- gread fid ;;
     match fv with
-    | DVALUE_Addr addr =>
-        ret (ptr_to_int addr, den)
+    | DVALUE_Base (DVALUE_Pointer p) =>
+        ret (ptr_to_int p, den)
     | _ => raise "address_one_library_function: invalid address, should not happen."
     end.
 

--- a/src/rocq/Semantics/VellvmIntegers.v
+++ b/src/rocq/Semantics/VellvmIntegers.v
@@ -59,7 +59,7 @@ Class VMemInt I : Type :=
     mrepr : Z -> EOU I; (* Not sure if we should even have this *)
 
     (* dtyp *)
-    mdtyp_of_int : dtyp
+    mdtyp_of_int : dtyp_base
   }.
 
 Definition mequ_Z (x y : Z) : bool :=

--- a/src/rocq/Syntax/DynamicTypes.v
+++ b/src/rocq/Syntax/DynamicTypes.v
@@ -26,7 +26,8 @@ Open Scope nat.
 
 
 Unset Elimination Schemes.
-Inductive dtyp : Set :=
+
+Variant dtyp_base : Set :=
 | DTYPE_I (sz:positive)
 | DTYPE_Iptr
 | DTYPE_Pointer
@@ -36,14 +37,22 @@ Inductive dtyp : Set :=
 | DTYPE_Token
 | DTYPE_Metadata
 | DTYPE_X86_mmx
-| DTYPE_Array (sz:N) (t:dtyp)
-| DTYPE_Struct (fields:list dtyp)
-| DTYPE_Packed_struct (fields:list dtyp)
 | DTYPE_Opaque
-| DTYPE_Vector (sz:N) (t:dtyp)     (* t must be integer, floating point, or pointer type *)
+| DTYPE_B (sz:positive).
+
+Inductive dtyp : Set :=
+| DTYPE_Base (dt:dtyp_base)
+| DTYPE_Struct (packed:bool) (fields:list dtyp)
+| DTYPE_Array (sz:N) (t:dtyp)
+| DTYPE_Vector (sz:N) (t:dtyp_base)
 .
 Set Elimination Schemes.
 
+
+Lemma dtyp_base_eq_dec : forall (t1 t2 : dtyp_base), {t1 = t2} + {t1 <> t2}.
+Proof.
+  repeat decide equality.
+Qed.
 
 Ltac dec_dtyp :=
   match goal with
@@ -53,56 +62,95 @@ Ltac dec_dtyp :=
   | [ |- { ?X = ?Y } + { ?X <> ?Y } ] => right; intros H; inversion H
   end.
 
+
 Lemma dtyp_eq_dec : forall (t1 t2:dtyp), {t1 = t2} + {t1 <> t2}.
+Proof.
   refine (fix f t1 t2 :=
             let lsteq_dec := list_eq_dec f in
             match t1, t2 with
-            | DTYPE_I n, DTYPE_I m => _
-            | DTYPE_Iptr , DTYPE_Iptr => _
-            | DTYPE_Pointer, DTYPE_Pointer => _
-            | DTYPE_Void, DTYPE_Void => _
-            | DTYPE_FP f1, DTYPE_FP f2 => _
-            | DTYPE_Label, DTYPE_Label => _
-            | DTYPE_Token, DTYPE_Token => _
-            | DTYPE_Metadata, DTYPE_Metadata => _
-            | DTYPE_X86_mmx, DTYPE_X86_mmx => _
-            | DTYPE_Array n t, DTYPE_Array m t' => _
-            | DTYPE_Struct l, DTYPE_Struct l' => _
-            | DTYPE_Packed_struct l, DTYPE_Packed_struct l' => _
-            | DTYPE_Opaque, DTYPE_Opaque => _
-            | DTYPE_Vector n t, DTYPE_Vector m t' => _
+            | DTYPE_Base t1, DTYPE_Base t2 => _
+            | DTYPE_Struct p l, DTYPE_Struct p' l' => _
+            | DTYPE_Array n t, DTYPE_Array n' t' => _
+            | DTYPE_Vector n t, DTYPE_Vector n' t' => _                                                     
             | _, _ => _
             end); try (ltac:(dec_dtyp); fail).
-  - destruct (Pos.eq_dec n m).
-    * left; subst; reflexivity.
-    * right; intros H; inversion H. contradiction.
-  - destruct (floating_point_variant_eq_dec f1 f2).
-    + left; subst; auto.
-    + right; intros H; inversion H; contradiction.
-  - destruct (N.eq_dec n m).
-    * destruct (f t t').
-    + left; subst; reflexivity.
-    + right; intros H; inversion H. contradiction.
-      * right; intros H; inversion H. contradiction.
-  - destruct (lsteq_dec l l').
+  - destruct (dtyp_base_eq_dec t1 t2).
     * left; subst; reflexivity.
     * right; intros H; inversion H. contradiction.
   - destruct (lsteq_dec l l').
-    * left; subst; reflexivity.
+    * destruct (bool_dec p p').
+      -- left; subst; reflexivity.
+      -- right; intros H; inversion H. contradiction.
     * right; intros H; inversion H. contradiction.
-  - destruct (N.eq_dec n m).
+  - destruct (N.eq_dec n n').
     * destruct (f t t').
-    + left; subst; reflexivity.
-    + right; intros H; inversion H. contradiction.
-      * right; intros H; inversion H. contradiction.
+      --  left; subst; reflexivity.
+      -- right; intros H; inversion H. contradiction.
+    * right; intros H; inversion H. contradiction.
+  - destruct (N.eq_dec n n').
+    * destruct (dtyp_base_eq_dec t t').
+      -- left; subst; reflexivity.
+      -- right; intros H; inversion H. contradiction.
+    * right; intros H; inversion H. contradiction.         
 Defined.
 Arguments dtyp_eq_dec: clear implicits.
 
-Definition dtyp_eqb (dt1 dt2 : dtyp) : bool
-  := match @dtyp_eq_dec dt1 dt2 with
-     | left x => true
-     | right x => false
-     end.
+Section DtypInd.
+  Variable P : dtyp -> Prop.
+  Hypothesis IH_Base   : forall t, P (DTYPE_Base t).
+  Hypothesis IH_Struct : forall (p:bool) (fields: list dtyp), (forall u, In u fields -> P u) -> P (DTYPE_Struct p fields).
+  Hypothesis IH_Array  : forall sz (t: dtyp), (P t) -> P (DTYPE_Array sz t).  
+  Hypothesis IH_Vector    : forall sz t, P (DTYPE_Vector sz t).
+
+  Lemma dtyp_ind : forall (dt:dtyp), P dt.
+    fix IH 1.
+    remember P as P0 in IH.
+    destruct dt; auto; subst.
+    - apply IH_Struct.
+      { revert fields.
+        fix IHfields 1. intros [|u fields']. intros. inversion H.
+        intros u' [<-|Hin]. apply IH. eapply IHfields. apply Hin.
+      }
+    - eapply IH_Array. auto.
+  Qed.
+End DtypInd.
+
+Section DtypRec.
+  Variable P : dtyp -> Set.
+  Hypothesis IH_Base   : forall t, P (DTYPE_Base t).
+  Hypothesis IH_Struct : forall (p:bool) (fields: list dtyp), (forall u, In u fields -> P u) -> P (DTYPE_Struct p fields).
+  Hypothesis IH_Array  : forall sz (t: dtyp), (P t) -> P (DTYPE_Array sz t).  
+  Hypothesis IH_Vector    : forall sz t, P (DTYPE_Vector sz t).
+
+  Lemma dtyp_rec : forall (dt:dtyp), P dt.
+    fix IH 1.
+    remember P as P0 in IH.
+    destruct dt; auto; subst.
+    - apply IH_Struct.
+      { revert fields.
+        fix IHfields 1. intros [|u fields']. intros. inversion H.
+        intros u' Hin.
+        pose proof In_cons_dec dtyp_eq_dec Hin.
+        destruct H.
+        subst. apply IH.
+        eapply IHfields. apply i.
+      }
+    - apply IH_Array. auto.
+  Qed.
+
+End DtypRec.
+
+Definition dtyp_base_eqb (dt1 dt2 : dtyp_base) : bool :=
+  match @dtyp_base_eq_dec dt1 dt2 with
+  | left x => true
+  | right x => false
+  end.
+
+Definition dtyp_eqb (dt1 dt2 : dtyp) : bool :=
+  match @dtyp_eq_dec dt1 dt2 with
+  | left x => true
+  | right x => false
+  end.
 
 Lemma dtyp_eqb_refl :
   forall dt, dtyp_eqb dt dt = true.
@@ -124,92 +172,28 @@ Proof using.
   destruct (dtyp_eq_dec t1 t2); auto; discriminate.
 Qed.
 
-Definition vector_dtyp dt :=
-  (exists n, dt = DTYPE_I n) \/ dt = DTYPE_Iptr \/ dt = DTYPE_Pointer \/ (exists fp, dt = DTYPE_FP fp).
+
+Definition vector_dtyp_base (dt : dtyp_base) : Prop :=
+  match dt with
+  | DTYPE_I _
+  | DTYPE_Iptr 
+  | DTYPE_Pointer 
+  | DTYPE_FP _
+  | DTYPE_B _ => True 
+  | _ => False
+  end.
+
+Lemma vector_dtyp_base_dec :
+  forall t,
+    {vector_dtyp_base t} + {~ vector_dtyp_base t}.
+Proof.
+  intros t.
+  destruct t; simpl; auto.
+Qed.
 
 
-
-Section DtypInd.
-  Variable P : dtyp -> Prop.
-  Hypothesis IH_I             : forall a, P (DTYPE_I a).
-  Hypothesis IH_Iptr          : P (DTYPE_Iptr).
-  Hypothesis IH_Pointer       : P DTYPE_Pointer.
-  Hypothesis IH_Void          : P DTYPE_Void.
-  Hypothesis IH_Float         : forall f, P (DTYPE_FP f).
-  Hypothesis IH_Label         : P DTYPE_Label.
-  Hypothesis IH_Token         : P DTYPE_Token.
-  Hypothesis IH_Metadata      : P DTYPE_Metadata.
-  Hypothesis IH_X86_mmx       : P DTYPE_X86_mmx.
-  Hypothesis IH_Array         : forall sz t, P t -> P (DTYPE_Array sz t).
-  Hypothesis IH_Struct        : forall (fields: list dtyp), (forall u, In u fields -> P u) -> P (DTYPE_Struct fields).
-  Hypothesis IH_Packed_Struct : forall (fields: list dtyp), (forall u, In u fields -> P u) -> P (DTYPE_Packed_struct fields).
-  Hypothesis IH_Opaque        : P DTYPE_Opaque.
-  Hypothesis IH_Vector        : forall sz t, P t -> P (DTYPE_Vector sz t).
-
-  Lemma dtyp_ind : forall (dt:dtyp), P dt.
-    fix IH 1.
-    remember P as P0 in IH.
-    destruct dt; auto; subst.
-    - apply IH_Array. auto.
-    - apply IH_Struct.
-      { revert fields.
-        fix IHfields 1. intros [|u fields']. intros. inversion H.
-        intros u' [<-|Hin]. apply IH. eapply IHfields. apply Hin.
-      }
-    - apply IH_Packed_Struct.
-      { revert fields.
-        fix IHfields 1. intros [|u fields']. intros. inversion H.
-        intros u' [<-|Hin]. apply IH. eapply IHfields. apply Hin.
-      }
-    - apply IH_Vector. auto.
-  Qed.
-End DtypInd.
-
-Section DtypRec.
-  Variable P : dtyp -> Set.
-  Hypothesis IH_I             : forall a, P (DTYPE_I a).
-  Hypothesis IH_Iptr          : P (DTYPE_Iptr).
-  Hypothesis IH_Pointer       : P DTYPE_Pointer.
-  Hypothesis IH_Void          : P DTYPE_Void.
-  Hypothesis IH_Float         : forall f, P (DTYPE_FP f).
-  Hypothesis IH_Label         : P DTYPE_Label.
-  Hypothesis IH_Token         : P DTYPE_Token.    
-  Hypothesis IH_Metadata      : P DTYPE_Metadata.
-  Hypothesis IH_X86_mmx       : P DTYPE_X86_mmx.
-  Hypothesis IH_Array         : forall sz t, P t -> P (DTYPE_Array sz t).
-  Hypothesis IH_Struct        : forall (fields: list dtyp), (forall u, In u fields -> P u) -> P (DTYPE_Struct fields).
-  Hypothesis IH_Packed_Struct : forall (fields: list dtyp), (forall u, In u fields -> P u) -> P (DTYPE_Packed_struct fields).
-  Hypothesis IH_Opaque        : P DTYPE_Opaque.
-  Hypothesis IH_Vector        : forall sz t, P t -> P (DTYPE_Vector sz t).
-
-  Lemma dtyp_rec : forall (dt:dtyp), P dt.
-    fix IH 1.
-    remember P as P0 in IH.
-    destruct dt; auto; subst.
-    - apply IH_Array. auto.
-    - apply IH_Struct.
-      { revert fields.
-        fix IHfields 1. intros [|u fields']. intros. inversion H.
-        intros u' Hin.
-        pose proof In_cons_dec dtyp_eq_dec Hin.
-        destruct H.
-        subst. apply IH.
-        eapply IHfields. apply i.
-      }
-    - apply IH_Packed_Struct.
-      { revert fields.
-        fix IHfields 1. intros [|u fields']. intros. inversion H.
-        intros u' Hin.
-        pose proof In_cons_dec dtyp_eq_dec Hin.
-        destruct H.
-        subst. apply IH.
-        eapply IHfields. apply i.
-      }
-    - apply IH_Vector. auto.
-  Qed.
-End DtypRec.
-
-
+(* SAZ: TODO - is this dead code? *)
+(*
 Section WF_dtyp.
 
   Inductive well_formed_dtyp : dtyp -> Prop :=
@@ -247,38 +231,15 @@ Section WF_dtyp.
   .
 
 End WF_dtyp.
-
-
-Lemma vector_dtyp_dec :
-  forall t,
-    {vector_dtyp t} + {~ vector_dtyp t}.
-Proof using.
-  intros t.
-  induction t;
-    try  solve
-      [ left; constructor; eauto
-      | left; firstorder
-      | right; intros CONTRA; red in CONTRA;
-        destruct CONTRA as [[n CONTRA] | [CONTRA | [CONTRA | [pf CONTRA]]]]; try discriminate].
-Qed.
+*)
 
 
 Fixpoint dtyp_measure (t : dtyp) : nat :=
   match t with
-  | DTYPE_I sz => 1
-  | DTYPE_Iptr => 1
-  | DTYPE_Pointer => 1
-  | DTYPE_Void => 1
-  | DTYPE_FP _ => 1
-  | DTYPE_Label => 1
-  | DTYPE_Token => 1
-  | DTYPE_Metadata => 1
-  | DTYPE_X86_mmx => 1
+  | DTYPE_Base t => 1
+  | DTYPE_Struct p fields => S (S (list_sum (map dtyp_measure fields)))
   | DTYPE_Array sz t => S (S (dtyp_measure t))
-  | DTYPE_Struct fields => S (S (list_sum (map dtyp_measure fields)))
-  | DTYPE_Packed_struct fields => S (S (list_sum (map dtyp_measure fields)))
-  | DTYPE_Opaque => 1
-  | DTYPE_Vector sz t => S (S (dtyp_measure t))
+  | DTYPE_Vector sz t => 1
   end.
 
 Lemma dtyp_measure_gt_0 :
@@ -296,137 +257,104 @@ Qed.
 apply N.eqb_eq.
 Qed.
 
-Fixpoint NO_VOID (dt : dtyp) : Prop
-  := match dt with
-     | DTYPE_I _
-     | DTYPE_Iptr
-     | DTYPE_Pointer
-     | DTYPE_FP _
-     | DTYPE_Label
-     | DTYPE_Token
-     | DTYPE_Metadata
-     | DTYPE_X86_mmx
-     | DTYPE_Opaque =>
-         True
-     | DTYPE_Void => False
-     | DTYPE_Vector sz t
-     | DTYPE_Array sz t =>
-         NO_VOID t
-     | DTYPE_Struct dts
-     | DTYPE_Packed_struct dts => FORALL NO_VOID dts
-     end.
+
+Definition NO_VOID_base (dt : dtyp_base) : Prop :=
+  match dt with
+  | DTYPE_Void => False    
+  | _ => True
+  end.
+                   
+Fixpoint NO_VOID (dt : dtyp) : Prop:=
+  match dt with
+  | DTYPE_Base dt => NO_VOID_base dt
+  | DTYPE_Struct p dts => FORALL NO_VOID dts
+  | DTYPE_Array sz t => NO_VOID t
+  | DTYPE_Vector sz t => NO_VOID_base t
+  end.  
+
 
 Lemma NO_VOID_Struct_fields :
-  forall dts,
-    NO_VOID (DTYPE_Struct dts) ->
+  forall p dts,
+    NO_VOID (DTYPE_Struct p dts) ->
     (forall dt, In dt dts -> NO_VOID dt).
 Proof using.
-  intros dts NV dt IN.
+  intros p dts NV dt IN.
   cbn in NV.
   rewrite FORALL_forall in NV.
   rewrite Forall_forall in NV.
   apply NV; auto.
 Qed.
 
-Lemma NO_VOID_Packed_struct_fields :
-  forall dts,
-    NO_VOID (DTYPE_Packed_struct dts) ->
-    (forall dt, In dt dts -> NO_VOID dt).
-Proof using.
-  intros dts NV dt IN.
-  cbn in NV.
-  rewrite FORALL_forall in NV.
-  rewrite Forall_forall in NV.
-  apply NV; auto.
-Qed.
 
-Lemma NO_VOID_Struct_cons :
-  forall dt dts,
-    NO_VOID (DTYPE_Struct (dt :: dts)) ->
-    NO_VOID (DTYPE_Struct dts).
+Lemma NO_VOID_base_dec :
+  forall dt,
+    {NO_VOID_base dt} + {~NO_VOID_base dt}.
 Proof using.
-  intros dt dts H.
-  cbn in *.
-  intuition.
-Qed.
+  destruct dt; simpl; auto.
+Qed.  
   
-Lemma NO_VOID_Packed_struct_cons :
-  forall dt dts,
-    NO_VOID (DTYPE_Packed_struct (dt :: dts)) ->
-    NO_VOID (DTYPE_Packed_struct dts).
-Proof using.
-  intros dt dts H.
-  cbn in *.
-  intuition.
-Qed.
-
 Lemma NO_VOID_dec :
   forall dt,
     {NO_VOID dt} + {~NO_VOID dt}.
 Proof using.
   intros dt.
-  induction dt.
-  all:
-    try match goal with
-      | NV : {NO_VOID _} + {~ NO_VOID _} |- _ =>
-          destruct NV
-      end;
-    try rewrite NO_VOID_equation;
-    try solve [left; cbn; auto | right; cbn; auto].
-
-  all: cbn; apply FORALL_dec; assumption.  
+  induction dt; simpl.
+  - apply NO_VOID_base_dec.
+  - apply FORALL_dec; assumption.
+  - assumption.
+  - apply NO_VOID_base_dec.
 Qed.
 
-Lemma NO_VOID_neq_dtyp :
-  forall dt1 dt2,
-    NO_VOID dt1 ->
-    ~ NO_VOID dt2 ->
-    dt1 <> dt2.
-Proof using.
-  intros dt1 dt2 NV NNV.
-  intros EQ.
-  induction dt1, dt2; inversion EQ.
-  all: cbn in NNV; try contradiction.
+(* Lemma NO_VOID_neq_dtyp : *)
+(*   forall dt1 dt2, *)
+(*     NO_VOID dt1 -> *)
+(*     ~ NO_VOID dt2 -> *)
+(*     dt1 <> dt2. *)
+(* Proof using. *)
+(*   intros dt1 dt2 NV NNV. *)
+(*   intros EQ. *)
+(*   induction dt1, dt2; inversion EQ. *)
+(*   all: cbn in NNV; try contradiction. *)
 
-  all: inversion EQ; subst;
-    cbn in NV;
-    contradiction.
-Qed.
+(*   all: inversion EQ; subst; *)
+(*     cbn in NV; *)
+(*     contradiction. *)
+(* Qed. *)
 
-Lemma NO_VOID_Struct_cons_inv :
-  forall dt dts,
-    NO_VOID dt ->
-    NO_VOID (DTYPE_Struct dts) ->
-    NO_VOID (DTYPE_Struct (dt :: dts)).
-Proof using.
-  intros dt dts NVdt NVdts.
-  cbn in *.
-  intuition.
-Qed.
+(* Lemma NO_VOID_Struct_cons_inv : *)
+(*   forall dt dts, *)
+(*     NO_VOID dt -> *)
+(*     NO_VOID (DTYPE_Struct dts) -> *)
+(*     NO_VOID (DTYPE_Struct (dt :: dts)). *)
+(* Proof using. *)
+(*   intros dt dts NVdt NVdts. *)
+(*   cbn in *. *)
+(*   intuition. *)
+(* Qed. *)
 
-Lemma NO_VOID_Packed_struct_cons_inv :
-  forall dt dts,
-    NO_VOID dt ->
-    NO_VOID (DTYPE_Packed_struct dts) ->
-    NO_VOID (DTYPE_Packed_struct (dt :: dts)).
-Proof using.
-  intros dt dts NVdt NVdts.
-  cbn in *.
-  intuition.
-Qed.
+(* Lemma NO_VOID_Packed_struct_cons_inv : *)
+(*   forall dt dts, *)
+(*     NO_VOID dt -> *)
+(*     NO_VOID (DTYPE_Packed_struct dts) -> *)
+(*     NO_VOID (DTYPE_Packed_struct (dt :: dts)). *)
+(* Proof using. *)
+(*   intros dt dts NVdt NVdts. *)
+(*   cbn in *. *)
+(*   intuition. *)
+(* Qed. *)
 
-Ltac solve_Forall_HIn :=
-  solve [ constructor; auto].
+(* Ltac solve_Forall_HIn := *)
+(*   solve [ constructor; auto]. *)
 
-#[global] Hint Resolve NO_VOID_Struct_cons_inv : NO_VOID.
-#[global] Hint Resolve NO_VOID_Packed_struct_cons_inv : NO_VOID.
+(* #[global] Hint Resolve NO_VOID_Struct_cons_inv : NO_VOID. *)
+(* #[global] Hint Resolve NO_VOID_Packed_struct_cons_inv : NO_VOID. *)
 
-Ltac solve_no_void :=
-  solve
-    [ auto with NO_VOID
-    | match goal with
-      | H: NO_VOID _ /\ _ |- _
-        => destruct H; solve_no_void
-      end
-    | cbn; solve_no_void
-    ].
+(* Ltac solve_no_void := *)
+(*   solve *)
+(*     [ auto with NO_VOID *)
+(*     | match goal with *)
+(*       | H: NO_VOID _ /\ _ |- _ *)
+(*         => destruct H; solve_no_void *)
+(*       end *)
+(*     | cbn; solve_no_void *)
+(*     ]. *)

--- a/src/rocq/Syntax/DynamicTypes.v
+++ b/src/rocq/Syntax/DynamicTypes.v
@@ -43,8 +43,7 @@ Variant dtyp_base : Set :=
 Inductive dtyp : Set :=
 | DTYPE_Base (dt:dtyp_base)
 | DTYPE_Struct (packed:bool) (fields:list dtyp)
-| DTYPE_Array (sz:N) (t:dtyp)
-| DTYPE_Vector (sz:N) (t:dtyp_base)
+| DTYPE_Array (vector:bool) (sz:N) (t:dtyp)
 .
 Set Elimination Schemes.
 
@@ -72,28 +71,24 @@ Proof.
             match t1, t2 with
             | DTYPE_Base t1, DTYPE_Base t2 => _
             | DTYPE_Struct p l, DTYPE_Struct p' l' => _
-            | DTYPE_Array n t, DTYPE_Array n' t' => _
-            | DTYPE_Vector n t, DTYPE_Vector n' t' => _                                                     
+            | DTYPE_Array v n t, DTYPE_Array v' n' t' => _
             | _, _ => _
             end); try (ltac:(dec_dtyp); fail).
   - destruct (dtyp_base_eq_dec t1 t2).
-    * left; subst; reflexivity.
-    * right; intros H; inversion H. contradiction.
-  - destruct (lsteq_dec l l').
-    * destruct (bool_dec p p').
-      -- left; subst; reflexivity.
-      -- right; intros H; inversion H. contradiction.
-    * right; intros H; inversion H. contradiction.
-  - destruct (N.eq_dec n n').
-    * destruct (f t t').
-      --  left; subst; reflexivity.
-      -- right; intros H; inversion H. contradiction.
-    * right; intros H; inversion H. contradiction.
-  - destruct (N.eq_dec n n').
-    * destruct (dtyp_base_eq_dec t t').
-      -- left; subst; reflexivity.
-      -- right; intros H; inversion H. contradiction.
-    * right; intros H; inversion H. contradiction.         
+    + left; subst; reflexivity.
+    + right; intros H; inversion H. contradiction.
+  - destruct (bool_dec p p').
+      + destruct (lsteq_dec l l').
+       * left; subst; reflexivity.
+       * right; intros H; inversion H. contradiction.
+      + right; intros H; inversion H. contradiction.
+  - destruct (bool_dec v v').
+    + destruct (N.eq_dec n n').
+      * destruct (f t t').
+        --  left; subst; reflexivity.
+        -- right; intros H; inversion H. contradiction.
+      * right; intros H; inversion H. contradiction.
+    + right; intros H; inversion H. contradiction.
 Defined.
 Arguments dtyp_eq_dec: clear implicits.
 
@@ -101,9 +96,7 @@ Section DtypInd.
   Variable P : dtyp -> Prop.
   Hypothesis IH_Base   : forall t, P (DTYPE_Base t).
   Hypothesis IH_Struct : forall (p:bool) (fields: list dtyp), (forall u, In u fields -> P u) -> P (DTYPE_Struct p fields).
-  Hypothesis IH_Array  : forall sz (t: dtyp), (P t) -> P (DTYPE_Array sz t).  
-  Hypothesis IH_Vector    : forall sz t, P (DTYPE_Vector sz t).
-
+  Hypothesis IH_Array  : forall (v:bool) sz (t: dtyp), (P t) -> P (DTYPE_Array v sz t).  
   Lemma dtyp_ind : forall (dt:dtyp), P dt.
     fix IH 1.
     remember P as P0 in IH.
@@ -121,9 +114,7 @@ Section DtypRec.
   Variable P : dtyp -> Set.
   Hypothesis IH_Base   : forall t, P (DTYPE_Base t).
   Hypothesis IH_Struct : forall (p:bool) (fields: list dtyp), (forall u, In u fields -> P u) -> P (DTYPE_Struct p fields).
-  Hypothesis IH_Array  : forall sz (t: dtyp), (P t) -> P (DTYPE_Array sz t).  
-  Hypothesis IH_Vector    : forall sz t, P (DTYPE_Vector sz t).
-
+  Hypothesis IH_Array  : forall (v:bool) sz (t: dtyp), (P t) -> P (DTYPE_Array v sz t).  
   Lemma dtyp_rec : forall (dt:dtyp), P dt.
     fix IH 1.
     remember P as P0 in IH.
@@ -139,7 +130,6 @@ Section DtypRec.
       }
     - apply IH_Array. auto.
   Qed.
-
 End DtypRec.
 
 Definition dtyp_base_eqb (dt1 dt2 : dtyp_base) : bool :=
@@ -173,7 +163,6 @@ Proof using.
   unfold dtyp_eqb in TYPE.
   destruct (dtyp_eq_dec t1 t2); auto; discriminate.
 Qed.
-
 
 Definition vector_dtyp_base (dt : dtyp_base) : Prop :=
   match dt with
@@ -240,8 +229,7 @@ Fixpoint dtyp_measure (t : dtyp) : nat :=
   match t with
   | DTYPE_Base t => 1
   | DTYPE_Struct p fields => S (S (list_sum (map dtyp_measure fields)))
-  | DTYPE_Array sz t => S (S (dtyp_measure t))
-  | DTYPE_Vector sz t => 1
+  | DTYPE_Array v sz t => S (S (dtyp_measure t))
   end.
 
 Lemma dtyp_measure_gt_0 :
@@ -270,8 +258,7 @@ Fixpoint NO_VOID (dt : dtyp) : Prop:=
   match dt with
   | DTYPE_Base dt => NO_VOID_base dt
   | DTYPE_Struct p dts => FORALL NO_VOID dts
-  | DTYPE_Array sz t => NO_VOID t
-  | DTYPE_Vector sz t => NO_VOID_base t
+  | DTYPE_Array v sz t => NO_VOID t
   end.  
 
 
@@ -304,7 +291,6 @@ Proof using.
   - apply NO_VOID_base_dec.
   - apply FORALL_dec; assumption.
   - assumption.
-  - apply NO_VOID_base_dec.
 Qed.
 
 (* Lemma NO_VOID_neq_dtyp : *)

--- a/src/rocq/Syntax/DynamicTypes.v
+++ b/src/rocq/Syntax/DynamicTypes.v
@@ -48,6 +48,8 @@ Inductive dtyp : Set :=
 .
 Set Elimination Schemes.
 
+(*  NOTE: to cut down on clutter, we coerce dtyp_base to dtyp *)
+Coercion DTYPE_Base : dtyp_base >-> dtyp.
 
 Lemma dtyp_base_eq_dec : forall (t1 t2 : dtyp_base), {t1 = t2} + {t1 <> t2}.
 Proof.

--- a/src/rocq/Syntax/ReprAST.v
+++ b/src/rocq/Syntax/ReprAST.v
@@ -132,8 +132,7 @@ Section ReprInstances.
     match t with
     | DTYPE_Base t => "(DTYPE_Base (" ++ repr t ++ "))"
     | DTYPE_Struct p fields => "(DTYPE_Struct " ++ repr p ++ " [" ++ (contents id (List.map repr_dtyp fields)) ++ "])"
-    | DTYPE_Array sz t => "(DTYPE_Array (" ++ repr sz ++ ") (" ++ repr_dtyp t ++ "))"
-    | DTYPE_Vector sz t => "(DTYPE_Vector (" ++ repr sz ++ ") (" ++ repr_dtyp_base t ++ "))"
+    | DTYPE_Array v sz t => "(DTYPE_Array " ++ repr v ++ " (" ++ repr sz ++ ") (" ++ repr_dtyp t ++ "))"
     end.
 
   Fixpoint repr_typ (t : typ) : string :=

--- a/src/rocq/Syntax/ReprAST.v
+++ b/src/rocq/Syntax/ReprAST.v
@@ -108,8 +108,8 @@ Section ReprInstances.
   #[global]
   Instance repr_floating_point_variant : Repr floating_point_variant
    := {| repr := repr_fp_variant |}.                                              
-  
-  Fixpoint repr_dtyp (t : dtyp) : string :=
+
+  Definition repr_dtyp_base (t : dtyp_base) : string :=
     match t with
     | DTYPE_I sz => "(DTYPE_I " ++ repr sz ++ ")"
     | DTYPE_Iptr => "DTYPE_Iptr"
@@ -120,11 +120,20 @@ Section ReprInstances.
     | DTYPE_Token => "DTYPE_Token"
     | DTYPE_Metadata => "DTYPE_Metadata"
     | DTYPE_X86_mmx => "DTYPE_X86_mmx"
-    | DTYPE_Array sz t => "(DTYPE_Array (" ++ repr sz ++ ") (" ++ repr_dtyp t ++ "))"
-    | DTYPE_Struct fields => "(DTYPE_Struct [" ++ (contents id (List.map repr_dtyp fields)) ++ "])"
-    | DTYPE_Packed_struct fields => "(DTYPE_Packed_struct [" ++ (contents id (List.map repr_dtyp fields)) ++ "])"
     | DTYPE_Opaque => "DTYPE_Opaque"
-    | DTYPE_Vector sz t => "(DTYPE_Vector (" ++ repr sz ++ ") (" ++ repr_dtyp t ++ "))"
+    | DTYPE_B sz => "(DTYPE_B " ++ repr sz ++ ")"
+    end.
+
+  #[global]
+  Instance repr_dtyp_base_Repr : Repr dtyp_base :=
+    {| repr := repr_dtyp_base |}.
+  
+  Fixpoint repr_dtyp (t : dtyp) : string :=
+    match t with
+    | DTYPE_Base t => "(DTYPE_Base (" ++ repr t ++ "))"
+    | DTYPE_Struct p fields => "(DTYPE_Struct " ++ repr p ++ " [" ++ (contents id (List.map repr_dtyp fields)) ++ "])"
+    | DTYPE_Array sz t => "(DTYPE_Array (" ++ repr sz ++ ") (" ++ repr_dtyp t ++ "))"
+    | DTYPE_Vector sz t => "(DTYPE_Vector (" ++ repr sz ++ ") (" ++ repr_dtyp_base t ++ "))"
     end.
 
   Fixpoint repr_typ (t : typ) : string :=

--- a/src/rocq/Syntax/ShowAST.v
+++ b/src/rocq/Syntax/ShowAST.v
@@ -225,8 +225,8 @@ Section ShowInstances.
           "<{" ++ (String.concat ", " (map show_dtyp fields)) ++ "}>"
         else
           "{" ++ (String.concat ", " (map show_dtyp fields)) ++ "}"
-    | DTYPE_Array sz t           => "[" ++ (show sz) ++ " x " ++ show_dtyp t ++ "]"
-    | DTYPE_Vector sz t          => "<" ++ (show sz) ++ " x " ++ show_dtyp_base t ++ ">"
+    | DTYPE_Array false sz t           => "[" ++ (show sz) ++ " x " ++ show_dtyp t ++ "]"
+    | DTYPE_Array true sz t          => "<" ++ (show sz) ++ " x " ++ show_dtyp t ++ ">"
     end.
 
   #[global] Instance dshowDTyp : Show dtyp :=

--- a/src/rocq/Syntax/ShowAST.v
+++ b/src/rocq/Syntax/ShowAST.v
@@ -202,7 +202,7 @@ Section ShowInstances.
   #[global] Instance dshowTyp : DShow typ :=
     {| dshow := dshow_typ |}.
 
-  Fixpoint show_dtyp (t : dtyp) : string :=
+  Definition show_dtyp_base (t : dtyp_base) : string :=
     match t with
     | DTYPE_I sz                 => "i" ++ (show sz)
     | DTYPE_Iptr                 => "iptr"
@@ -213,11 +213,20 @@ Section ShowInstances.
     | DTYPE_Token                => "token"
     | DTYPE_Metadata             => "metadata"
     | DTYPE_X86_mmx              => "X86_mmx"
-    | DTYPE_Array sz t           => "[" ++ (show sz) ++ " x " ++ show_dtyp t ++ "]"
-    | DTYPE_Struct fields        => "{" ++ (String.concat ", " (map show_dtyp fields)) ++ "}"
-    | DTYPE_Packed_struct fields => "<{" ++ (String.concat ", " (map show_dtyp fields)) ++ "}>"
     | DTYPE_Opaque               => "Opaque"
-    | DTYPE_Vector sz t          => "<" ++ (show sz) ++ " x " ++ show_dtyp t ++ ">"
+    | DTYPE_B sz                 => "b" ++ (show sz)
+    end.
+  
+  Fixpoint show_dtyp (t : dtyp) : string :=
+    match t with
+    | DTYPE_Base t => show_dtyp_base t
+    | DTYPE_Struct p fields  =>
+        if p then
+          "<{" ++ (String.concat ", " (map show_dtyp fields)) ++ "}>"
+        else
+          "{" ++ (String.concat ", " (map show_dtyp fields)) ++ "}"
+    | DTYPE_Array sz t           => "[" ++ (show sz) ++ " x " ++ show_dtyp t ++ "]"
+    | DTYPE_Vector sz t          => "<" ++ (show sz) ++ " x " ++ show_dtyp_base t ++ ">"
     end.
 
   #[global] Instance dshowDTyp : Show dtyp :=

--- a/src/rocq/Syntax/SurfaceSyntax.v
+++ b/src/rocq/Syntax/SurfaceSyntax.v
@@ -228,19 +228,19 @@ Module VIR_Notations.
 
   (** Array, vector. LLVM IR uses [[N x T]] for arrays and [<N x T>]
       for vectors. *)
-  Notation "'[' sz 'x' t ']'" := (TYPE_Array sz t)
+  Notation "'[' sz 'x' t ']'" := (TYPE_Array false sz t)
     (in custom vir_typ at level 5,
      sz constr at level 0, t custom vir_typ at level 99,
      only printing).
-  Notation "'[' sz 'x' t ']'" := (DTYPE_Array sz t)
+  Notation "'[' sz 'x' t ']'" := (DTYPE_Array false sz t)
     (in custom vir_typ at level 5,
      sz constr at level 0, t custom vir_typ at level 99,
      only printing).
-  Notation "'<' sz 'x' t '>'" := (TYPE_Vector sz t)
+  Notation "'<' sz 'x' t '>'" := (TYPE_Array true sz t)
     (in custom vir_typ at level 5,
      sz constr at level 0, t custom vir_typ at level 99,
      only printing).
-  Notation "'<' sz 'x' t '>'" := (DTYPE_Vector sz t)
+  Notation "'<' sz 'x' t '>'" := (DTYPE_Array true sz t)
     (in custom vir_typ at level 5,
      sz constr at level 0, t custom vir_typ at level 99,
      only printing).

--- a/src/rocq/Syntax/SurfaceSyntax.v
+++ b/src/rocq/Syntax/SurfaceSyntax.v
@@ -252,23 +252,23 @@ Module VIR_Notations.
     (in custom vir_typ at level 5, only printing).
   Notation "'{|' '|}'" := (DTYPE_Struct nil)
     (in custom vir_typ at level 5, only printing).
-  Notation "'{|' fields '|}'" := (TYPE_Struct fields)
+  Notation "'{|' fields '|}'" := (TYPE_Struct false fields)
     (in custom vir_typ at level 5,
      fields custom vir_typ_list at level 99,
      only printing).
-  Notation "'{|' fields '|}'" := (DTYPE_Struct fields)
+  Notation "'{|' fields '|}'" := (DTYPE_Struct false fields)
     (in custom vir_typ at level 5,
      fields custom vir_typ_list at level 99,
      only printing).
   Notation "'<{' '}>'" := (TYPE_Packed_struct nil)
     (in custom vir_typ at level 5, only printing).
-  Notation "'<{' '}>'" := (DTYPE_Packed_struct nil)
+  Notation "'<{' '}>'" := (DTYPE_Struct true nil)
     (in custom vir_typ at level 5, only printing).
   Notation "'<{' fields '}>'" := (TYPE_Packed_struct fields)
     (in custom vir_typ at level 5,
      fields custom vir_typ_list at level 99,
      only printing).
-  Notation "'<{' fields '}>'" := (DTYPE_Packed_struct fields)
+  Notation "'<{' fields '}>'" := (DTYPE_Struct true fields)
     (in custom vir_typ at level 5,
      fields custom vir_typ_list at level 99,
      only printing).

--- a/src/rocq/Syntax/TypToDtyp.v
+++ b/src/rocq/Syntax/TypToDtyp.v
@@ -90,44 +90,117 @@ Qed.
 #[export] Hint Resolve wf_lt_typ_order : core.
 #[export] Hint Constructors lex_ord : core.
 
-Program Fixpoint typ_to_dtyp (env : list (ident * typ)) (t : typ) {measure (List.length env, t) (lex_ord lt typ_order)} : dtyp :=
+Program Fixpoint typ_to_dtyp_base_option (env : list (ident * typ)) (t : typ) {measure (List.length env) lt} : option dtyp_base :=
   match t with
-  | TYPE_Array sz t =>
-    let nt := typ_to_dtyp env t in
-    DTYPE_Array sz nt
-
-  | TYPE_Function ret args varargs =>
-    DTYPE_Pointer
-
-  | TYPE_Struct fields =>
-    let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
-    DTYPE_Struct nfields
-
-  | TYPE_Packed_struct fields =>
-    let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
-    DTYPE_Packed_struct nfields
-
-  | TYPE_Vector sz t =>
-    let nt := typ_to_dtyp env t in
-    DTYPE_Vector sz nt
-
+  | TYPE_Function ret args varargs => Some DTYPE_Pointer
   | TYPE_Identified id =>
     let opt := find (fun a => Ident.eq_dec id (fst a)) env in
     match opt with
-    | None => DTYPE_Void   (* TODO: should this be None? *)
-    | Some (_, t) => typ_to_dtyp (remove_key Ident.eq_dec id env) t
+    | None => None
+    | Some (_, t) => typ_to_dtyp_base_option (remove_key Ident.eq_dec id env) t
     end
+  | TYPE_I sz => Some (DTYPE_I sz)
+  | TYPE_Iptr => Some (DTYPE_Iptr)
+  | TYPE_Pointer t' => Some DTYPE_Pointer
+  | TYPE_Label => Some DTYPE_Label
+  | TYPE_Token => Some DTYPE_Token
+  | TYPE_Void => Some DTYPE_Void
+  | TYPE_FP fp => Some (DTYPE_FP fp)
+  | TYPE_Metadata => Some DTYPE_Metadata
+  | TYPE_X86_mmx => Some DTYPE_X86_mmx
+  | TYPE_Opaque => Some DTYPE_Opaque
+  | TYPE_Array _ _ => None
+  | TYPE_Struct _ => None
+  | TYPE_Vector _ _ => None
+  | TYPE_Packed_struct _ => None
+  end.
+Next Obligation.
+  symmetry in Heq_opt. apply find_some in Heq_opt. destruct Heq_opt as [Hin Heqb_ident].
+  simpl in Heqb_ident.
+  destruct (Ident.eq_dec id wildcard'). subst. eapply remove_key_in. apply Hin.
+  inversion Heqb_ident.
+Defined.
 
-  | TYPE_I sz => DTYPE_I sz
-  | TYPE_Iptr => DTYPE_Iptr
-  | TYPE_Pointer t' => DTYPE_Pointer
-  | TYPE_Label => DTYPE_Label
-  | TYPE_Token => DTYPE_Token
-  | TYPE_Void => DTYPE_Void
-  | TYPE_FP fp => DTYPE_FP fp
-  | TYPE_Metadata => DTYPE_Metadata
-  | TYPE_X86_mmx => DTYPE_X86_mmx
-  | TYPE_Opaque => DTYPE_Opaque
+Lemma typ_to_dtyp_base_option_equation  : forall env t,
+  typ_to_dtyp_base_option env t =
+  match t with
+  | TYPE_Function ret args varargs => Some DTYPE_Pointer
+  | TYPE_Identified id =>
+    let opt := find (fun a => Ident.eq_dec id (fst a)) env in
+    match opt with
+    | None => None
+    | Some (_, t) => typ_to_dtyp_base_option (remove_key Ident.eq_dec id env) t
+    end
+  | TYPE_I sz => Some (DTYPE_I sz)
+  | TYPE_Iptr => Some (DTYPE_Iptr)
+  | TYPE_Pointer t' => Some DTYPE_Pointer
+  | TYPE_Label => Some DTYPE_Label
+  | TYPE_Token => Some DTYPE_Token
+  | TYPE_Void => Some DTYPE_Void
+  | TYPE_FP fp => Some (DTYPE_FP fp)
+  | TYPE_Metadata => Some DTYPE_Metadata
+  | TYPE_X86_mmx => Some DTYPE_X86_mmx
+  | TYPE_Opaque => Some DTYPE_Opaque
+  | TYPE_Array _ _ => None
+  | TYPE_Struct _ => None
+  | TYPE_Vector _ _ => None
+  | TYPE_Packed_struct _ => None
+  end.
+Proof using.
+  intros env t.
+  unfold typ_to_dtyp_base_option.
+  unfold typ_to_dtyp_base_option_func at 1.
+  rewrite WfExtensionality.WfExtensionality.fix_sub_eq_ext. simpl.
+  destruct t; try reflexivity; simpl.
+  destruct (find (fun a : ident * typ => Ident.eq_dec id (fst a)) env).
+  destruct p; simpl; eauto.
+  reflexivity.
+Defined.
+
+Program Fixpoint typ_to_dtyp (env : list (ident * typ)) (t : typ) {measure (List.length env, t) (lex_ord lt typ_order)} : dtyp :=
+  match typ_to_dtyp_base_option env t with
+  | Some dt => DTYPE_Base dt
+  | None =>
+      match t with
+      | TYPE_Array sz t =>
+          let nt := typ_to_dtyp env t in
+          DTYPE_Array sz nt
+
+      | TYPE_Struct fields =>
+          let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
+          DTYPE_Struct false nfields
+
+      | TYPE_Packed_struct fields =>
+          let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
+          DTYPE_Struct true nfields
+
+      | TYPE_Vector sz t =>
+          match typ_to_dtyp_base_option env t with
+          | Some dt =>
+              if (vector_dtyp_base_dec dt)
+              then DTYPE_Vector sz dt
+              else DTYPE_Base DTYPE_Void
+          | None => DTYPE_Base DTYPE_Void
+          end
+      | TYPE_Identified id =>
+          let opt := find (fun a => Ident.eq_dec id (fst a)) env in
+          match opt with
+          | None => DTYPE_Base DTYPE_Void   (* TODO: should this be None? *)
+          | Some (_, t) => typ_to_dtyp (remove_key Ident.eq_dec id env) t
+          end
+      (* These cases cannot happen *)
+      | TYPE_Function ret args varargs => DTYPE_Base DTYPE_Void
+      | TYPE_I sz => DTYPE_Base DTYPE_Void
+      | TYPE_Iptr => DTYPE_Base DTYPE_Void
+      | TYPE_Pointer t' => DTYPE_Base DTYPE_Void
+      | TYPE_Label => DTYPE_Base DTYPE_Void
+      | TYPE_Token => DTYPE_Base DTYPE_Void
+      | TYPE_Void => DTYPE_Base DTYPE_Void
+      | TYPE_FP fp => DTYPE_Base DTYPE_Void
+      | TYPE_Metadata => DTYPE_Base DTYPE_Void
+      | TYPE_X86_mmx => DTYPE_Base DTYPE_Void
+      | TYPE_Opaque => DTYPE_Base DTYPE_Void
+      end
   end.
 Next Obligation.
   left.
@@ -139,69 +212,80 @@ Defined.
 
 Lemma typ_to_dtyp_equation  : forall env t,
     typ_to_dtyp env t =
-    match t with
-    | TYPE_Array sz t =>
-      let nt := typ_to_dtyp env t in
-      DTYPE_Array sz nt
+  match typ_to_dtyp_base_option env t with
+  | Some dt => DTYPE_Base dt
+  | None =>
+      match t with
+      | TYPE_Array sz t =>
+          let nt := typ_to_dtyp env t in
+          DTYPE_Array sz nt
 
-    | TYPE_Function ret args varargs =>
-      DTYPE_Pointer (* Function nret nargs *)
+      | TYPE_Struct fields =>
+          let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
+          DTYPE_Struct false nfields
 
-    | TYPE_Struct fields =>
-      let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
-      DTYPE_Struct nfields
+      | TYPE_Packed_struct fields =>
+          let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
+          DTYPE_Struct true nfields
 
-    | TYPE_Packed_struct fields =>
-      let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
-      DTYPE_Packed_struct nfields
-
-    | TYPE_Vector sz t =>
-      let nt := typ_to_dtyp env t in
-      DTYPE_Vector sz nt
-
-    | TYPE_Identified id =>
-      let opt := find (fun a => Ident.eq_dec id (fst a)) env in
-      match opt with
-      | None => DTYPE_Void   (* TODO: should this be None? *)
-      | Some (_, t) => typ_to_dtyp (remove_key Ident.eq_dec id env) t
+      | TYPE_Vector sz t =>
+          match typ_to_dtyp_base_option env t with
+          | Some dt =>
+              if (vector_dtyp_base_dec dt)
+              then DTYPE_Vector sz dt
+              else DTYPE_Base DTYPE_Void
+          | None => DTYPE_Base DTYPE_Void
+          end
+      | TYPE_Identified id =>
+          let opt := find (fun a => Ident.eq_dec id (fst a)) env in
+          match opt with
+          | None => DTYPE_Base DTYPE_Void   (* TODO: should this be None? *)
+          | Some (_, t) => typ_to_dtyp (remove_key Ident.eq_dec id env) t
+          end
+      (* These cases cannot happen *)
+      | TYPE_Function ret args varargs => DTYPE_Base DTYPE_Void
+      | TYPE_I sz => DTYPE_Base DTYPE_Void
+      | TYPE_Iptr => DTYPE_Base DTYPE_Void
+      | TYPE_Pointer t' => DTYPE_Base DTYPE_Void
+      | TYPE_Label => DTYPE_Base DTYPE_Void
+      | TYPE_Token => DTYPE_Base DTYPE_Void
+      | TYPE_Void => DTYPE_Base DTYPE_Void
+      | TYPE_FP fp => DTYPE_Base DTYPE_Void
+      | TYPE_Metadata => DTYPE_Base DTYPE_Void
+      | TYPE_X86_mmx => DTYPE_Base DTYPE_Void
+      | TYPE_Opaque => DTYPE_Base DTYPE_Void
       end
-
-    | TYPE_I sz => DTYPE_I sz
-    | TYPE_Iptr => DTYPE_Iptr
-    | TYPE_Pointer t' => DTYPE_Pointer
-    | TYPE_Void => DTYPE_Void
-    | TYPE_FP f => DTYPE_FP f
-    | TYPE_Label => DTYPE_Label
-    | TYPE_Token => DTYPE_Token
-    | TYPE_Metadata => DTYPE_Metadata
-    | TYPE_X86_mmx => DTYPE_X86_mmx
-    | TYPE_Opaque => DTYPE_Opaque
-    end.
+  end.
 Proof using.
   intros env t.
   unfold typ_to_dtyp.
   unfold typ_to_dtyp_func at 1.
-  rewrite WfExtensionality.WfExtensionality.fix_sub_eq_ext.
-  destruct t; try reflexivity. simpl.
-  destruct (find (fun a : ident * typ => Ident.eq_dec id (fst a)) env).
-  destruct p; simpl; eauto.
+  rewrite WfExtensionality.WfExtensionality.fix_sub_eq_ext. simpl.
+  destruct t; try reflexivity; simpl.
+  - destruct (typ_to_dtyp_base_option env t); reflexivity.
+  - destruct (typ_to_dtyp_base_option env (TYPE_Identified id)); simpl.
+    + reflexivity.
+    + destruct (find (fun a : ident * typ => Ident.eq_dec id (fst a)) env).
+      destruct p; simpl; eauto.
   reflexivity.
 Defined.
 
 (* Specialized version of the characteristic equation for contexts where we don't want to compute *)
-Lemma typ_to_dtyp_I : forall s i, typ_to_dtyp s (TYPE_I i) = DTYPE_I i.
+(* SAZ: Not sure where these are needed. *)
+(*
+Lemma typ_to_dtyp_I : forall s i, typ_to_dtyp s (TYPE_I i) = DTYPE_Base (DTYPE_I i).
 Proof using.
   intros; rewrite typ_to_dtyp_equation; reflexivity.
 Qed.
 
-Lemma typ_to_dtyp_D : forall s fp, typ_to_dtyp s (TYPE_FP fp) = DTYPE_FP fp.
+Lemma typ_to_dtyp_D : forall s fp, typ_to_dtyp s (TYPE_FP fp) = (DTYPE_Base (DTYPE_FP fp)).
 Proof using.
   intros; rewrite typ_to_dtyp_equation; reflexivity.
 Qed.
 
 Lemma typ_to_dtyp_P :
   forall t s,
-    typ_to_dtyp s (TYPE_Pointer t) = DTYPE_Pointer.
+    typ_to_dtyp s (TYPE_Pointer t) = (DTYPE_Base DTYPE_Pointer).
 Proof using.
   intros t s.
   apply typ_to_dtyp_equation.
@@ -214,6 +298,7 @@ Proof using.
   rewrite typ_to_dtyp_D.
   reflexivity.
 Qed.
+*)
 
 (** ** Conversion of syntactic components
 

--- a/src/rocq/Syntax/TypToDtyp.v
+++ b/src/rocq/Syntax/TypToDtyp.v
@@ -159,7 +159,7 @@ Defined.
 
 Program Fixpoint typ_to_dtyp (env : list (ident * typ)) (t : typ) {measure (List.length env, t) (lex_ord lt typ_order)} : dtyp :=
   match typ_to_dtyp_base_option env t with
-  | Some dt => DTYPE_Base dt
+  | Some dt => dt
   | None =>
       match t with
       | TYPE_Array sz t =>
@@ -179,27 +179,27 @@ Program Fixpoint typ_to_dtyp (env : list (ident * typ)) (t : typ) {measure (List
           | Some dt =>
               if (vector_dtyp_base_dec dt)
               then DTYPE_Vector sz dt
-              else DTYPE_Base DTYPE_Void
-          | None => DTYPE_Base DTYPE_Void
+              else  DTYPE_Void
+          | None =>  DTYPE_Void
           end
       | TYPE_Identified id =>
           let opt := find (fun a => Ident.eq_dec id (fst a)) env in
           match opt with
-          | None => DTYPE_Base DTYPE_Void   (* TODO: should this be None? *)
+          | None =>  DTYPE_Void   (* TODO: should this be None? *)
           | Some (_, t) => typ_to_dtyp (remove_key Ident.eq_dec id env) t
           end
       (* These cases cannot happen *)
-      | TYPE_Function ret args varargs => DTYPE_Base DTYPE_Void
-      | TYPE_I sz => DTYPE_Base DTYPE_Void
-      | TYPE_Iptr => DTYPE_Base DTYPE_Void
-      | TYPE_Pointer t' => DTYPE_Base DTYPE_Void
-      | TYPE_Label => DTYPE_Base DTYPE_Void
-      | TYPE_Token => DTYPE_Base DTYPE_Void
-      | TYPE_Void => DTYPE_Base DTYPE_Void
-      | TYPE_FP fp => DTYPE_Base DTYPE_Void
-      | TYPE_Metadata => DTYPE_Base DTYPE_Void
-      | TYPE_X86_mmx => DTYPE_Base DTYPE_Void
-      | TYPE_Opaque => DTYPE_Base DTYPE_Void
+      | TYPE_Function ret args varargs =>  DTYPE_Void
+      | TYPE_I sz =>  DTYPE_Void
+      | TYPE_Iptr =>  DTYPE_Void
+      | TYPE_Pointer t' =>  DTYPE_Void
+      | TYPE_Label =>  DTYPE_Void
+      | TYPE_Token =>  DTYPE_Void
+      | TYPE_Void =>  DTYPE_Void
+      | TYPE_FP fp =>  DTYPE_Void
+      | TYPE_Metadata =>  DTYPE_Void
+      | TYPE_X86_mmx =>  DTYPE_Void
+      | TYPE_Opaque =>  DTYPE_Void
       end
   end.
 Next Obligation.
@@ -213,7 +213,7 @@ Defined.
 Lemma typ_to_dtyp_equation  : forall env t,
     typ_to_dtyp env t =
   match typ_to_dtyp_base_option env t with
-  | Some dt => DTYPE_Base dt
+  | Some dt =>  dt
   | None =>
       match t with
       | TYPE_Array sz t =>
@@ -233,27 +233,27 @@ Lemma typ_to_dtyp_equation  : forall env t,
           | Some dt =>
               if (vector_dtyp_base_dec dt)
               then DTYPE_Vector sz dt
-              else DTYPE_Base DTYPE_Void
-          | None => DTYPE_Base DTYPE_Void
+              else  DTYPE_Void
+          | None =>  DTYPE_Void
           end
       | TYPE_Identified id =>
           let opt := find (fun a => Ident.eq_dec id (fst a)) env in
           match opt with
-          | None => DTYPE_Base DTYPE_Void   (* TODO: should this be None? *)
+          | None =>  DTYPE_Void   (* TODO: should this be None? *)
           | Some (_, t) => typ_to_dtyp (remove_key Ident.eq_dec id env) t
           end
       (* These cases cannot happen *)
-      | TYPE_Function ret args varargs => DTYPE_Base DTYPE_Void
-      | TYPE_I sz => DTYPE_Base DTYPE_Void
-      | TYPE_Iptr => DTYPE_Base DTYPE_Void
-      | TYPE_Pointer t' => DTYPE_Base DTYPE_Void
-      | TYPE_Label => DTYPE_Base DTYPE_Void
-      | TYPE_Token => DTYPE_Base DTYPE_Void
-      | TYPE_Void => DTYPE_Base DTYPE_Void
-      | TYPE_FP fp => DTYPE_Base DTYPE_Void
-      | TYPE_Metadata => DTYPE_Base DTYPE_Void
-      | TYPE_X86_mmx => DTYPE_Base DTYPE_Void
-      | TYPE_Opaque => DTYPE_Base DTYPE_Void
+      | TYPE_Function ret args varargs =>  DTYPE_Void
+      | TYPE_I sz =>  DTYPE_Void
+      | TYPE_Iptr =>  DTYPE_Void
+      | TYPE_Pointer t' =>  DTYPE_Void
+      | TYPE_Label =>  DTYPE_Void
+      | TYPE_Token =>  DTYPE_Void
+      | TYPE_Void =>  DTYPE_Void
+      | TYPE_FP fp =>  DTYPE_Void
+      | TYPE_Metadata =>  DTYPE_Void
+      | TYPE_X86_mmx =>  DTYPE_Void
+      | TYPE_Opaque =>  DTYPE_Void
       end
   end.
 Proof using.
@@ -273,19 +273,19 @@ Defined.
 (* Specialized version of the characteristic equation for contexts where we don't want to compute *)
 (* SAZ: Not sure where these are needed. *)
 (*
-Lemma typ_to_dtyp_I : forall s i, typ_to_dtyp s (TYPE_I i) = DTYPE_Base (DTYPE_I i).
+Lemma typ_to_dtyp_I : forall s i, typ_to_dtyp s (TYPE_I i) =  (DTYPE_I i).
 Proof using.
   intros; rewrite typ_to_dtyp_equation; reflexivity.
 Qed.
 
-Lemma typ_to_dtyp_D : forall s fp, typ_to_dtyp s (TYPE_FP fp) = (DTYPE_Base (DTYPE_FP fp)).
+Lemma typ_to_dtyp_D : forall s fp, typ_to_dtyp s (TYPE_FP fp) = ( (DTYPE_FP fp)).
 Proof using.
   intros; rewrite typ_to_dtyp_equation; reflexivity.
 Qed.
 
 Lemma typ_to_dtyp_P :
   forall t s,
-    typ_to_dtyp s (TYPE_Pointer t) = (DTYPE_Base DTYPE_Pointer).
+    typ_to_dtyp s (TYPE_Pointer t) = ( DTYPE_Pointer).
 Proof using.
   intros t s.
   apply typ_to_dtyp_equation.

--- a/src/rocq/Syntax/TypToDtyp.v
+++ b/src/rocq/Syntax/TypToDtyp.v
@@ -164,7 +164,7 @@ Program Fixpoint typ_to_dtyp (env : list (ident * typ)) (t : typ) {measure (List
       match t with
       | TYPE_Array sz t =>
           let nt := typ_to_dtyp env t in
-          DTYPE_Array sz nt
+          DTYPE_Array false sz nt
 
       | TYPE_Struct fields =>
           let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
@@ -178,7 +178,7 @@ Program Fixpoint typ_to_dtyp (env : list (ident * typ)) (t : typ) {measure (List
           match typ_to_dtyp_base_option env t with
           | Some dt =>
               if (vector_dtyp_base_dec dt)
-              then DTYPE_Vector sz dt
+              then DTYPE_Array true sz dt
               else  DTYPE_Void
           | None =>  DTYPE_Void
           end
@@ -218,7 +218,7 @@ Lemma typ_to_dtyp_equation  : forall env t,
       match t with
       | TYPE_Array sz t =>
           let nt := typ_to_dtyp env t in
-          DTYPE_Array sz nt
+          DTYPE_Array false sz nt
 
       | TYPE_Struct fields =>
           let nfields := map_In fields (fun t _ => typ_to_dtyp env t) in
@@ -232,7 +232,7 @@ Lemma typ_to_dtyp_equation  : forall env t,
           match typ_to_dtyp_base_option env t with
           | Some dt =>
               if (vector_dtyp_base_dec dt)
-              then DTYPE_Vector sz dt
+              then DTYPE_Array true sz dt
               else  DTYPE_Void
           | None =>  DTYPE_Void
           end

--- a/src/rocq/Utils/ListUtil.v
+++ b/src/rocq/Utils/ListUtil.v
@@ -367,14 +367,14 @@ Section monad.
 
   (* Helper for looping 2 argument evaluation over vectors, producing a vector *)
 
-  Definition vec_loop {A : Type}
-    (f : A -> A -> m A)
-    (elts : list (A * A)) : m (list A) :=
+  Definition vec_loop {A B C: Type}
+    (f : A -> B -> m C)
+    (elts : list (A * B)) : m (list C) :=
     monad_fold_right (fun acc '(e1, e2) =>
                         val <- f e1 e2 ;;
                         ret (val :: acc)
       ) elts [].
-
+  
 End monad.
 Arguments monad_fold_right {_ _ _ _}.
 Arguments monad_app_fst {_ _ _ _ _}.
@@ -383,7 +383,7 @@ Arguments map_monad {_ _ _ _}.
 Arguments map_monad_ {_ _ _ _}.
 Arguments sequence {_ _ _}.
 Arguments foldM {_ _ _ _}.
-Arguments vec_loop {_ _ _}.
+Arguments vec_loop {_ _ _ _ _}.
 Definition repeatMN {A m} `{Monad m} (n : N) (ma : m A) : m (list A)
   := sequence (repeatN n ma).
 


### PR DESCRIPTION
This pull request refactors the core `dtyp` and `dvalue` types into `dtyp_base` & `dtyp` and `dvalue_base` & `dvalue` versions.  

There are a couple of design questions about this change that we could revisit:

1. `poison` lives *only* at `dtyp_base` and `dvalue_base` even though it carries a `dtyp`.  This is to ensure that there is only one representation of a dynamic poison value.  The alternative would be to have a poison constructor in both `dtyp_base` and `dtyp`, but then we end up with both `DTYPE_Poison (DTYPE_Base (DTYPE_I sz)` and `DTYPE_Base (DTYPE_Posion_base (DTYPE_I sz))` as syntactically distinct but semantically "equivalent".      The current design retains canonical forms but comes at some complexity.

2. `DVALUE_Vector`, unlike `DVALUE_Array` carries only `dvalue_base` elements.  This is closer to the actual constraints, since vectors can only contain primitive data values, but it does add some amount of friction in the development, since we need to occasionally "downcast" `dvalue` to `dvalue_base`.  If we moved to the old way, where both arrays and vectors carried `dvalue` we might get some simplification.  (And indeed, we could simply add a boolean flag to the constructor to distinguish them...)

3. I did end up adding `DTYPE_Base : dtype_base -> dtyp` and `DVALUE_Base : dvalue_base -> dvalue` as coercions, but that did not end up buying us very much because we use typeclasses in many places.  It might be simpler to just remove those coercions.

My current thought is that we should keep the design for (1), but maybe experiment with unifying vectors and arrays to address (2).  I don't think (3) makes much difference yet, so maybe remove the coercions?

I do think that many of the proofs will be simplified with this approach, but that remains to be seen.

I have no idea how this affects the performance of the interpreter, but that could also be a consideration.