### PR TITLE
Possible patch for parsing of floats, debatable

### DIFF
--- a/src/rocq/Semantics/VellvmFloats.v
+++ b/src/rocq/Semantics/VellvmFloats.v
@@ -52,10 +52,7 @@ Class VFloat FP : Type :=
    Bparse 24 128 __ __ base intPart expPart.
  *) 
 
-(* Converts a syntactic floating point value to a float32
-   SAZ: not sure whether the "parsed" conversion is correct
-    it maybe should fail if the number isn't exactly representable.
- *)
+(* Converts a syntactic floating point value to a float32. *)
 (* semantic comparison of uint and zero - inlined below to give better proofs. *)
 Definition uint_is_zero (us:Decimal.uint) : bool :=
   match Pos.of_uint us with
@@ -65,10 +62,10 @@ Definition uint_is_zero (us:Decimal.uint) : bool :=
 
 Definition xx := Decimal.D1 (Decimal.D2 (Decimal.D3 Decimal.Nil)).
 
-
 (*
-   The following function creates a float32 from a parsed representation of a
-   floating point value, which is a *positive* number of the form:
+   The following function creates a [float] (a 64-bit double) from a parsed
+   representation of a floating point value, which is a *positive* number of the
+   form:
       "xs.ys e exp"
    where [xs] is the integral part [ys] is the fractional part and [exp] is the exponent.
 
@@ -89,49 +86,12 @@ Definition xx := Decimal.D1 (Decimal.D2 (Decimal.D3 Decimal.Nil)).
 
     Negative floating point values are handled later by flipping the sign bit.
  *)
