### PR TITLE
Fptrunc

### DIFF
--- a/src/rocq/Semantics/Operations/Conversion.v
+++ b/src/rocq/Semantics/Operations/Conversion.v
@@ -240,7 +240,10 @@ Section Convert.
         match t1, x, t2 with
         | DTYPE_FP FP_float, DVALUE_Float f, DTYPE_FP FP_double  =>
             ret (DVALUE_Double (float_to_double f))
-            
+
+        | DTYPE_FP FP_float, DVALUE_Poison t, DTYPE_FP FP_double =>
+            ret (dvp t2)
+           
         | _, _, _ => raise_error "ill-typed Fpext"
         end
 

--- a/src/rocq/Semantics/Operations/Conversion.v
+++ b/src/rocq/Semantics/Operations/Conversion.v
@@ -84,6 +84,26 @@ Section Convert.
   Program Definition float_to_double (f : ll_float) : ll_double :=
     Bconv _ _ _ _ eq_refl eq_refl (fun _ => default_nan_64) BinarySingleNaN.mode_NE f.
 
+  (* Floating point truncation *)
+  (* LANGREF: The ‘fptrunc’ instruction casts a value from a larger
+     floating-point type to a smaller floating-point type.  This instruction is
+     assumed to execute in the default floating-point environment.
+
+     NaN values follow the usual NaN behaviors, except that if a NaN payload is
+     propagated from the input (“Quieting NaN propagation” or “Unchanged NaN
+     propagation” cases), then the low order bits of the NaN payload which
+     cannot fit in the resulting type are discarded.
+
+     Same caveat as for [float_to_double], but worst:
+     unlike extension, truncation genuinely rounds, and we do not model the
+     non-default rounding modes.  [mode_NE] is the default environment's
+     round-to-nearest-ties-to-even.  As with [float_to_double], we do not
+     propagate NaN payloads: every NaN input yields the default quiet NaN
+     rather than the input's payload with its low bits dropped.
+   *)
+  Program Definition double_to_float (f : ll_double) : ll_float :=
+    Bconv _ _ _ _ eq_refl eq_refl (fun _ => default_nan_32) BinarySingleNaN.mode_NE f.
+
   (** ** Typed conversion
         Performs a dynamic conversion of a [dvalue] of type [t1] to one of type [t2].
         For instance, convert an integer over 8 bits to one over 1 bit by truncation.
@@ -224,8 +244,21 @@ Section Convert.
         | _, _, _ => raise_error "ill-typed Fpext"
         end
 
-    | Fptrunc _
-      => raise_error "TODO: unimplemented numeric conversion"
+    | Fptrunc _ =>
+        (* NOTE: Does not support "fast-math" flags *)
+        match t1, x, t2 with
+        (* [double] and [float] are the only floating-point types carried by
+           [dvalue_base], so double-to-float is the only narrowing there is.
+           In particular the LangRef's second example, [fptrunc double 1.0E+300
+           to half], is out of reach. *)
+        | DTYPE_FP FP_double, DVALUE_Double f, DTYPE_FP FP_float =>
+            ret (DVALUE_Float (double_to_float f))
+
+        | DTYPE_FP FP_double, DVALUE_Poison t, DTYPE_FP FP_float =>
+            ret (dvp t2)
+
+        | _, _, _ => raise_error "ill-typed Fptrunc"
+        end
     end.
   
   Arguments convert_pure_base _ _ _ _ : simpl nomatch.

--- a/tests/ll/fptrunc.ll
+++ b/tests/ll/fptrunc.ll
@@ -1,0 +1,40 @@
+; Examples from the LLVM LangRef's 'fptrunc .. to' Instruction section.
+; langref: fptrunc-to-instruction sha1=d1b341ea44c338cd913afd5cf077e4911db0d717
+;
+; LangRef 24.0.0git gives the following example(s):
+;
+; %X = fptrunc double 16777217.0 to float    ; yields float:16777216.0
+; %Y = fptrunc double 1.0E+300 to half       ; yields half:+infinity
+
+; 16777217 is not representable as a float; round-to-nearest-ties-to-even
+; brings it down to 16777216.
+define float @fptrunc_roundoff() {
+  %X = fptrunc double 16777217.0 to float
+  ret float %X
+}
+
+; The LangRef's second example targets half, which Vellvm does not model.
+; double -> float overflows in the same way: 1.0E+300 is beyond float's range,
+; so it rounds to +infinity.
+define float @fptrunc_overflow() {
+  %Y = fptrunc double 1.0E+300 to float
+  ret float %Y
+}
+
+; Exactly representable values are unchanged.
+define float @fptrunc_exact() {
+  %Z = fptrunc double 2.5 to float
+  ret float %Z
+}
+
+; Rounding happens on the way down, not truncation towards zero: the double
+; halfway between two floats goes to the one with the even significand.
+define float @fptrunc_ties_to_even() {
+  %W = fptrunc double 16777219.0 to float
+  ret float %W
+}
+
+; ASSERT EQ: float 16777216.0 = call float @fptrunc_roundoff()
+; ASSERT EQ: float 0x7FF0000000000000 = call float @fptrunc_overflow()
+; ASSERT EQ: float 2.5 = call float @fptrunc_exact()
+; ASSERT EQ: float 16777220.0 = call float @fptrunc_ties_to_even()


### PR DESCRIPTION
Implement a simple version of fptrunc, and fix a bug in fpext.

Both still do incorrect/incomplete things around NaN, to be addressed later.