### PR TITLE
Improve split used on vectors and implement shuffle_vector

### DIFF
--- a/src/rocq/Semantics/Denotation.v
+++ b/src/rocq/Semantics/Denotation.v
@@ -322,7 +322,7 @@ Section Denotation.
         vec1 <- denote_exp (Some dt_vec1) vecop1 ;;
         vec2 <- denote_exp (Some dt_vec2) vecop2 ;;
         idxmask <- denote_exp (Some dt_mask) idxmask;;
-        raise ("todo: implement shuffle_vector" )
+        lift (shuffle_vector vec1 vec2 idxmask)
 
     | OP_ExtractValue (dt, str) idxs =>
         str <- denote_exp (Some dt) str ;;

--- a/src/rocq/Semantics/DynamicValues.v
+++ b/src/rocq/Semantics/DynamicValues.v
@@ -884,6 +884,41 @@ Section DValue.
     else
       split_h pre idx l.
 
+  (* Tail-safe analogue of [split]: [split_h]'s accumulator grows via
+     [pre ++ [h]], an append, making it quadratic in [idx] *)
+  Fixpoint split_acc_go {A} (rev_pre : list A) (idx : Z) (l : list A)
+    : option (list A * A * list A) :=
+    match l with
+    | [] => None
+    | h :: tl =>
+        (if idx =? 0 then Some (rev_append rev_pre [], h, tl)
+         else split_acc_go (h :: rev_pre) (idx - 1) tl)%Z
+    end.
+
+  Definition split_acc {A} (idx : Z) (l : list A) : option (list A * A * list A) :=
+    if (idx <? 0)%Z then None else split_acc_go [] idx l.
+
+  Lemma split_acc_go_eq {A} : forall (l : list A) idx rev_pre,
+      split_acc_go rev_pre idx l = split_h (rev_append rev_pre []) idx l.
+  Proof.
+    induction l as [| h l IH]; intros idx rev_pre; cbn [split_acc_go split_h].
+    - reflexivity.
+    - destruct (idx =? 0)%Z eqn:EQ.
+      + reflexivity.
+      + rewrite IH; f_equal.
+        cbn [rev_append].
+        rewrite rev_append_rev, rev_append_rev, app_nil_r.
+        reflexivity.
+  Qed.
+
+  Lemma split_acc_eq {A} (idx : Z) (l : list A) :
+    split_acc idx l = split [] idx l.
+  Proof.
+    unfold split_acc, split.
+    destruct (idx <? 0)%Z; auto.
+    rewrite split_acc_go_eq; reflexivity.
+  Qed.
+
   (* [split]/[split_h] of related lists produce related pieces. *)
   Lemma Forall2_split_h {A B} (R : A -> B -> Prop) :
     forall i (l1 : list A) (l2 : list B),
@@ -978,7 +1013,7 @@ Section DValue.
     | DVALUE_Array true (DTYPE_Array true _ dt) elts =>
         match dvalue_to_Z idx with
         | Some i =>
-            match split [] i elts with
+            match split_acc i elts with
             | None => ret (DVALUE_Base (DVALUE_Poison dt))
             | Some (pre, elt, post) =>  ret elt
             end
@@ -992,7 +1027,7 @@ Section DValue.
     | DVALUE_Array true (DTYPE_Array true sz dt) elts =>
         match dvalue_to_Z idx with
         | Some i =>
-            match split [] i elts with
+            match split_acc i elts with
             | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz dt)))
             | Some (pre, _, post) =>  ret (DVALUE_Array true (DTYPE_Array true sz dt) (pre ++ [elt] ++ post))
             end
@@ -1002,7 +1037,7 @@ Section DValue.
         let elts : list dvalue := repeat (DVALUE_Base (DVALUE_Poison dt)) (N.to_nat sz) in
         match dvalue_to_Z idx with
         | Some i =>
-            match split [] i elts with
+            match split_acc i elts with
             | None => ret (DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz dt)))
             | Some (pre, _, post) =>  ret (DVALUE_Array true (DTYPE_Array true sz dt) (pre ++ [elt] ++ post))
             end

