### PR TITLE
Fixes to float arithmetic

### DIFF
--- a/src/rocq/Semantics/IntrinsicsDefinitions.v
+++ b/src/rocq/Semantics/IntrinsicsDefinitions.v
@@ -215,7 +215,7 @@ Definition maxnum_32_decl: declaration typ :=
 
 Definition minimum_32_decl: declaration typ :=
   {|
-    dc_name        := Name "minimum.f32";
+    dc_name        := Name "llvm.minimum.f32";
     dc_type        := TYPE_Function (TYPE_FP FP_float) [(TYPE_FP FP_float);(TYPE_FP FP_float)] false;
     dc_param_attrs := ([], [[];[]]);
     dc_attrs       := [];
@@ -386,34 +386,81 @@ Section Intrinsics.
   (* Intrinsics semantic functions -------------------------------------------- *)
 
   #[local] Notation retr x := (ret (inr x)).
+  (* LANGREF: [llvm.fabs] is explicitly *not* a "floating-point math
+     operation": it "acts directly on the underlying bit representation and
+     never changes anything except possibly for the sign bit".  So its result
+     on a NaN is fully determined -- the payload and quiet bit are preserved
+     and the sign is cleared -- with none of the non-determinism that applies
+     to NaN results of genuine math operations.
+
+     [Float.abs] / [Float32.abs] are [Babs] instantiated with [abs_nan], which
+     clears the sign.  Flocq's [b64_abs] / [b32_abs] instead use [unop_nan_pl],
+     which returns the NaN completely unchanged, sign included -- so
+     [llvm.fabs(-NaN)] used to come back negative. *)
+
   (* Absolute value for Float. *)
   Definition llvm_fabs_f32 : pure_base_function :=
     fun args =>
       match args with
-      | [DVALUE_Float d] => retr (DVALUE_Float (b32_abs d))
-      | _ => raise_error "llvm_fabs_f64 got incorrect / ill-typed inputs"
+      | [DVALUE_Float d] => retr (DVALUE_Float (Float32.abs d))
+      | _ => raise_error "llvm_fabs_f32 got incorrect / ill-typed inputs"
       end.
 
   (* Abosulute value for Doubles. *)
   Definition llvm_fabs_f64 : pure_base_function :=
     fun args =>
       match args with
-      | [DVALUE_Double d] => retr (DVALUE_Double (b64_abs d))
+      | [DVALUE_Double d] => retr (DVALUE_Double (Float.abs d))
       | _ => raise_error "llvm_fabs_f64 got incorrect / ill-typed inputs"
       end.
 
+  (* Is a NaN payload quiet?  The quiet bit is the top bit of the significand:
+     bit 51 for binary64, bit 22 for binary32. *)
+  Definition quiet_nan_pl64 (pl : positive) : bool := Pos.testbit pl 51%N.
+  Definition quiet_nan_pl32 (pl : positive) : bool := Pos.testbit pl 22%N.
+
+  (* LANGREF (llvm.maxnum): "If both operands are qNaNs, returns a NaN. If one
+     operand is qNaN and another operand is a number, returns the number. If
+     both operands are numbers, returns the greater of the two arguments. -0.0
+     is considered to be less than +0.0 for this intrinsic."
+
+     Note that a qNaN operand does *not* propagate -- returning the qNaN, as we
+     used to, is simply wrong, not a permitted resolution of NaN
+     non-determinism.
+
+     For a *signaling* NaN operand the LangRef does leave the result
+     non-deterministic: the intrinsic may "return a NaN" or "treat the
+     signaling NaN as a quiet NaN".  We resolve that by returning a NaN, which
+     keeps the sNaN behaviour the tests in tests/llvm-arith/double already pin
+     down.  Once NaN choices become draw events this is the branch point.
+
+     The [Ceq] case is what implements "-0.0 is less than +0.0": for equal
+     non-zero operands either answer is the same value, and for the +0.0/-0.0
+     pair it picks the positive one regardless of argument order. *)
   Definition Float_maxnum (a b: float): float :=
     match a, b with
-    | B754_nan _ _ _, _ | _, B754_nan _ _ _ => build_nan _ _ (binop_nan_pl64 a b)
+    | B754_nan _ _ _, B754_nan _ _ _ => build_nan _ _ (binop_nan_pl64 a b)
+    | B754_nan _ pl _, _ =>
+        if quiet_nan_pl64 pl then b else build_nan _ _ (binop_nan_pl64 a b)
+    | _, B754_nan _ pl _ =>
+        if quiet_nan_pl64 pl then a else build_nan _ _ (binop_nan_pl64 a b)
     | _, _ =>
-      if Float.cmp Clt a b then b else a
+      if Float.cmp Ceq a b
+      then (if Bsign _ _ a then b else a)
+      else (if Float.cmp Clt a b then b else a)
     end.
 
   Definition Float32_maxnum (a b: float32): float32 :=
     match a, b with
-    | B754_nan _ _ _, _ | _, B754_nan _ _ _ => build_nan _ _ (binop_nan_pl32 a b)
+    | B754_nan _ _ _, B754_nan _ _ _ => build_nan _ _ (binop_nan_pl32 a b)
+    | B754_nan _ pl _, _ =>
+        if quiet_nan_pl32 pl then b else build_nan _ _ (binop_nan_pl32 a b)
+    | _, B754_nan _ pl _ =>
+        if quiet_nan_pl32 pl then a else build_nan _ _ (binop_nan_pl32 a b)
     | _, _ =>
-      if Float32.cmp Clt a b then b else a
+      if Float32.cmp Ceq a b
+      then (if Bsign _ _ a then b else a)
+      else (if Float32.cmp Clt a b then b else a)
     end.
 
   Definition llvm_maxnum_f64 : pure_base_function :=
@@ -430,18 +477,28 @@ Section Intrinsics.
       | _ => raise_error "llvm_maxnum_f32 got incorrect / ill-typed inputs"
       end.
 
+  (* LANGREF (llvm.minimum): "If either operand is a NaN, returns a NaN.
+     Otherwise returns the lesser of the two arguments. -0.0 is considered to
+     be less than +0.0 for this intrinsic."
+
+     Unlike [llvm.maxnum], propagating a NaN operand is the specified
+     behaviour, so only the signed-zero case needed fixing here. *)
   Definition Float_minimum (a b: float): float :=
     match a, b with
     | B754_nan _ _ _, _ | _, B754_nan _ _ _ => build_nan _ _ (binop_nan_pl64 a b)
     | _, _ =>
-      if Float.cmp Clt a b then a else b
+      if Float.cmp Ceq a b
+      then (if Bsign _ _ a then a else b)
+      else (if Float.cmp Clt a b then a else b)
     end.
 
   Definition Float32_minimum (a b: float32): float32 :=
     match a, b with
     | B754_nan _ _ _, _ | _, B754_nan _ _ _ => build_nan _ _ (binop_nan_pl32 a b)
     | _, _ =>
-      if Float32.cmp Clt a b then a else b
+      if Float32.cmp Ceq a b
+      then (if Bsign _ _ a then a else b)
+      else (if Float32.cmp Clt a b then a else b)
     end.
 
   Definition llvm_minimum_f64 : pure_base_function :=

--- a/src/rocq/Semantics/Operations/Conversion.v
+++ b/src/rocq/Semantics/Operations/Conversion.v
@@ -66,10 +66,6 @@ Section Convert.
  *)
   
   (* Floating point extension *)
