### PR TITLE
Fix to float_to_float32 against NaN

### DIFF
--- a/src/rocq/Numeric/Floats.v
+++ b/src/rocq/Numeric/Floats.v
@@ -38,8 +38,13 @@ Definition is_float_representable_as_float32 (f : binary_float 53 1024) : bool :
   match f with
   | B754_zero _ => true
   | B754_infinity _ => true
-  (* IEEE-754 defines a specific injection, which is all we care about? *)
-  | B754_nan _ _ _ => true
+  (* A NaN is NOT automatically representable: LLVM applies the exactness rule to
+     the payload too.  [m] is the raw 52-bit mantissa field, and narrowing keeps
+     only its high 23 bits, so the low 29 must be zero.  Checked against clang:
+     [float 0x7FF0000020000000] is accepted (payload 2^29) whereas
+     [float 0x7FF0000000000001] is rejected with "floating point constant invalid
+     for type". *)
+  | B754_nan _ m _ => (Z.pos m mod 2^29 =? 0)%Z
   | B754_finite s m e_minus_52 _ =>
       (* Flocq stores the exponents offset by some amount, 52 for float64 *)
       let e := e_minus_52 + 52 in
@@ -65,13 +70,6 @@ Definition is_float_representable_as_float32 (f : binary_float 53 1024) : bool :
       (-149 <=? e)%Z && (e <=? 127)%Z
       && ((Z.pos m mod Z.pow 2 53) mod 2^necessary_mantissa_zero_bits =? 0)%Z
   end.
-
-(** Converts a 64-bit float value to a 32-bit float, or fails if not exactly representable *)
-Definition float_to_float32 (f : float) : option float32 :=
-  if is_float_representable_as_float32 f
-  then Some (Bconv 53 1024 24 128 eq_refl eq_refl
-        (fun f => exist _ (B754_nan 24 128 false 1 eq_refl) eq_refl) mode_NE f)
-  else None.
 
 Lemma integer_representable_n :
   forall n : Z, - 2 ^ 53 <= n <= 2 ^ 53 -> integer_representable 53 1024 n.
@@ -186,6 +184,38 @@ Definition quiet_nan_32 (sp: bool * positive) : {x :float32 | is_nan _ _ x = tru
   exist _ (B754_nan 24 128 s (quiet_nan_32_payload p) (quiet_nan_32_proof p)) (eq_refl true).
 
 Definition default_nan_32 := quiet_nan_32 Archi.default_nan_32.
+
+(** Narrowing a NaN payload without quieting it, for the [float 0x...] literal
+    form.  This is [quiet_nan_32_payload] minus the [Pos.lor] with the quiet bit:
+    LLVM's assembler reads the 16-digit hex form as a *double bit pattern* that
+    must be exactly representable as a float, and the resulting float is the
+    plain bit-level reshaping — sign kept, mantissa field shifted right by 29,
+    quiet bit NOT forced.  Verified against clang:
+    [float 0x7FF0000020000000] yields the *signaling* [0x7F800001], so this is
+    deliberately NOT [Float.to_single], whose [to_single_nan] quiets. *)
+
+Definition narrow_nan_32_payload (p: positive) :=
+  Z.to_pos (P_mod_two_p (Pos.shiftr_nat p 29) 23%nat).
+
+Lemma narrow_nan_32_proof: forall p, nan_pl 24 (narrow_nan_32_payload p) = true.
+Proof. intros; apply normalized_nan; auto; lia. Qed.
+
+Definition narrow_nan_32 (f : float) : {x : float32 | is_nan _ _ x = true} :=
+  match f with
+  | B754_nan s p _ =>
+      exist _ (B754_nan 24 128 s (narrow_nan_32_payload p) (narrow_nan_32_proof p)) (eq_refl true)
+  | _ => default_nan_32
+  end.
+
+(** Converts a 64-bit float value to a 32-bit float, or fails if not exactly
+    representable.  The [is_float_representable_as_float32] guard makes the
+    conversion lossless on every branch it accepts, including the NaN one, where
+    it guarantees that the low 29 payload bits discarded by [narrow_nan_32] are
+    zero. *)
+Definition float_to_float32 (f : float) : option float32 :=
+  if is_float_representable_as_float32 f
+  then Some (Bconv 53 1024 24 128 eq_refl eq_refl narrow_nan_32 mode_NE f)
+  else None.
 
 Local Notation __ := (eq_refl Datatypes.Lt).
 

--- a/tests/llvm-arith/float/hex_nan_literal.ll
+++ b/tests/llvm-arith/float/hex_nan_literal.ll
@@ -1,0 +1,85 @@
+; LANGREF: the [float 0x<16 hex digits>] literal form is *not* a floating-point
+; math operation, so none of the NaN non-determinism applies to it.  The 16
+; digits are a double bit pattern which the assembler requires to be exactly
+; representable as a float, and the value is the plain bit-level reshaping of
+; that pattern: sign kept, 52-bit mantissa field shifted right by 29, quiet bit
+; taken from the input rather than forced.  Every expected value below was read
+; off `clang -O2` constant-folding the same bitcast.
+;
+; Discriminates the old implementation, whose double->float narrowing
+; (float_to_float32, Numeric/Floats.v) passed Bconv a conv_nan that DISCARDED
+; its argument and returned the constant B754_nan 24 128 false 1 -- so every
+; NaN literal, whatever its sign, payload or quiet bit, came out as
+; 0x7F800001.  Note also that the right fix is not Float.to_single: its
+; to_single_nan quiets, which @snan_payload below would catch.
+
+; Quiet NaN, zero payload -- the common case.  Old code: 0x7F800001.
+define i32 @qnan() {
+  %a = bitcast float 0x7FF8000000000000 to i32
+  ret i32 %a
+}
+
+; The sign must survive.  Old code dropped it (conv_nan hardcoded sign=false).
+define i32 @neg_qnan() {
+  %a = bitcast float 0xFFF8000000000000 to i32
+  ret i32 %a
+}
+
+; A *signaling* NaN whose payload (2^29) survives the 29-bit truncation, so
+; LLVM accepts it.  The result stays signaling: 0x7F800001, not 0x7FC00001.
+; This is the case that pins "no quieting" and rules out Float.to_single.
+define i32 @snan_payload() {
+  %a = bitcast float 0x7FF0000020000000 to i32
+  ret i32 %a
+}
+
+; Widest payload that survives the shift: every mantissa bit above the low 29.
+define i32 @max_payload() {
+  %a = bitcast float 0x7FFFFFFFE0000000 to i32
+  ret i32 %a
+}
+
+; Negative signaling NaN: sign kept, quiet bit still clear.
+define i32 @neg_snan() {
+  %a = bitcast float 0xFFF4000000000000 to i32
+  ret i32 %a
+}
+
+; For contrast: the double path never narrows, so the pattern is verbatim.
+; This one was already correct (Float.of_bits, no conversion involved).
+define i64 @qnan_double() {
+  %a = bitcast double 0x7FF8000000000000 to i64
+  ret i64 %a
+}
+
+; An ordinary finite literal that is exactly representable, to check the fix did
+; not disturb the non-NaN path.  0x3FF4CCCCC0000000 is 1.3f widened to double.
+define i32 @finite_exact() {
+  %a = bitcast float 0x3FF4CCCCC0000000 to i32
+  ret i32 %a
+}
+
+; Payload bit 0 does not survive the 29-bit truncation, so this literal is not
+; exactly representable and must be rejected -- clang: "floating point constant
+; invalid for type".  The old representability check exempted NaNs outright and
+; silently produced 0x7F800001 here.
+define i32 @snan_payload_lost() {
+  %a = bitcast float 0x7FF0000000000001 to i32
+  ret i32 %a
+}
+
+; The same rule on a finite value: the true double 1.3 is not an f32.
+define i32 @finite_inexact() {
+  %a = bitcast float 0x3FF4CCCCCCCCCCCD to i32
+  ret i32 %a
+}
+
+; ASSERT EQ: i32 2143289344 = call i32 @qnan()
+; ASSERT EQ: i32 4290772992 = call i32 @neg_qnan()
+; ASSERT EQ: i32 2139095041 = call i32 @snan_payload()
+; ASSERT EQ: i32 2147483647 = call i32 @max_payload()
+; ASSERT EQ: i32 4288675840 = call i32 @neg_snan()
+; ASSERT EQ: i64 9221120237041090560 = call i64 @qnan_double()
+; ASSERT EQ: i32 1067869798 = call i32 @finite_exact()
+; ASSERT FAILS: call i32 @snan_payload_lost()
+; ASSERT FAILS: call i32 @finite_inexact()


### PR DESCRIPTION
LangRef specifies for bitcast:

> The ‘bitcast’ instruction converts value to type ty2. It is always a no-op cast because no bits change with this conversion. The conversion is done as if the value had been stored to memory and read back as type ty2.

This was not respected for NaNs: CompCert's inherited `float_to_float32` would both accept too many representable values, and systematically convert any valid NaN to the same one.

I am not sure if/when we would actually observe this subtle difference, but it complies with clang (better at least) this way, added a bunch of tests by Claude with it.