--- a/src/rocq/Semantics/DynamicValues.v
+++ b/src/rocq/Semantics/DynamicValues.v
@@ -1046,6 +1046,29 @@ Section DValue.
     | _ => raise_error ("insertelement: non-vector type " ++ (show vec))%string
     end.
 
+  (* A mask element that isn't a resolvable integer or is out of range of
+     [elts1 ++ elts2] yields poison *)
+  Definition shuffle_vector (vec1 vec2 mask : dvalue) : EOU dvalue :=
+    match vec1, vec2, mask with
+    | DVALUE_Array true (DTYPE_Array true _ dt) elts1,
+      DVALUE_Array true (DTYPE_Array true _ _) elts2,
+      DVALUE_Array true (DTYPE_Array true n _) idxs =>
+        let combined := elts1 ++ elts2 in
+        let lane (idxv : dvalue) : dvalue :=
+          match dvalue_to_Z idxv with
+          | Some i =>
+              if (i <? 0)%Z then DVALUE_Base (DVALUE_Poison dt)
+              else match nth_error combined (Z.to_nat i) with
+                   | Some v => v
+                   | None => DVALUE_Base (DVALUE_Poison dt)
+                   end
+          | None => DVALUE_Base (DVALUE_Poison dt)
+          end
+        in
+        ret (DVALUE_Array true (DTYPE_Array true n dt) (List.map lane idxs))
+    | _, _, _ => raise_error "shufflevector: non-vector operand"
+    end.
+
 (*  ------------------------------------------------------------------------- *)
 
 

--- a/src/rocq/Semantics/DynamicValues.v
+++ b/src/rocq/Semantics/DynamicValues.v
@@ -1046,13 +1046,21 @@ Section DValue.
     | _ => raise_error ("insertelement: non-vector type " ++ (show vec))%string
     end.
 
+  (* Need to be careful to properly compute a poison at array type rather than
+     an arry of poison values *)
+  Definition vector_elts (v : dvalue) : option (dtyp * list dvalue) :=
+    match v with
+    | DVALUE_Array true (DTYPE_Array true _ dt) elts => Some (dt, elts)
+    | DVALUE_Base (DVALUE_Poison (DTYPE_Array true sz dt)) =>
+        Some (dt, repeat (DVALUE_Base (DVALUE_Poison dt)) (N.to_nat sz))
+    | _ => None
+    end.
+
   (* A mask element that isn't a resolvable integer or is out of range of
      [elts1 ++ elts2] yields poison *)
   Definition shuffle_vector (vec1 vec2 mask : dvalue) : EOU dvalue :=
-    match vec1, vec2, mask with
-    | DVALUE_Array true (DTYPE_Array true _ dt) elts1,
-      DVALUE_Array true (DTYPE_Array true _ _) elts2,
-      DVALUE_Array true (DTYPE_Array true n _) idxs =>
+    match vector_elts vec1, vector_elts vec2, mask with
+    | Some (dt, elts1), Some (_, elts2), DVALUE_Array true (DTYPE_Array true n _) idxs =>
         let combined := elts1 ++ elts2 in
         let lane (idxv : dvalue) : dvalue :=
           match dvalue_to_Z idxv with

--- a/src/rocq/Theory/I2F/I2F_exp.v
+++ b/src/rocq/Theory/I2F/I2F_exp.v
@@ -1296,6 +1296,86 @@ Proof.
       ltac:(do 2 constructor; apply Forall2_app; [auto | constructor; auto]).
 Qed.
 