-  (* SAZ: I'm not sure that this implementation does the right thing
-     with respect to the rounding mode (maybe not a problem for extension)
-     and NAN propagation.
-   *)
   (* LANGREF: The ‘fpext’ instruction extends the value from a smaller
      floating-point type to a larger floating-point type. The fpext cannot be
      used to make a no-op cast because it always changes bits. Use bitcast to
@@ -80,9 +76,19 @@ Section Convert.
      propagation” cases), then it is copied to the high order bits of the
      resulting payload, and the remaining low order bits are zero.
 
+     [Float.of_single] is [Bconv] instantiated with [Float.of_single_nan],
+     which implements exactly the rule above: [expand_nan_payload] shifts the
+     source payload left by 29 bits, putting it in the high order bits of the
+     result and zeroing the rest.  Rolling our own [conv_nan] here instead
+     (which is what we used to do) flattens every NaN to the default one:
+     legal, since the "Preferred NaN" case is always an option, but needlessly
+     lossy and inconsistent with what the binops do.
+
+     Note that [of_single_nan] consults [Archi.float_of_single_preserves_sNaN],
+     which we set to [true]: a signaling NaN stays signaling across [fpext].
+     That is the "Unchanged NaN propagation" case, and is legal.
    *)
-  Program Definition float_to_double (f : ll_float) : ll_double :=
-    Bconv _ _ _ _ eq_refl eq_refl (fun _ => default_nan_64) BinarySingleNaN.mode_NE f.
+  Definition float_to_double : ll_float -> ll_double := Float.of_single.
 
   (* Floating point truncation *)
   (* LANGREF: The ‘fptrunc’ instruction casts a value from a larger
@@ -94,15 +100,19 @@ Section Convert.
      propagation” cases), then the low order bits of the NaN payload which
      cannot fit in the resulting type are discarded.
 