-Definition positive_decimal_decimal_signed_to_float32 (xs ys : Decimal.uint) (exp:Decimal.signed_int) : float32 :=
-  match Pos.of_uint xs with
-  | N0 =>
-      (* xs is 0 *)
-      match Pos.of_uint ys with
-      | N0 => (* ys is 0 *)
-          (* 000.000 *)
-          Float32.zero
-      | Npos yyy =>
-          (* 000.123e^exp = yyy * 10^(exp -|yyy|) *)
-          Float32.from_parsed 10 yyy (BinInt.Z.sub (BinInt.Z.of_int exp) (IntDef.Z.of_nat (Decimal.nb_digits ys)))
-      end          
-  | Npos xxx =>
-      match Pos.of_uint ys with
-      | N0 =>
-          (* 12.000 * 10^exp *)
-          Float32.from_parsed 10 xxx (BinInt.Z.of_int exp)
-      | Npos yyy =>
-          (* 12.345 = 12345 * 10^(exp -|yyy|) *)
-          match BinNat.N.of_nat (Decimal.nb_digits ys) with
-          | N0 => Float32.zero (* Should not happen since Pos.of_uint <> N0 *)
-          | Npos ypos =>
-              let xxx_shifted := Pos.mul xxx (pos_pow 10 ypos) in
-              let total := Pos.add xxx_shifted yyy in 
-              Float32.from_parsed 10 total (BinInt.Z.sub (BinInt.Z.of_int exp) (IntDef.Z.of_nat (Decimal.nb_digits ys)))
-          end
-      end
-  end.
-
-
-(* Same as above, but with the exponent set to 0, so that we get 123.4565 *)
-Definition positive_decimal_decimal_to_float32 (xs ys : Decimal.uint) : float32 :=
-  positive_decimal_decimal_signed_to_float32 xs ys (Nat.to_int 0).
-
 (* SAZ: I'm worried that this is going to be too inefficient for the interpreter. *)
-
-(*
-Eval vm_compute in (positive_decimal_decimal_to_float32 (Decimal.D0 Decimal.Nil) xx).
-Eval vm_compute in (positive_decimal_decimal_to_float32 xx (Decimal.D0 Decimal.Nil)).
-Eval vm_compute in (positive_decimal_decimal_to_float32 (Decimal.D0 Decimal.Nil) (Decimal.D0 Decimal.Nil)).
-*)
-
-(* Same as above, but producing a [float] (aka [double], 64-bit float, instead of a [float32]. *)
+(* There is deliberately no float32 counterpart: a decimal literal at type
+   [float] is parsed as a double by this function and then narrowed by
+   [float_to_float32], which is what LLVM does.  The former
+   [positive_decimal_decimal_{signed_,}to_float32] pair, which rounded the
+   decimal straight to binary32, was removed when that gate went in. *)
 Definition positive_decimal_decimal_signed_to_float (xs ys : Decimal.uint) (exp:Decimal.signed_int) : float :=
   match Pos.of_uint xs with
   | N0 =>
@@ -172,20 +132,48 @@ Definition hexadecimal_uint_to_float32 (h:Hexadecimal.uint) : option float32 :=
   float_to_float32 (Bits.b64_of_bits (BinInt.Z.of_hex_uint h)). 
 
 
+(** A *decimal* literal at type [float] is read the way LLVM's parser reads it:
+    parsed as a [double] first, then narrowed, and REJECTED if that narrowing
+    would lose anything.  So [float 1.5] and [float 1.0e10] are fine, whereas
+    [float 1.3], [float 3.0e38] and [float 16777217.0] are errors -- "floating
+    point constant invalid for type", as llvm-as puts it.  ([float 1.0e400] is
+    accepted: it overflows to an infinity as a double, and infinity narrows
+    exactly.)
+
+    NB this rule is NOT stated in LangRef, unlike the exactness requirement on
+    the hex form.  LangRef's "Simple Constants" claims flatly that "the
+    assembler ... accepts 1.25 but rejects 1.3", without distinguishing float
+    from double -- but LLVM accepts [double 1.3], so the documented rule is not
+    the implemented one.  What is encoded here is clang's observed behaviour
+    (LLParser parses to an APFloat and errors if [convert] reports losesInfo),
+    which is the reference [make test] is differential against.
+
+    Going through the double matters twice over.  It is what makes the gate
+    agree with LLVM's, and it also settles the rounding: computing the float32
+    straight from the decimal would round once, whereas LLVM rounds decimal ->
+    binary64 -> binary32, and double rounding is not in general single rounding.
+    On the literals we now accept the question is moot -- they are exact -- but
+    only because we reject the ones where it could have shown up. *)
+
 Definition float32_of_float_syntax (fs:float_syntax) : option float32 :=
   match fs with
-  | FS_decimal (Decimal.Decimal (Decimal.Pos xs) ys) => 
-      Some (positive_decimal_decimal_to_float32 xs ys)
-                                                        
+  | FS_decimal (Decimal.Decimal (Decimal.Pos xs) ys) =>
+      float_to_float32 (positive_decimal_decimal_to_float xs ys)
+
   | FS_decimal (Decimal.Decimal (Decimal.Neg xs) ys) =>
-      Some (Float32.neg (positive_decimal_decimal_to_float32 xs ys))
- 
+      float_to_float32 (Float.neg (positive_decimal_decimal_to_float xs ys))
+
   | FS_decimal (Decimal.DecimalExp (Decimal.Pos i) ui exp) =>
-      Some (positive_decimal_decimal_signed_to_float32 i ui exp)
+      float_to_float32 (positive_decimal_decimal_signed_to_float i ui exp)
 
   | FS_decimal (Decimal.DecimalExp (Decimal.Neg i) ui exp) =>
-      Some (Float32.neg (positive_decimal_decimal_signed_to_float32 i ui exp))
-           
+      float_to_float32 (Float.neg (positive_decimal_decimal_signed_to_float i ui exp))
+
+  (* NB: not routed through [float_of_float_syntax]'s hex arm, which rejects a
+     literal of more than 16 digits ([hexadecimal_uint_to_bit_int]'s range
+     check).  LLVM instead truncates it mod 2^64 -- clang folds
+     [float 0x1FFF8000000000000] to [0xFFF8000000000000] -- which is what
+     [b64_of_bits] does here. *)
   | FS_hex FH_X u => hexadecimal_uint_to_float32 u
 
   | FS_hex _ _ => None

--- a/tests/llvm-arith/float/decimal_literal_exactness.ll
+++ b/tests/llvm-arith/float/decimal_literal_exactness.ll
@@ -1,0 +1,115 @@
+; LLVM parses every decimal floating-point literal as a *double*, and then, at
+; type [float], additionally requires that double -> float be lossless.  So the
+; decimal and hexadecimal spellings are governed by exactly the same exactness
+; rule; clang even prints an accepted decimal float back as the double-encoded
+; hex form.  A literal that would need rounding is not a rounded constant, it is
+; an error: "floating point constant invalid for type".
+;
+; Discriminates the previous implementation, which rounded the decimal straight
+; to binary32 (Float32.from_parsed) with no exactness gate at all, and so
+; accepted every literal below including the ones clang refuses.  Expected
+; values read off `clang -O2` folding the same bitcast.
+;
+; Note tests/memory/loadAndStore.ll:61-64 had already commented out its inexact
+; decimal float assertions (0.33, 255.294, 25500.798, 255.12345) with ';;;;'.
+; Those are exactly the cases this rule rejects.
+
+; --- Accepted: exactly representable ---------------------------------------
+
+define i32 @exact_half() {
+  %a = bitcast float 1.5 to i32
+  ret i32 %a
+}
+
+define i32 @exact_quarter() {
+  %a = bitcast float 0.25 to i32
+  ret i32 %a
+}
+
+; Exponent form, still exact.
+define i32 @exact_exp() {
+  %a = bitcast float 1.0e10 to i32
+  ret i32 %a
+}
+
+; The literal float_literal.ll uses; its long decimal is exactly an f32.
+define i32 @exact_long_decimal() {
+  %a = bitcast float 125.31999969482421875 to i32
+  ret i32 %a
+}
+
+define i32 @exact_zero() {
+  %a = bitcast float 0.0 to i32
+  ret i32 %a
+}
+
+; Signed zero must keep its sign through the narrowing.
+define i32 @exact_neg_zero() {
+  %a = bitcast float -0.0 to i32
+  ret i32 %a
+}
+
+; Overflows to an infinity already as a double, and infinity narrows exactly,
+; so this is accepted rather than rejected.
+define i32 @overflow_to_inf() {
+  %a = bitcast float 1.0e400 to i32
+  ret i32 %a
+}
+
+define i32 @overflow_to_neg_inf() {
+  %a = bitcast float -1.0e400 to i32
+  ret i32 %a
+}
+
+; Symmetrically, underflows to zero as a double, and zero narrows exactly.
+define i32 @underflow_to_zero() {
+  %a = bitcast float 1.0e-400 to i32
+  ret i32 %a
+}
+
+; --- Rejected: would need rounding ------------------------------------------
+
+; The classic case: 1.3 is a repeating binary fraction.
+define i32 @inexact_simple() {
+  %a = bitcast float 1.3 to i32
+  ret i32 %a
+}
+
+define i32 @inexact_tenth() {
+  %a = bitcast float 0.1 to i32
+  ret i32 %a
+}
+
+; Finite and comfortably inside the f32 range, but not on an f32 grid point.
+define i32 @inexact_in_range() {
+  %a = bitcast float 3.0e38 to i32
+  ret i32 %a
+}
+
+; 2^24 + 1 -- needs 25 significand bits, one more than f32 has.
+define i32 @inexact_integer() {
+  %a = bitcast float 16777217.0 to i32
+  ret i32 %a
+}
+
+; Would land in the f32 subnormal range, where the double has more precision
+; than the target can hold.
+define i32 @inexact_subnormal() {
+  %a = bitcast float 1.0e-45 to i32
+  ret i32 %a
+}
+
+; ASSERT EQ: i32 1069547520 = call i32 @exact_half()
+; ASSERT EQ: i32 1048576000 = call i32 @exact_quarter()
+; ASSERT EQ: i32 1343554297 = call i32 @exact_exp()
+; ASSERT EQ: i32 1123722199 = call i32 @exact_long_decimal()
+; ASSERT EQ: i32 0 = call i32 @exact_zero()
+; ASSERT EQ: i32 2147483648 = call i32 @exact_neg_zero()
+; ASSERT EQ: i32 2139095040 = call i32 @overflow_to_inf()
+; ASSERT EQ: i32 4286578688 = call i32 @overflow_to_neg_inf()
+; ASSERT EQ: i32 0 = call i32 @underflow_to_zero()
+; ASSERT FAILS: call i32 @inexact_simple()
+; ASSERT FAILS: call i32 @inexact_tenth()
+; ASSERT FAILS: call i32 @inexact_in_range()
+; ASSERT FAILS: call i32 @inexact_integer()
+; ASSERT FAILS: call i32 @inexact_subnormal()

--- a/tests/llvm-arith/float/fptosi.ll
+++ b/tests/llvm-arith/float/fptosi.ll
@@ -1,19 +1,26 @@
+; The non-integral arguments are spelled in hex because a decimal literal at
+; type float must be exactly representable as an f32 -- llvm-as rejects
+; `float 123.1` outright. Each hex constant below is the double encoding of
+; the f32 these assertions used to name in decimal, i.e. exactly what clang
+; emits, so the values under test are unchanged. 0x7FF0000000000000 is +inf,
+; which is what the old `float 1.0E+300` overflowed to anyway.
+
 define i8 @to_i8(float %f) {
   %ans = fptosi float %f to i8
   ret i8 %ans
 }   
 
-; ASSERT EQ: i8 poison = call i8 @to_i8(float 1.0E+300)
-; ASSERT EQ: i8 poison = call i8 @to_i8(float 1.04E+17)
+; ASSERT EQ: i8 poison = call i8 @to_i8(float 0x7FF0000000000000)
+; ASSERT EQ: i8 poison = call i8 @to_i8(float 0x437717B720000000)
 ; ASSERT EQ: i8 123 = call i8 @to_i8(float 123.0)
-; ASSERT EQ: i8 123 = call i8 @to_i8(float 123.1)
-; ASSERT EQ: i8 122 = call i8 @to_i8(float 122.9)
+; ASSERT EQ: i8 123 = call i8 @to_i8(float 0x405EC66660000000)
+; ASSERT EQ: i8 122 = call i8 @to_i8(float 0x405EB999A0000000)
 ; ASSERT EQ: i8 -123 = call i8 @to_i8(float -123.0)
-; ASSERT EQ: i8 -123 = call i8 @to_i8(float -123.1)
-; ASSERT EQ: i8 -122 = call i8 @to_i8(float -122.9)
+; ASSERT EQ: i8 -123 = call i8 @to_i8(float 0xC05EC66660000000)
+; ASSERT EQ: i8 -122 = call i8 @to_i8(float 0xC05EB999A0000000)
 ; ASSERT EQ: i8 0 = call i8 @to_i8(float -0.0)
 ; ASSERT EQ: i8 0 = call i8 @to_i8(float 0.0)
-; ASSERT EQ: i8 -1 = call i8 @to_i8(float -1.2)
+; ASSERT EQ: i8 -1 = call i8 @to_i8(float 0xBFF3333340000000)
 
 
 
@@ -22,11 +29,11 @@ define i1 @to_i1(float %f) {
   ret i1 %Z
 }
 
-; ASSERT EQ: i1 poison = call i1 @to_i1(float 1.0E+300)
-; ASSERT EQ: i1 poison = call i1 @to_i1(float 1.04E+17)
+; ASSERT EQ: i1 poison = call i1 @to_i1(float 0x7FF0000000000000)
+; ASSERT EQ: i1 poison = call i1 @to_i1(float 0x437717B720000000)
 ; ASSERT EQ: i1 0 = call i1 @to_i1(float 0.0)
 ; ASSERT EQ: i1 0 = call i1 @to_i1(float 0.75)
 ; ASSERT EQ: i1 poison = call i1 @to_i1(float 1.0)
 ; ASSERT EQ: i1 -1 = call i1 @to_i1(float -1.0)
-; ASSERT EQ: i1 -1 = call i1 @to_i1(float -1.1)
+; ASSERT EQ: i1 -1 = call i1 @to_i1(float 0xBFF19999A0000000)
 ; ASSERT EQ: i1 0 = call i1 @to_i1(float -0.5)

--- a/tests/llvm-arith/float/fptoui.ll
+++ b/tests/llvm-arith/float/fptoui.ll
@@ -1,13 +1,20 @@
+; The non-integral arguments are spelled in hex because a decimal literal at
+; type float must be exactly representable as an f32 -- llvm-as rejects
+; `float 123.1` outright. Each hex constant below is the double encoding of
+; the f32 these assertions used to name in decimal, i.e. exactly what clang
+; emits, so the values under test are unchanged. 0x7FF0000000000000 is +inf,
+; which is what the old `float 1.0E+300` overflowed to anyway.
+
 define i8 @to_i8(float %f) {
   %ans = fptoui float %f to i8
   ret i8 %ans
 }   
 
-; ASSERT EQ: i8 poison = call i8 @to_i8(float 1.0E+300)
-; ASSERT EQ: i8 poison = call i8 @to_i8(float 1.04E+17)
+; ASSERT EQ: i8 poison = call i8 @to_i8(float 0x7FF0000000000000)
+; ASSERT EQ: i8 poison = call i8 @to_i8(float 0x437717B720000000)
 ; ASSERT EQ: i8 123 = call i8 @to_i8(float 123.0)
-; ASSERT EQ: i8 123 = call i8 @to_i8(float 123.1)
-; ASSERT EQ: i8 122 = call i8 @to_i8(float 122.9)
+; ASSERT EQ: i8 123 = call i8 @to_i8(float 0x405EC66660000000)
+; ASSERT EQ: i8 122 = call i8 @to_i8(float 0x405EB999A0000000)
 
 
 define i1 @to_i1(float %f) {
@@ -15,8 +22,8 @@ define i1 @to_i1(float %f) {
   ret i1 %Z
 }
 
-; ASSERT EQ: i1 poison = call i1 @to_i1(float 1.0E+300)
-; ASSERT EQ: i1 poison = call i1 @to_i1(float 1.04E+17)
+; ASSERT EQ: i1 poison = call i1 @to_i1(float 0x7FF0000000000000)
+; ASSERT EQ: i1 poison = call i1 @to_i1(float 0x437717B720000000)
 ; ASSERT EQ: i1 0 = call i1 @to_i1(float 0.0)
 ; ASSERT EQ: i1 0 = call i1 @to_i1(float 0.75)
 ; ASSERT EQ: i1 1 = call i1 @to_i1(float 1.0)


### PR DESCRIPTION
This patch would attempt to comply with clang w.r.t. #473 by removing @Zdancewic 's function to parse at float32, and replace it by parsing at double and converting to i32.

However since it's unclear to me that it's the behavior specified in langref, we might want to probe llvm people before merging.