### PR TITLE
tentative stub for @llvm.sqrt.f32

### DIFF
--- a/src/libll/rust-intrinsics.ll
+++ b/src/libll/rust-intrinsics.ll
@@ -1203,3 +1203,90 @@ define { i8, i1 } @llvm.uadd.with.overflow.i8(i8 noundef %0, i8 noundef %1) loca
   %fullres = insertvalue {i8, i1} %base, i1 %overflow, 1
   ret {i8, i1} %fullres
 }
+
+; This was LLM-generated, but was exhaustively tested.
+define float @llvm.sqrt.f32(float %x) {
+entry:
+  %is_nan = fcmp uno float %x, %x
+  br i1 %is_nan, label %silence_nan, label %chk1
+
+chk1:
+  %is_neg = fcmp olt float %x, 0.000000e+00
+  br i1 %is_neg, label %ret_nan, label %chk2
+
+chk2:
+  ; covers +0.0, -0.0 (sign preserved via ret_x), and +inf
+  %is_zero = fcmp oeq float %x, 0.000000e+00
+  %is_inf  = fcmp oeq float %x, 0x7FF0000000000000
+  %trivial = or i1 %is_zero, %is_inf
+  br i1 %trivial, label %ret_x, label %compute
+
+compute:
+  ; The fast-inverse-sqrt bit trick assumes a *normalized* float (implicit
+  ; leading 1 + biased exponent). Subnormals have exponent field 0 and no
+  ; implicit 1, so the magic-constant seed is wildly wrong and Newton-Raphson
+  ; overflows to +inf. Fix: if x is subnormal (x < 2^-126, the smallest
+  ; normal), scale it up into the normalized range by 2^96, run the algorithm,
+  ; then scale the result back down by 2^48 since sqrt(x*2^96) = sqrt(x)*2^48.
+  %smallest_normal = bitcast i32 8388608 to float      ; 0x00800000 = 2^-126
+  %is_sub    = fcmp olt float %x, %smallest_normal
+  %scale_up_c   = bitcast i32 1870659584 to float      ; 0x6F800000 = 2^96
+  %scale_down_c = bitcast i32 662700032 to float       ; 0x27800000 = 2^-48
+  %scale_up   = select i1 %is_sub, float %scale_up_c,   float 1.000000e+00
+  %scale_down = select i1 %is_sub, float %scale_down_c, float 1.000000e+00
+  %xs = fmul float %x, %scale_up
+
+  ; initial guess for 1/sqrt(xs): i = 0x5f3759df - (bits(xs) >> 1)
+  %ibits  = bitcast float %xs to i32
+  %ishift = lshr i32 %ibits, 1
+  %iguess = sub i32 1597463007, %ishift        ; 0x5f3759df
+  %y0     = bitcast i32 %iguess to float
+
+  %half = fmul float %xs, 5.000000e-01
+
+  ; Newton-Raphson on rsqrt, x3
+  %y0sq  = fmul float %y0, %y0
+  %t0    = fmul float %half, %y0sq
+  %c0    = fsub float 1.500000e+00, %t0
+  %y1    = fmul float %y0, %c0
+
+  %y1sq  = fmul float %y1, %y1
+  %t1    = fmul float %half, %y1sq
+  %c1    = fsub float 1.500000e+00, %t1
+  %y2    = fmul float %y1, %c1
+
+  %y2sq  = fmul float %y2, %y2
+  %t2    = fmul float %half, %y2sq
+  %c2    = fsub float 1.500000e+00, %t2
+  %y3    = fmul float %y2, %c2
+
+  ; sqrt(xs) = xs * rsqrt(xs)
+  %r0 = fmul float %xs, %y3
+
+  ; one Newton step directly on sqrt to shave off remaining error
+  %r0d   = fdiv float %xs, %r0
+  %rsum  = fadd float %r0, %r0d
+  %result_scaled = fmul float %rsum, 5.000000e-01
+
+  ; undo the scaling (no-op when x was already normal: scale_down = 1.0)
+  %result = fmul float %result_scaled, %scale_down
+  br label %ret_val
+
+silence_nan:
+  ; quiet the NaN by setting the most-significant mantissa bit (bit 22),
+  ; which silences a signaling NaN while preserving its sign and payload
+  %nan_bits    = bitcast float %x to i32
+  %quiet_bits  = or i32 %nan_bits, 4194304        ; 0x00400000
+  %quiet_nan   = bitcast i32 %quiet_bits to float
+  ret float %quiet_nan
+
+ret_nan:
+  %nan = fdiv float 0.000000e+00, 0.000000e+00   ; generate qNaN, no hex literal needed
+  ret float %nan
+
+ret_x:
+  ret float %x
+
+ret_val:
+  ret float %result
+}