-     Same caveat as for [float_to_double], but worst:
-     unlike extension, truncation genuinely rounds, and we do not model the
-     non-default rounding modes.  [mode_NE] is the default environment's
-     round-to-nearest-ties-to-even.  As with [float_to_double], we do not
-     propagate NaN payloads: every NaN input yields the default quiet NaN
-     rather than the input's payload with its low bits dropped.
+     [Float.to_single] is [Bconv] instantiated with [Float.to_single_nan],
+     which implements exactly the rule above: [reduce_nan_payload] shifts the
+     source payload right by 29 bits, discarding the low order bits that do not
+     fit.  It quiets the payload *before* the shift, which is precisely what
+     stops the shift from producing the all-zero payload the LangRef warns
+     about (an all-zero payload with the quiet bit clear would denote an
+     infinity, not a NaN).
+
+     Caveat inherited from [float_to_double]: unlike extension, truncation
+     genuinely rounds, and we do not model the non-default rounding modes.
+     [mode_NE] is the default environment's round-to-nearest-ties-to-even.
    *)
-  Program Definition double_to_float (f : ll_double) : ll_float :=
-    Bconv _ _ _ _ eq_refl eq_refl (fun _ => default_nan_32) BinarySingleNaN.mode_NE f.
+  Definition double_to_float : ll_double -> ll_float := Float.to_single.
 
   (** ** Typed conversion
         Performs a dynamic conversion of a [dvalue] of type [t1] to one of type [t2].

--- a/src/rocq/Theory/I2F/I2F_interp.v
+++ b/src/rocq/Theory/I2F/I2F_interp.v
@@ -279,7 +279,7 @@ Proof.
     [ simp I2FA_Intrinsic; apply I2F_pure_base_to_semantic; [apply I2F_llvm_maxnum_f32 | exact Hargs] | ].
   destruct (RelDec.rel_dec f2 "llvm.maxnum.f64");
     [ simp I2FA_Intrinsic; apply I2F_pure_base_to_semantic; [apply I2F_llvm_maxnum_f64 | exact Hargs] | ].
-  destruct (RelDec.rel_dec f2 "minimum.f32");
+  destruct (RelDec.rel_dec f2 "llvm.minimum.f32");
     [ simp I2FA_Intrinsic; apply I2F_pure_base_to_semantic; [apply I2F_llvm_minimum_f32 | exact Hargs] | ].
   destruct (RelDec.rel_dec f2 "llvm.minimum.f64");
     [ simp I2FA_Intrinsic; apply I2F_pure_base_to_semantic; [apply I2F_llvm_minimum_f64 | exact Hargs] | ].

--- a/tests/llvm-arith/double/fabs_nan.ll
+++ b/tests/llvm-arith/double/fabs_nan.ll
@@ -1,0 +1,56 @@
+; LANGREF: llvm.fabs is not a "floating-point math operation" -- it "acts
+; directly on the underlying bit representation and never changes anything
+; except possibly for the sign bit".  So on a NaN input the result is fully
+; determined: quiet bit and payload preserved, sign cleared.
+;
+; Discriminates the old implementation, which used Flocq's b64_abs/b32_abs
+; (whose unop_nan_pl returns the NaN unchanged, sign included) and so returned
+; a *negative* NaN here.  The results are bitcast to integers because a
+; comparison on the float values themselves cannot see a sign bit on a NaN.
+
+declare double @llvm.fabs.f64(double)
+declare float @llvm.fabs.f32(float)
+
+; -qNaN with a non-zero payload: sign cleared, payload kept.
+define i64 @fabs_neg_qnan() {
+  %a = call double @llvm.fabs.f64(double 0xFFF8000000000123)
+  %b = bitcast double %a to i64
+  ret i64 %b
+}
+
+; Already positive: unchanged.
+define i64 @fabs_pos_qnan() {
+  %a = call double @llvm.fabs.f64(double 0x7FF8000000000123)
+  %b = bitcast double %a to i64
+  ret i64 %b
+}
+
+; -sNaN: the quiet bit must not be set either -- fabs is not a math operation,
+; so it may not quiet its argument.
+define i64 @fabs_neg_snan() {
+  %a = call double @llvm.fabs.f64(double 0xFFF0000000000123)
+  %b = bitcast double %a to i64
+  ret i64 %b
+}
+
+; Ordinary negative value, for contrast.
+define double @fabs_neg_number() {
+  %a = call double @llvm.fabs.f64(double -2.5)
+  ret double %a
+}
+
+; Same story at single precision.  Here we look at the sign bit directly rather
+; than at the whole word, so the test does not depend on how the frontend
+; narrows the (double-encoded) NaN literal to a float.
+define i32 @fabs_neg_qnan_f32_sign() {
+  %a = call float @llvm.fabs.f32(float 0xFFF8024600000000)
+  %b = bitcast float %a to i32
+  %s = lshr i32 %b, 31
+  ret i32 %s
+}
+
+; ASSERT EQ: i64 9221120237041090851 = call i64 @fabs_neg_qnan()
+; ASSERT EQ: i64 9221120237041090851 = call i64 @fabs_pos_qnan()
+; ASSERT EQ: i64 9218868437227405603 = call i64 @fabs_neg_snan()
+; ASSERT EQ: double 2.5 = call double @fabs_neg_number()
+; ASSERT EQ: i32 0 = call i32 @fabs_neg_qnan_f32_sign()

--- a/tests/llvm-arith/double/fpext_fptrunc_nan.ll
+++ b/tests/llvm-arith/double/fpext_fptrunc_nan.ll
@@ -1,0 +1,51 @@
+; LANGREF: on fpext, "if a NaN payload is propagated from the input [...] it is
+; copied to the high order bits of the resulting payload, and the remaining low
+; order bits are zero".  On fptrunc, "the low order bits of the NaN payload
+; which cannot fit in the resulting type are discarded".
+;
+; Discriminates the old float_to_double / double_to_float, which rolled their
+; own conv_nan returning a constant, and so flattened every NaN to the default
+; one -- legal (the "Preferred NaN" case is always an option) but lossy, and
+; inconsistent with the binops, which propagate.
+;
+; float has a 23-bit significand and double a 52-bit one, so the payload shift
+; is by 29 bits in both directions.
+
+; A float qNaN whose payload is 1 (bit 0 set) widens to a double qNaN whose
+; payload is 1 << 29.
+define i64 @fpext_payload() {
+  %f = bitcast i32 2143289345 to float          ; 0x7FC00001, qNaN payload 1
+  %d = fpext float %f to double
+  %b = bitcast double %d to i64
+  ret i64 %b
+}
+
+; The reverse trip narrows it back.
+define i32 @fptrunc_payload() {
+  %d = bitcast i64 9221120237577961472 to double ; 0x7FF8000020000000
+  %f = fptrunc double %d to float
+  %b = bitcast float %f to i32
+  ret i32 %b
+}
+
+; Payload bits that do not fit are discarded, not rounded: the low 29 bits go.
+define i32 @fptrunc_discards_low_bits() {
+  %d = bitcast i64 9221120237577961473 to double ; 0x7FF8000020000001
+  %f = fptrunc double %d to float
+  %b = bitcast float %f to i32
+  ret i32 %b
+}
+
+; When every payload bit falls off the bottom, the result is the preferred
+; quiet NaN rather than an infinity -- the LangRef calls this case out.
+define i32 @fptrunc_payload_vanishes() {
+  %d = bitcast i64 9221120237041090851 to double ; 0x7FF8000000000123
+  %f = fptrunc double %d to float
+  %b = bitcast float %f to i32
+  ret i32 %b
+}
+
+; ASSERT EQ: i64 9221120237577961472 = call i64 @fpext_payload()
+; ASSERT EQ: i32 2143289345 = call i32 @fptrunc_payload()
+; ASSERT EQ: i32 2143289345 = call i32 @fptrunc_discards_low_bits()
+; ASSERT EQ: i32 2143289344 = call i32 @fptrunc_payload_vanishes()

--- a/tests/llvm-arith/double/max1.ll
+++ b/tests/llvm-arith/double/max1.ll
@@ -1,10 +1,12 @@
 declare double @llvm.maxnum.f64(double, double) #0
 
-; 1st argument is qNaN
+; 1st argument is qNaN.  LANGREF: "If one operand is qNaN and another
+; operand is a number, returns the number."  This file previously asserted the
+; qNaN, pinning down a bug in Float_maxnum.
 define double @main(i8 %argc, i8** %arcv) {
   %1 = call double @llvm.maxnum.f64(double 0x7FF8000000000000, double 2.0)
   ret double %1
 }
 
-; ASSERT EQ: double 0x7FF8000000000000 = call double @main(i64 0, i8** null)
+; ASSERT EQ: double 2.0 = call double @main(i64 0, i8** null)
 

--- a/tests/llvm-arith/double/max2.ll
+++ b/tests/llvm-arith/double/max2.ll
@@ -1,10 +1,12 @@
 declare double @llvm.maxnum.f64(double, double) #0
 
-; 2nd argument is qNaN
+; 2nd argument is qNaN.  LANGREF: "If one operand is qNaN and another
+; operand is a number, returns the number."  This file previously asserted the
+; qNaN, pinning down a bug in Float_maxnum.
 define double @main(i8 %argc, i8** %arcv) {
   %1 = call double @llvm.maxnum.f64(double 1.0, double 0x7FF8000000000000)
   ret double %1
 }
 
-; ASSERT EQ: double 0x7FF8000000000000 = call double @main(i64 0, i8** null)
+; ASSERT EQ: double 1.0 = call double @main(i64 0, i8** null)
 

--- a/tests/llvm-arith/double/maxnum_qnan.ll
+++ b/tests/llvm-arith/double/maxnum_qnan.ll
@@ -1,0 +1,51 @@
+; LANGREF (llvm.maxnum): "If both operands are qNaNs, returns a NaN. If one
+; operand is qNaN and another operand is a number, returns the number."
+;
+; Discriminates the old implementation, which returned a NaN as soon as either
+; operand was a NaN.  Note this is not a case of NaN non-determinism: with a
+; qNaN operand the LangRef fixes the answer to be the *number*.
+;
+; The sNaN cases are the ones the LangRef does leave non-deterministic ("return
+; a NaN" or "treat the sNaN as a quiet NaN"); we resolve them by returning a
+; NaN, which is what max3.ll / max4.ll pin down.
+
+declare double @llvm.maxnum.f64(double, double)
+declare float @llvm.maxnum.f32(float, float)
+
+define double @qnan_first() {
+  %r = call double @llvm.maxnum.f64(double 0x7FF8000000000000, double 2.0)
+  ret double %r
+}
+
+define double @qnan_second() {
+  %r = call double @llvm.maxnum.f64(double 1.0, double 0x7FF8000000000000)
+  ret double %r
+}
+
+; A qNaN carrying a payload is still just a qNaN: the number wins.
+define double @qnan_payload_first() {
+  %r = call double @llvm.maxnum.f64(double 0x7FF8000000000123, double -3.5)
+  ret double %r
+}
+
+; Both qNaN: a NaN is returned.
+define i64 @qnan_both() {
+  %r = call double @llvm.maxnum.f64(double 0x7FF8000000000123, double 0x7FF8000000000456)
+  %b = bitcast double %r to i64
+  ret i64 %b
+}
+
+; The qNaN is built by bitcast rather than written as a literal: the frontend
+; does not preserve quietness when it narrows a NaN literal to float (it turns
+; this qNaN into an sNaN), and an sNaN operand would take the other branch.
+define float @qnan_first_f32() {
+  %n = bitcast i32 2143289344 to float          ; 0x7FC00000, preferred qNaN
+  %r = call float @llvm.maxnum.f32(float %n, float 2.0)
+  ret float %r
+}
+
+; ASSERT EQ: double 2.0 = call double @qnan_first()
+; ASSERT EQ: double 1.0 = call double @qnan_second()
+; ASSERT EQ: double -3.5 = call double @qnan_payload_first()
+; ASSERT EQ: i64 9221120237041090851 = call i64 @qnan_both()
+; ASSERT EQ: float 2.0 = call float @qnan_first_f32()

--- a/tests/llvm-arith/double/minmax_signed_zero.ll
+++ b/tests/llvm-arith/double/minmax_signed_zero.ll
@@ -1,0 +1,53 @@
+; LANGREF: for both llvm.maxnum and llvm.minimum, "-0.0 is considered to be
+; less than +0.0 for this intrinsic".  So maxnum(-0.0, +0.0) is +0.0 and
+; minimum(-0.0, +0.0) is -0.0, in either argument order.
+;
+; Discriminates the old implementations, which decided with a bare
+; `cmp Clt`: since -0.0 and +0.0 compare equal under IEEE ordering, the answer
+; degenerated to "the first argument", which is right in one order and wrong in
+; the other.  Results are bitcast to integers because +0.0 and -0.0 compare
+; equal as floats -- the sign bit is exactly what is under test.
+
+declare double @llvm.maxnum.f64(double, double)
+declare double @llvm.minimum.f64(double, double)
+declare float @llvm.minimum.f32(float, float)
+
+define i64 @max_neg_pos() {
+  %r = call double @llvm.maxnum.f64(double -0.0, double 0.0)
+  %b = bitcast double %r to i64
+  ret i64 %b
+}
+
+define i64 @max_pos_neg() {
+  %r = call double @llvm.maxnum.f64(double 0.0, double -0.0)
+  %b = bitcast double %r to i64
+  ret i64 %b
+}
+
+define i64 @min_neg_pos() {
+  %r = call double @llvm.minimum.f64(double -0.0, double 0.0)
+  %b = bitcast double %r to i64
+  ret i64 %b
+}
+
+define i64 @min_pos_neg() {
+  %r = call double @llvm.minimum.f64(double 0.0, double -0.0)
+  %b = bitcast double %r to i64
+  ret i64 %b
+}
+
+; llvm.minimum.f32 was registered under the name "minimum.f32", without the
+; "llvm." prefix, so calls to it never resolved to the intrinsic.  This
+; exercises the f32 variant at all.
+define i32 @min_f32_neg_pos() {
+  %r = call float @llvm.minimum.f32(float -0.0, float 0.0)
+  %b = bitcast float %r to i32
+  ret i32 %b
+}
+
+; +0.0 is 0; -0.0 is the sign bit alone.
+; ASSERT EQ: i64 0 = call i64 @max_neg_pos()
+; ASSERT EQ: i64 0 = call i64 @max_pos_neg()
+; ASSERT EQ: i64 -9223372036854775808 = call i64 @min_neg_pos()
+; ASSERT EQ: i64 -9223372036854775808 = call i64 @min_pos_neg()
+; ASSERT EQ: i32 -2147483648 = call i32 @min_f32_neg_pos()


### PR DESCRIPTION
This patch fixes a few issues in float operations.

## fpext/fptrunc

Trying to comply with langref requirement on NaN:
```
NaN values follow the usual [NaN behaviors](https://llvm.org/docs/LangRef.html#floatnan), except that if a NaN payload is propagated from the input (“Quieting NaN propagation” or “Unchanged NaN propagation” cases), then it is copied to the high order bits of the resulting payload, and the remaining low order bits are zero.
```

The story is still fuzzy as to this requirement of copying bits is the fact that the choice of NaN propagation is non-deterministic (see https://llvm.org/docs/LangRef.html#floatnan) which we don't yet model. But at least this way the interpret has trunc/exp be inverse over NaN.

## Incorrectly registered intrinsics

minimum.f32 was simply incorrectly registered in the intrinsics.

## fabs

Explicitly required to preserve quiet/signaling bit and payload over NaN (see https://llvm.org/docs/LangRef.html#llvm-fabs-intrinsic), while we cleared it.

## Float_maxnum/Float32_maxnum:

The logic over quiet/signaling bits for NaN is explicitly intrincate (see https://llvm.org/docs/LangRef.html#llvm-maxnum-intrinsic). We still don't model the non-deterministic part but at least pick a compliant choice now.

Furthermore, it is made explicit that: `"-0.0 is considered to be less than +0.0", which we didn't correctly handle.