### PR TITLE
Avl locals globals

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -33,12 +33,14 @@ the expected result; update the `ASSERT EQ` accordingly).
 | `iptr-roundtrip.ll` | `ptrtoint`/`inttoptr` round trips and loads through recovered pointers: the ITOP/PTOI + provenance machinery. | loop bound |
 | `undef-pick.ll` | the uvalue side: values kept symbolic (`undef` + select), stored (symbolic byte serialization) and branched on (Pick/concretization). | loop bound |
 
-Reference timings (Apple Silicon, July 2026, commit at suite creation):
-loop-phi-arith 6.6 s · calls-fib 6.9 s · mem-scan 5.0 s · mem-aggregate
-3.1 s · alloca-churn 2.0 s · iptr-roundtrip 4.1 s · undef-pick 3.5 s ·
-locals-chain 9.6 s. wide-arith: 6.1 s on the dvalue-refactor branch
-(July 2026), which introduced width-indexed integers; it does not run
-on older interpreters that lack arbitrary-width support. These are for
+Reference timings (Apple Silicon, July 2026, after switching the
+local/global envs to AVL maps and fixing the quadratic pending-bind
+accumulation in `map_monad_`/`denote_code`):
+loop-phi-arith 5.6 s · calls-fib 6.2 s · mem-scan 4.3 s · mem-aggregate
+2.3 s · alloca-churn 1.8 s · iptr-roundtrip 3.1 s · undef-pick 2.8 s ·
+wide-arith 4.3 s · locals-chain 0.24 s. locals-chain now scales linearly
+and no longer runs for seconds at N=10000 — regenerate with a larger N
+(`gen-locals-chain.py`) if you need it above startup noise. These are for
 orientation only — always re-measure the baseline on your own machine
 before comparing.
 

--- a/src/_RocqProject
+++ b/src/_RocqProject
@@ -27,6 +27,7 @@
 
 ./rocq/Syntax/LLVMAst.v
 ./rocq/Syntax/AstLib.v
+./rocq/Syntax/RawIdMaps.v
 ./rocq/Syntax/CFG.v
 ./rocq/Syntax/DynamicTypes.v
 ./rocq/Syntax/Traversal.v

--- a/src/ml/debugger.ml
+++ b/src/ml/debugger.ml
@@ -153,7 +153,7 @@ let rec read_command () =
 
 let print_stack_frame_vars (sf : Stack.stack_frame) =
   List.iter (fun (k, v) ->
-      Printf.printf "%s -> %s\n" (Camlcoq.camlstring_of_coqstring (ShowAST.show_raw_id k)) (string_of_dvalue v)) sf.stack_vars
+      Printf.printf "%s -> %s\n" (Camlcoq.camlstring_of_coqstring (ShowAST.show_raw_id k)) (string_of_dvalue v)) (RawIdMaps.RM.elements sf.stack_vars)
 
 let print_stack_vars (s : Stack.stack_frame list) =
   List.iteri (fun n (sf : Stack.stack_frame) ->
@@ -166,7 +166,7 @@ let print_stack_frames (s : Stack.stack_frame list) =
 
 let print_globals g =
   List.iter  (fun (k, v) ->
-      Printf.printf "%s -> %s\n" (Camlcoq.camlstring_of_coqstring (ShowAST.show_raw_id k)) (string_of_dvalue v)) g
+      Printf.printf "%s -> %s\n" (Camlcoq.camlstring_of_coqstring (ShowAST.show_raw_id k)) (string_of_dvalue v)) (RawIdMaps.RM.elements g)
 
 
 let help_msg : string =

--- a/src/ml/extracted/Extract.v
+++ b/src/ml/extracted/Extract.v
@@ -68,7 +68,7 @@ Extract Constant fast_mode_object => "
   ".
 
 Extract Constant locals_object => "