### PR DESCRIPTION
For some work, I needed an implementation of f32 square root.

I had a LLM generate a stub, which seemed to work okay enough, but in order to improve trust, I decided to test it.
It turns out it was not quite correct, and I got a fix, after which it seems to pass this test.

This is the test I wrote:

```llvm
declare i32 @llvm.abs.i32(i32, i1)
declare float @llvm.sqrt.f32(float)
declare i32 @printf(ptr, ...)

@failure = private unnamed_addr constant [88 x i8] c"Mismatch on input: %f = 0x%08x, native output: %f = 0x%08X, manual output: %f = 0x%08X\0A\00", align 1
@done = private constant [7 x i8] c"Done!\0A\00", align 1

define i1 @main() {
entry:
  br label %loop.body

loop.body:
  %bit_pattern = phi i32 [ 0, %entry ], [ %next_bit_pattern, %next ]
  %input_float = bitcast i32 %bit_pattern to float

  %res_native = call float @llvm.sqrt.f32(float %input_float)
  %res_manual = call float @manually.sqrt.f32(float %input_float)

  %bits_native = bitcast float %res_native to i32
  %bits_manual = bitcast float %res_manual to i32
  %signed_distance = sub i32 %bits_native, %bits_manual 
  %distance = call i32 @llvm.abs.i32(i32 %signed_distance, i1 true)
  %close_enough = icmp ule i32 %distance, 1
  br i1 %close_enough, label %next, label %not.equal

next:
  %next_bit_pattern = add i32 %bit_pattern, 1
  %done = icmp eq i32 %next_bit_pattern, 0
  br i1 %done, label %all.equal, label %loop.body

not.equal:
  %bits_input = bitcast float %input_float to i32
  %input_double = fpext float %input_float to double
  %res_native_double = fpext float %res_native to double
  %res_manual_double = fpext float %res_manual to double
  call i32 (ptr, ...) @printf(ptr @failure, double %input_double, i32 %bits_input, double %res_native_double, i32 %bits_native, double %res_manual_double, i32 %bits_manual)
  br label %next

all.equal:
  call i32 (ptr, ...) @printf(ptr @done)
  ret i1 0 
}
```

The intent of the test is to check every single f32 input (there are about 4 billion of them, but this only takes something like 10 seconds total).
The `icmp` test tries to assert whether this implementation's result is within 1 ULP (you can change the number) of the native implementation your libm would use. This was tested on MacOS, and seemed to work great after the function was fixed to handle subnormals better!

Opening this for consideration for upstreaming.

---

Now for how it works:

For normal floats, this does:
1. Use the "Quake III fast inverse square root" trick to get a pretty good estimate of the (reciprocal of the) square root.
2. Then it uses the Newton-Raphson refinement method to increasingly improve this estimate, until it's within 1 ULP of the actual result.

For subnormal floats, it scales them into the normal range, does the above computation, and scales the result back. Seems to work, but I'm not sure how mathematically justified this is.

For NaNs, there's just some special handling to match libm semantics: libm silents signaling NaNs. So we do the same (it's a one-bit switch for signaling NaNs, otherwise identity function for non-signaling NaNs).