+(** * shufflevector *)
+
+(* [vector_elts] normalizes a whole vector operand (concrete array or the
+   scalar poison encoding) to its element dtyp/list; related dvalues
+   normalize to related pieces (or both fail). *)
+Lemma I2F_vector_elts : forall v1 v2,
+    I2F_dvalue v1 v2 ->
+    match vector_elts v1, vector_elts v2 with
+    | Some (dt1, elts1), Some (dt2, elts2) => dt1 = dt2 /\ Forall2 I2F_dvalue elts1 elts2
+    | None, None => True
+    | _, _ => False
+    end.
+Proof.
+  intros v1 v2 H; inversion H; subst; cbn.
+  - match goal with
+    | HB : I2F_dvalue_base _ _ |- _ => inversion HB; subst; cbn; auto
+    end.
+    match goal with
+    | t : dtyp |- _ => destruct t as [ ? | ? ? | [|] ? ? ]
+    end; cbn; auto.
+  - auto.
+  - match goal with v : bool |- _ => destruct v end; cbn; auto.
+    match goal with
+    | t : dtyp |- _ => destruct t as [ ? | ? ? | [|] ? ? ]
+    end; cbn; auto.
+Qed.
+
+Lemma Forall2_nth_error {A B} (R : A -> B -> Prop) (l1 : list A) (l2 : list B) :
+  Forall2 R l1 l2 ->
+  forall n,
+    match nth_error l1 n, nth_error l2 n with
+    | Some a, Some b => R a b
+    | None, None => True
+    | _, _ => False
+    end.
+Proof.
+  intros F; induction F; intros [| n]; cbn; auto.
+  apply IHF.
+Qed.
+
+Lemma Forall2_map_rel {A1 A2 B1 B2} (R : A1 -> A2 -> Prop) (R' : B1 -> B2 -> Prop)
+  (f : A1 -> B1) (g : A2 -> B2) :
+  (forall a b, R a b -> R' (f a) (g b)) ->
+  forall l1 l2, Forall2 R l1 l2 -> Forall2 R' (map f l1) (map g l2).
+Proof.
+  intros HRR l1 l2 F; induction F; cbn; constructor; auto.
+Qed.
+
+Lemma I2F_shuffle_vector a1 a2 a3 b1 b2 b3 :
+  I2F_dvalue a1 b1 ->
+  I2F_dvalue a2 b2 ->
+  I2F_dvalue a3 b3 ->
+  I2F_EOU I2F_dvalue (shuffle_vector a1 a2 a3) (shuffle_vector b1 b2 b3).
+Proof.
+  intros R1 R2 R3.
+  unfold shuffle_vector.
+  pose proof (I2F_vector_elts R1) as V1.
+  pose proof (I2F_vector_elts R2) as V2.
+  destruct (vector_elts a1) as [[dt1 elts1]|], (vector_elts b1) as [[dt1' elts1']|];
+    try contradiction; try (repeat constructor).
+  destruct (vector_elts a2) as [[dt2 elts2]|], (vector_elts b2) as [[dt2' elts2']|];
+    try contradiction; try (repeat constructor).
+  destruct V1 as [EQ1 HE1]; subst.
+  destruct V2 as [EQ2 HE2]; subst.
+  inversion R3; subst; cbn; try (repeat constructor).
+  break_match_goal; auto.
+  break_match_goal; auto.
+  break_match_goal; auto.
+  do 2 constructor.
+  eapply Forall2_map_rel; eauto.
+  intros idxv idxv' Ridx.
+  rewrite (I2F_dvalue_to_Z Ridx).
+  destruct (dvalue_to_Z idxv') as [i |]; [| repeat constructor].
+  destruct (i <? 0)%Z; [repeat constructor |].
+  pose proof (Forall2_nth_error (Forall2_app HE1 HE2) (Z.to_nat i)) as N.
+  destruct (nth_error (elts1 ++ elts2) (Z.to_nat i)) as [?v|],
+      (nth_error (elts1' ++ elts2') (Z.to_nat i)) as [v'|];
+    try contradiction; [assumption | repeat constructor].
+Qed.
+
 (** * extract_value *)
 Lemma I2F_extract_value a b idxs :
   I2F_dvalue a b ->
@@ -1637,7 +1717,8 @@ Proof with try (rstep || cbnn; simp I2FE_Failure; reflexivity).
   - destruct vec1,vec2,idxmask; cbn; intros _.
     erbind; [apply IHe | intros].
     erbind; [apply IHe0 | intros].
-    erbind; [apply IHe1 | intros]...
+    erbind; [apply IHe1 | intros].
+    apply I2F_refine_lift, I2F_shuffle_vector; auto.
   - destruct vec; cbn; intros _.
     erbind; [apply IHe | intros].
     apply I2F_refine_lift, I2F_extract_value; eauto.

--- a/src/rocq/Theory/I2F/I2F_exp.v
+++ b/src/rocq/Theory/I2F/I2F_exp.v
@@ -1323,27 +1323,6 @@ Proof.
     end; cbn; auto.
 Qed.
 
-Lemma Forall2_nth_error {A B} (R : A -> B -> Prop) (l1 : list A) (l2 : list B) :
-  Forall2 R l1 l2 ->
-  forall n,
-    match nth_error l1 n, nth_error l2 n with
-    | Some a, Some b => R a b
-    | None, None => True
-    | _, _ => False
-    end.
-Proof.
-  intros F; induction F; intros [| n]; cbn; auto.
-  apply IHF.
-Qed.
-
-Lemma Forall2_map_rel {A1 A2 B1 B2} (R : A1 -> A2 -> Prop) (R' : B1 -> B2 -> Prop)
-  (f : A1 -> B1) (g : A2 -> B2) :
-  (forall a b, R a b -> R' (f a) (g b)) ->
-  forall l1 l2, Forall2 R l1 l2 -> Forall2 R' (map f l1) (map g l2).
-Proof.
-  intros HRR l1 l2 F; induction F; cbn; constructor; auto.
-Qed.
-
 Lemma I2F_shuffle_vector a1 a2 a3 b1 b2 b3 :
   I2F_dvalue a1 b1 ->
   I2F_dvalue a2 b2 ->

--- a/src/rocq/Theory/I2F/I2F_exp.v
+++ b/src/rocq/Theory/I2F/I2F_exp.v
@@ -1252,6 +1252,7 @@ Proof.
   end; cbn; try (repeat constructor).
   rewrite (I2F_dvalue_to_Z R2).
   destruct (dvalue_to_Z b2) as [i |]; cbn; try (repeat constructor).
+  rewrite !split_acc_eq.
   i2f_split_case i ltac:(auto).
 Qed.
 
@@ -1279,6 +1280,7 @@ Proof.
         pose proof (Forall2_repeat _ _ n
                       (I2F_dvalue_Base (I2F_dvalue_Poison dt))) as F
     end.
+    rewrite !split_acc_eq.
     i2f_split_case i
       ltac:(do 2 constructor; apply Forall2_app; [auto | constructor; auto]).
   - (* Vector *)
@@ -1289,6 +1291,7 @@ Proof.
     end; cbn; try (repeat constructor).
     rewrite (I2F_dvalue_to_Z R3).
     destruct (dvalue_to_Z b3) as [i |]; cbn; try (repeat constructor).
+    rewrite !split_acc_eq.
     i2f_split_case i
       ltac:(do 2 constructor; apply Forall2_app; [auto | constructor; auto]).
 Qed.

--- a/src/rocq/Utils/ListUtil.v
+++ b/src/rocq/Utils/ListUtil.v
@@ -596,6 +596,27 @@ Section Forall2.
     apply Forall2_split_every_pos with (k := length l); eauto.
   Qed.
 
+  Lemma Forall2_nth_error {A B} (R : A -> B -> Prop) (l1 : list A) (l2 : list B) :
+    Forall2 R l1 l2 ->
+    forall n,
+      match nth_error l1 n, nth_error l2 n with
+      | Some a, Some b => R a b
+      | None, None => True
+      | _, _ => False
+      end.
+  Proof.
+    intros F; induction F; intros [| n]; cbn; auto.
+    apply IHF.
+  Qed.
+
+  Lemma Forall2_map_rel {A1 A2 B1 B2} (R : A1 -> A2 -> Prop) (R' : B1 -> B2 -> Prop)
+    (f : A1 -> B1) (g : A2 -> B2) :
+    (forall a b, R a b -> R' (f a) (g b)) ->
+    forall l1 l2, Forall2 R l1 l2 -> Forall2 R' (map f l1) (map g l2).
+  Proof.
+    intros HRR l1 l2 F; induction F; cbn; constructor; auto.
+  Qed.
+
 End Forall2.
 
 (** *** Interactions between monadic computations and lists *)

--- a/tests/llvm-arith/i32/shufflevector.ll
+++ b/tests/llvm-arith/i32/shufflevector.ll
@@ -1,0 +1,6 @@
+define <4 x i32> @shuffle_it() {
+  %r = shufflevector <4 x i32> <i32 10, i32 20, i32 30, i32 40>, <4 x i32> <i32 100, i32 200, i32 300, i32 400>, <4 x i32> <i32 0, i32 4, i32 3, i32 7>
+  ret <4 x i32> %r
+}
+
+; ASSERT EQ: <4 x i32> <i32 10, i32 100, i32 40, i32 400> = call <4 x i32> @shuffle_it()

--- a/tests/llvm-arith/i32/shufflevector.ll
+++ b/tests/llvm-arith/i32/shufflevector.ll
@@ -1,6 +1,30 @@
-define <4 x i32> @shuffle_it() {
-  %r = shufflevector <4 x i32> <i32 10, i32 20, i32 30, i32 40>, <4 x i32> <i32 100, i32 200, i32 300, i32 400>, <4 x i32> <i32 0, i32 4, i32 3, i32 7>
+; Examples from the LLVM LangRef's shufflevector section.
+
+define <4 x i32> @interleave(<4 x i32> %v1, <4 x i32> %v2) {
+  %r = shufflevector <4 x i32> %v1, <4 x i32> %v2,
+                      <4 x i32> <i32 0, i32 4, i32 1, i32 5>
   ret <4 x i32> %r
 }
 
-; ASSERT EQ: <4 x i32> <i32 10, i32 100, i32 40, i32 400> = call <4 x i32> @shuffle_it()
+define <4 x i32> @identity(<4 x i32> %v1) {
+  %r = shufflevector <4 x i32> %v1, <4 x i32> poison,
+                      <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x i32> %r
+}
+
+define <4 x i32> @narrow(<8 x i32> %v1) {
+  %r = shufflevector <8 x i32> %v1, <8 x i32> poison,
+                      <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x i32> %r
+}
+
+define <8 x i32> @widen(<4 x i32> %v1, <4 x i32> %v2) {
+  %r = shufflevector <4 x i32> %v1, <4 x i32> %v2,
+                      <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  ret <8 x i32> %r
+}
+
+; ASSERT EQ: <4 x i32> <i32 10, i32 100, i32 20, i32 200> = call <4 x i32> @interleave(<4 x i32> <i32 10, i32 20, i32 30, i32 40>, <4 x i32> <i32 100, i32 200, i32 300, i32 400>)
+; ASSERT EQ: <4 x i32> <i32 10, i32 20, i32 30, i32 40> = call <4 x i32> @identity(<4 x i32> <i32 10, i32 20, i32 30, i32 40>)
+; ASSERT EQ: <4 x i32> <i32 1, i32 2, i32 3, i32 4> = call <4 x i32> @narrow(<8 x i32> <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>)
+; ASSERT EQ: <8 x i32> <i32 10, i32 20, i32 30, i32 40, i32 100, i32 200, i32 300, i32 400> = call <8 x i32> @widen(<4 x i32> <i32 10, i32 20, i32 30, i32 40>, <4 x i32> <i32 100, i32 200, i32 300, i32 400>)


### PR DESCRIPTION
Same treatment to vector operations as many others by now: swapping `split` for a tail-rec (and linear)  `split_acc`.

Also added a straightforward implementation of `shuffle_vector` that was laying around as todo forever.