-  let locals_ref = ref [] in
+  let locals_ref = ref RawIdMaps.RM.empty in
   let locals_set ls = (locals_ref := ls; ()) in
   let locals_get = fun _ -> !locals_ref in
   fun _ -> { locals_set;
@@ -77,7 +77,7 @@ Extract Constant locals_object => "
   ".
 
 Extract Constant globals_object => "
-  let globals_ref = ref [] in
+  let globals_ref = ref RawIdMaps.RM.empty in
   let globals_set gs = (globals_ref := gs; ()) in
   let globals_get = fun _ -> !globals_ref in
   fun _ -> { globals_set;
@@ -86,7 +86,7 @@ Extract Constant globals_object => "
   ".
 
 Extract Constant local_stack_object => "
-  let local_stack_ref = ref [{ stack_vars = []; stack_exc = None; stack_loc = None }] in
+  let local_stack_ref = ref [{ stack_vars = RawIdMaps.RM.empty; stack_exc = None; stack_loc = None }] in
   let local_stack_set ls = (local_stack_ref := match !local_stack_ref with [] -> Stdlib.failwith ""Empty stack, can't set"" | _::xs -> ls :: xs) in
   let local_stack_get = fun _ -> !local_stack_ref in
   let local_stack_push ls = local_stack_ref := ls :: !local_stack_ref in

--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -733,7 +733,7 @@ Section Denotation.
 
   (* Denoting a list of instruction simply binds the trees together *)
   Definition denote_code (c: code dtyp) (varargs : option ptr) : CFGtop unit :=
-    map_monad_ (fun i => denote_instr i varargs) c.
+    loop_monad (fun i => denote_instr i varargs) c.
 
   Definition denote_phi (bid_from : block_id) (id_p : local_id * phi dtyp * (list (metadata dtyp))) : CFGtop (local_id * dvalue) :=
     let '(id, Phi dt args, md) := id_p in

--- a/src/rocq/Semantics/Handlers/Global.v
+++ b/src/rocq/Semantics/Handlers/Global.v
@@ -4,8 +4,7 @@ From Stdlib Require Import
   String.
 
 From ExtLib Require Import
-  Structures.Maps
-  Data.Map.FMapAList.
+  Structures.Maps.
 
 From ITree Require Import
   ITree
@@ -31,7 +30,7 @@ Import ITree.Basics.Basics.Monads.
 
 Section Globals.
   Context {Pa : Params}.
-  Definition global_env := FMapAList.alist raw_id dvalue.
+  Definition global_env := rmap dvalue.
   #[local] Notation map := (global_env).
   
   Definition handle_global {E} `{FailureE -< E} : GlobalE ~> stateT map (itree E) :=

--- a/src/rocq/Semantics/Handlers/Local.v
+++ b/src/rocq/Semantics/Handlers/Local.v
@@ -4,8 +4,7 @@ From Stdlib Require Import
   Morphisms.
 
 From ExtLib Require Import
-  Structures.Maps
-  Data.Map.FMapAList.
+  Structures.Maps.
 
 From ITree Require Import
   ITree
@@ -30,7 +29,7 @@ Import ITree.Basics.Basics.Monads.
 
 Section Locals.
   Context {Pa : Params}.
-  Definition local_env := FMapAList.alist raw_id dvalue.
+  Definition local_env := rmap dvalue.
   #[local] Notation map := (local_env).
 
   Definition handle_local {E} `{FailureE -< E} : LocalE ~> stateT map (itree E) :=

--- a/src/rocq/Semantics/Handlers/Stack.v
+++ b/src/rocq/Semantics/Handlers/Stack.v
@@ -27,7 +27,7 @@ Section StackMap.
   Context {Pa : Params}.
 
   Record stack_frame :=
-    { stack_vars : FMapAList.alist raw_id dvalue;
+    { stack_vars : local_env;
       stack_exc : option dvalue;
       stack_loc : option string;
     }.

--- a/src/rocq/Semantics/Implementations/Memory.v
+++ b/src/rocq/Semantics/Implementations/Memory.v
@@ -63,7 +63,7 @@ Section MemoryModel.
     ptrs <- lift (get_consecutive_ptrs p (N.length bytes));;
     let ptr_bytes := zip ptrs bytes in
     (* Actually perform writes *)
-    map_monad_ (fun '(ptr, byte) => write_byte ptr byte) ptr_bytes.
+    loop_monad (fun '(ptr, byte) => write_byte ptr byte) ptr_bytes.
 
   Definition write_dvalue (dt : dtyp) (p : ptr) (v : dvalue) : memM unit :=
     write_bytes p (dvalue_to_memory_bytes v dt).

--- a/src/rocq/Semantics/TopLevel.v
+++ b/src/rocq/Semantics/TopLevel.v
@@ -2,6 +2,7 @@
 
 (* begin hide *)
 From Stdlib Require Import Program.
+From ExtLib Require Import Structures.Maps.
 From ITree Require Import
   ITree
   Events.State.
@@ -300,7 +301,7 @@ Section withParams.
       args <- arg_gen;;
       denote_vellvm ret_typ entry args
         (convert_types (mcfg_of_tle (link PREDEFINED_FUNCTIONS prog)))
-    in interp_mcfg t [] (Build_stack_frame [] None None,[]) initial_state.
+    in interp_mcfg t Maps.empty (Build_stack_frame Maps.empty None None,[]) initial_state.
 
   (**
      Finally, the reference interpreter assumes no user-defined intrinsics and starts

--- a/src/rocq/Semantics/TopLevel.v
+++ b/src/rocq/Semantics/TopLevel.v
@@ -131,7 +131,7 @@ Section withParams.
       gwrite (g_ident g) v.
 
   Definition allocate_globals (gs:list (global dtyp)) : MCFGtop unit :=
-    map_monad_ allocate_global gs.
+    loop_monad allocate_global gs.
 
   Definition i8 : dtyp := DTYPE_I 8%positive.
 
@@ -185,7 +185,7 @@ Section withParams.
     end.
 
   Definition allocate_declarations (ds:list (declaration dtyp)) : MCFGtop unit :=
-    map_monad_ allocate_declaration ds.
+    loop_monad allocate_declaration ds.
 
   (* We have to initialize the global definitions after allocating them because they
      might be mutually recursive.  It is possible to declare cyclic data structures
@@ -212,7 +212,7 @@ Section withParams.
     store dt a uv.
 
   Definition initialize_globals (gs:list (global dtyp)): MCFGtop unit :=
-    map_monad_ initialize_global gs.
+    loop_monad initialize_global gs.
 
   Definition build_global_environment (CFGtop : CFG.mcfg dtyp) : MCFGtop unit :=
     allocate_declarations ((m_declarations CFGtop) ++ (List.map (df_prototype) (m_definitions CFGtop)));;

--- a/src/rocq/Syntax.v
+++ b/src/rocq/Syntax.v
@@ -13,6 +13,7 @@ From Vellvm Require Export
      Syntax.LLVMAst
      Syntax.CFG
      Syntax.AstLib
+     Syntax.RawIdMaps
      Syntax.Scope
      Syntax.Traversal
      Syntax.DynamicTypes

--- a/src/rocq/Syntax/RawIdMaps.v
+++ b/src/rocq/Syntax/RawIdMaps.v
@@ -1,0 +1,63 @@
+(* begin hide *)
+From Stdlib Require Import
+  FSets.FMapAVL
+  FMapFacts.
+
+From ExtLib Require Import
+  Structures.Maps.
+
+From Vellvm Require Import
+  Syntax.LLVMAst
+  Syntax.AstLib.
+(* end hide *)
+
+(** * Efficient maps keyed by [raw_id]
+    AVL maps over [raw_id], used for the local and global environments
+    ([Handlers.Local.local_env], [Handlers.Global.global_env]) in place of
+    association lists, whose linear lookups made environment accesses a
+    quadratic cost center (see [perf/README.md], [perf/locals-chain.ll]).
+
+    The handlers access their environment exclusively through ExtLib's
+    [Map] typeclass, so we expose the AVL map as a [Map] instance and the
+    swap is transparent to them. [IntMaps] plays the same role for
+    [Z]-keyed maps in the memory model.
+ *)
+
+Module RM := FMapAVL.Make(RawIDOrd).
+Module RMF := FMapFacts.WProperties_fun(RawIDOrd)(RM).
+
+(* Polymorphic type of maps indexed by [raw_id] *)
+Definition rmap := RM.t.
+
+#[global] Instance Map_rmap {V} : Map raw_id V (rmap V) :=
+  { empty := @RM.empty V
+  ; add := @RM.add V
+  ; remove := @RM.remove V
+  ; lookup := @RM.find V
+  (* eta-expanded so the extracted record is a syntactic value: a partial
+     application here trips OCaml's value restriction and weakens the type *)
+  ; union := fun m1 m2 =>
+               RM.map2 (fun mx my => match mx with Some x => Some x | None => my end) m1 m2
+  }.
+
+(* Sorted list of the bindings, for consumers that need to enumerate the
+   environment (e.g. the OCaml debugger's locals/globals printing). *)
+Definition rmap_to_list {V} (m : rmap V) : list (raw_id * V) := RM.elements m.
+
+#[global] Instance MapOk_rmap {V} : MapOk (@eq raw_id) (@Map_rmap V).
+Proof.
+  refine {| mapsto := fun k v (m : rmap V) => RM.MapsTo k v m |}; cbn.
+  - intros k v IN.
+    apply RMF.F.empty_mapsto_iff in IN; exact IN.
+  - intros k v m.
+    symmetry; apply RMF.F.find_mapsto_iff.
+  - intros m k v.
+    apply RM.add_1; reflexivity.
+  - intros m k v k' NEQ v'.
+    symmetry; apply RMF.F.add_neq_mapsto_iff; auto.
+  - intros m k v IN.
+    apply RMF.F.remove_mapsto_iff in IN.
+    destruct IN as [NEQ _]; apply NEQ; reflexivity.
+  - intros m k k' NEQ v'.
+    symmetry; apply RMF.F.remove_neq_mapsto_iff; auto.
+Defined.

--- a/src/rocq/Theory/I2F/I2F_denotation.v
+++ b/src/rocq/Theory/I2F/I2F_denotation.v
@@ -242,7 +242,7 @@ Lemma I2F_denote_code :
     I2F_refine_CFG TT (@denote_code PInf c va1) (@denote_code PFin c va2).
 Proof.
   intros.
-  unfold denote_code, map_monad_.
+  unfold denote_code, loop_monad.
   induction c; cbn.
   - now rstep.
   - rbind TT; [apply I2F_denote_instr; auto | intros [] [] _].

--- a/src/rocq/Theory/I2F/I2F_denotation.v
+++ b/src/rocq/Theory/I2F/I2F_denotation.v
@@ -243,13 +243,10 @@ Lemma I2F_denote_code :
 Proof.
   intros.
   unfold denote_code, map_monad_.
-  rbind TT; [| intros; now rstep].
   induction c; cbn.
   - now rstep.
   - rbind TT; [apply I2F_denote_instr; auto | intros [] [] _].
-    rbind TT.
     apply IHc.
-    intros; now rstep.
 Qed.
 
 Hint Constructors I2F_dvalue : core.

--- a/src/rocq/Utils/ListUtil.v
+++ b/src/rocq/Utils/ListUtil.v
@@ -561,9 +561,19 @@ Section monad.
           ret (b::bs)
       end.
 
+  (* Not defined as [map_monad f l;; ret tt]: collecting the results makes
+     every element executed so far a pending bind continuation, so each
+     subsequent step of an itree-interpreted computation re-associates
+     through all of them — O(n) per step, O(n²) for a straight-line block
+     (see perf/locals-chain.ll). The direct sequencing fold keeps the
+     pending-bind depth constant. *)
   Definition map_monad_ {A B}
     (f: A -> m B) (l: list A): m unit :=
-    map_monad f l;; ret tt.
+    (fix loop l :=
+       match l with
+       | [] => ret tt
+       | a::l' => f a;; loop l'
+       end) l.
 
   Definition sequence {a} (ms : list (m a)) : m (list a)
     := map_monad id ms.

--- a/src/rocq/Utils/ListUtil.v
+++ b/src/rocq/Utils/ListUtil.v
@@ -567,7 +567,7 @@ Section monad.
      through all of them — O(n) per step, O(n²) for a straight-line block
      (see perf/locals-chain.ll). The direct sequencing fold keeps the
      pending-bind depth constant. *)
-  Definition map_monad_ {A B}
+  Definition loop_monad {A B}
     (f: A -> m B) (l: list A): m unit :=
     (fix loop l :=
        match l with
@@ -618,7 +618,7 @@ Arguments monad_fold_right {_ _ _ _}.
 Arguments monad_app_fst {_ _ _ _ _}.
 Arguments monad_app_snd {_ _ _ _ _}.
 Arguments map_monad {_ _ _ _}.
-Arguments map_monad_ {_ _ _ _}.
+Arguments loop_monad {_ _ _ _}.
 Arguments sequence {_ _ _}.
 Arguments foldM {_ _ _ _}.
 Arguments vec_loop {_ _ _ _ _}.


### PR DESCRIPTION
This contains two performance patches:
- First I simply swapped the association map used for locals and globals in favour of AVL, as already used in the memory.
- But then it did not reduce as much the benchmark stressing locals, so I asked Claude its opinion, and it found something I did not see at all: `map_monad_` was inefficient because it collected the result before discarding it. Swapping it for an implementation that discards results on the go makes a much more drastic change. 

Namely, with of course a very non-scientific measuring on my own machine and no repetition, we have for the locals-chain stress test:
- base: 9.05 s
- avl maps for locals: 6.53 s
- avl maps for locals and optimized map_monad_: 0.24 s

